### PR TITLE
changed windows runtime identifier to win7-x64

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
       command: 'publish'
       publishWebProjects: false
       projects: '**/apps/**/*-zero/*.csproj'
-      arguments: '--runtime win-x64 --configuration $(buildConfiguration) --no-build --output $(Build.ArtifactStagingDirectory)\zero_build'
+      arguments: '--runtime win7-x64 --configuration $(buildConfiguration) --no-build --output $(Build.ArtifactStagingDirectory)\zero_build'
       zipAfterPublish: false
 
   - task: CmdLine@2

--- a/src/apps/src/Eryph-zero/eryph-zero.csproj
+++ b/src/apps/src/Eryph-zero/eryph-zero.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <RootNamespace>Eryph.Runtime.Zero</RootNamespace>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
   </PropertyGroup>

--- a/src/apps/src/Eryph-zero/eryph-zero.csproj
+++ b/src/apps/src/Eryph-zero/eryph-zero.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <RootNamespace>Eryph.Runtime.Zero</RootNamespace>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>

--- a/src/apps/src/Eryph-zero/eryph-zero.csproj
+++ b/src/apps/src/Eryph-zero/eryph-zero.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
-    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <RootNamespace>Eryph.Runtime.Zero</RootNamespace>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>


### PR DESCRIPTION
caused System.MissingMethodException in powershell commands:

```
Command: New-VM, Error: The type initializer for 'Microsoft.Management.Infrastructure.Native.OperationCallbacks' threw an exception., Exception: Microsoft.HyperV.PowerShell.VirtualizationException: The type initializer for
                'Microsoft.Management.Infrastructure.Native.OperationCallbacks' threw an exception.
                 ---> System.TypeInitializationException: The type initializer for 'Microsoft.Management.Infrastructure.Native.OperationCallbacks' threw an exception.
                 ---> System.MissingMethodException: Method not found: 'System.Reflection.Emit.AssemblyBuilder System.AppDomain.DefineDynamicAssembly(System.Reflection.AssemblyName, System.Reflection.Emit.AssemblyBuilderAccess)'.
                   at Microsoft.Management.Infrastructure.Native.OperationCallbacks..cctor()
                   --- End of inner exception stack trace ---
                   at Microsoft.Management.Infrastructure.Native.OperationCallbacks..ctor()
                   at Microsoft.Management.Infrastructure.Options.Internal.OperationOptionsExtensionMethods.GetOperationCallbacks(CimOperationOptions operationOptions)
                   at Microsoft.Management.Infrastructure.Options.Internal.OperationOptionsExtensionMethods.GetOperationCallbacks(CimOperationOptions operationOptions, CimAsyncCallbacksReceiverBase acceptCallbacksReceiver)
                   at Microsoft.Management.Infrastructure.CimSession.TestConnectionCore(CimOperationOptions options, CimAsyncCallbacksReceiverBase asyncCallbacksReceiver)
                   at Microsoft.Management.Infrastructure.CimSession.<TestConnection>b__99_0(CimAsyncCallbacksReceiverBase asyncCallbacksReceiver)
                   at Microsoft.Management.Infrastructure.Internal.Operations.CimSyncEnumerableBase`2.GetEnumerator()
                   at System.Linq.Enumerable.TryGetSingle[TSource](IEnumerable`1 source, Boolean& found)
                   at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source)
                   at Microsoft.Management.Infrastructure.CimSession.TestConnection(CimInstance& instance, CimException& exception)
                   at Microsoft.Virtualization.Client.Management.CimSessionWrapper.TestConnection(ICimInstance& instance, CimException& exception)
                   at Microsoft.Virtualization.Client.Management.Server.CreateSession()
                   at Microsoft.Virtualization.Client.Management.Server..ctor(ServerNames serverNames, IUserPassCredential credential)
                   at Microsoft.Virtualization.Client.Management.Server.<>c__DisplayClass80_0.<GetServer>b__0()
                   at Microsoft.Virtualization.Client.Management.Server.<>c__DisplayClass111_0`1.<GetServerFromDictionary>b__0(TKey ignored)
                   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
                   at Microsoft.Virtualization.Client.Management.Server.GetServerFromDictionary[TKey](ConcurrentDictionary`2 servers, TKey lookupKey, Func`1 createServer, String serverName)
                   at Microsoft.Virtualization.Client.Management.Server.GetServer(ServerNames serverNames, IUserPassCredential credential)
                   at Microsoft.Virtualization.Client.Management.Server.GetServer(String name, IUserPassCredential credential)
                   at Microsoft.HyperV.PowerShell.VirtualizationObjectLocator.GetServer(String computerName, IUserPassCredential credential)
                   at Microsoft.HyperV.PowerShell.VirtualizationObjectLocator.GetServer(String computerName)
                   at Microsoft.HyperV.PowerShell.Commands.ParameterResolvers.GetServers(IServerParameters cmdletParameters, IOperationWatcher operationWatcher)
                   at Microsoft.HyperV.PowerShell.Commands.NewVM.CreateObjects(IOperationWatcher operationWatcher)
                   at Microsoft.HyperV.PowerShell.Commands.VirtualizationCreationCmdlet`1.PerformOperation(IOperationWatcher operationWatcher)
                   at Microsoft.HyperV.PowerShell.Commands.VirtualizationCmdletBase.PerformOperationWithLogging(IOperationWatcher operationWatcher)
                   --- End of inner exception stack trace ---
```