### PR TITLE
handle invalid adapters

### DIFF
--- a/src/apps/src/Eryph-zero/appsettings.Development.json
+++ b/src/apps/src/Eryph-zero/appsettings.Development.json
@@ -2,7 +2,7 @@
   "Logging": {
     "IncludeScopes": {},
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Debug",
       "System": "Information",
       "Microsoft": "Warning",
       "Eryph": "Trace"

--- a/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/VirtualMachineNetworkAdapterInfo.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/VirtualMachineNetworkAdapterInfo.cs
@@ -1,10 +1,13 @@
-﻿namespace Eryph.Resources.Machines
+﻿using System;
+
+namespace Eryph.Resources.Machines
 {
     public class VirtualMachineNetworkAdapterData
     {
         public string Id { get; set; }
         public string AdapterName { get; set; }
         public string VirtualSwitchName { get; set; }
+        public Guid? VirtualSwitchId { get; set; }
         public ushort VLanId { get; set; }
         public string MACAddress { get; set; }
     }

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeNetworkAdapters.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeNetworkAdapters.cs
@@ -94,7 +94,7 @@ namespace Eryph.VmManagement.Converging
 
             return await optionalAdapter.BindAsync(async adapter =>
             {
-                if (adapter.Value.Connected && adapter.Value.SwitchName == switchName)
+                if (adapter.Value.Connected && adapter.Cast<ConnectedVMNetworkAdapter>().Value.SwitchName == switchName)
                     return Unit.Default;
 
                 await Context.ReportProgress(

--- a/src/core/src/Eryph.VmManagement/Data/Full/VMNetworkAdapter.cs
+++ b/src/core/src/Eryph.VmManagement/Data/Full/VMNetworkAdapter.cs
@@ -3,7 +3,16 @@ using Eryph.VmManagement.Data.Core;
 
 namespace Eryph.VmManagement.Data.Full
 {
-    public class VMNetworkAdapter : VirtualMachineDeviceInfo, IVMNetworkAdapterWithConnection
+    public class ConnectedVMNetworkAdapter : VMNetworkAdapter, IVMNetworkAdapterWithConnection
+    {
+        public string SwitchName { get; private set; }
+
+        public Guid? SwitchId { get; private set; }
+
+    }
+
+
+    public class VMNetworkAdapter : VirtualMachineDeviceInfo, IVMNetworkAdapterCore
     {
         //public bool DynamicMacAddressEnabled { get; private set; }
 
@@ -47,21 +56,19 @@ namespace Eryph.VmManagement.Data.Full
 
         //public string TestReplicaSwitchName { get; private set; }
 
-        public string SwitchName { get; private set; }
 
         //public string AdapterId { get; private set; }
 
         //public string[] StatusDescription { get; private set; }
 
 
-        //public VMNetworkAdapterOperationalStatus[] Status { get; private set; }
+        public VMNetworkAdapterOperationalStatus[] Status { get; private set; }
 
 
         //public bool IsManagementOs { get; private set; }
 
         //public bool IsExternalAdapter { get; private set; }
 
-        public Guid? SwitchId { get; private set; }
 
 
         //public VMNetworkAdapterAclSetting[] AclList { get; private set; }

--- a/src/core/src/Eryph.VmManagement/TypedPsObject.cs
+++ b/src/core/src/Eryph.VmManagement/TypedPsObject.cs
@@ -35,6 +35,11 @@ namespace Eryph.VmManagement
             return new TypedPsObject<T>(PsObject);
         }
 
+        public TypedPsObject<TNew> Cast<TNew>()
+        {
+            return new TypedPsObject<TNew>(PsObject);
+        }
+
         public TypedPsObject<TProp> GetProperty<TProp>(Expression<Func<T, TProp>> property)
         {
             var paramType = property.Parameters[0].Type; // first parameter of expression
@@ -97,7 +102,8 @@ namespace Eryph.VmManagement
 
                     c.CreateMap(GetPsType("DvdDrive"), typeof(DvdDriveInfo));
 
-                    var adapterMapping = c.CreateMap(GetPsType(nameof(VMNetworkAdapter)), typeof(VMNetworkAdapter));
+                    c.CreateMap(GetPsType(nameof(VMNetworkAdapter)), typeof(VMNetworkAdapter));
+                    c.CreateMap(GetPsType(nameof(VMNetworkAdapter)), typeof(ConnectedVMNetworkAdapter));
 
                     c.CreateMap(GetPsType(nameof(VMNetworkAdapter)), typeof(PlannedVMNetworkAdapter));
 

--- a/src/modules/src/Eryph.Modules.VmHostAgent/VirtualMachineConfigCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/VirtualMachineConfigCommandHandler.cs
@@ -126,19 +126,19 @@ namespace Eryph.Modules.VmHostAgent
             var metadataIdString = "";
             if (!string.IsNullOrWhiteSpace(notes))
             {
-                var metadataIndex = notes.IndexOf("Eryph metadata id: ", StringComparison.InvariantCultureIgnoreCase);
+                var metadataIndex = notes.IndexOf("eryph metadata id: ", StringComparison.InvariantCultureIgnoreCase);
                 if (metadataIndex != -1)
                 {
-                    var metadataEnd = metadataIndex + "Eryph metadata id: ".Length + 36;
+                    var metadataEnd = metadataIndex + "eryph metadata id: ".Length + 36;
                     if (metadataEnd <= notes.Length)
-                        metadataIdString = notes.Substring(metadataIndex + "Eryph metadata id: ".Length, 36);
+                        metadataIdString = notes.Substring(metadataIndex + "eryph metadata id: ".Length, 36);
                 }
             }
 
 
             if (string.IsNullOrWhiteSpace(metadataIdString))
             {
-                var newNotes = $"Eryph metadata id: {metadata.Id}";
+                var newNotes = $"eryph metadata id: {metadata.Id}";
 
                 return Engine.RunAsync(new PsCommandBuilder().AddCommand("Set-VM").AddParameter("VM", vmInfo.PsObject)
                     .AddParameter("Notes", newNotes)).MapAsync(u => metadata);
@@ -159,9 +159,9 @@ namespace Eryph.Modules.VmHostAgent
         {
             var oldNotes = vmInfo.Value.Notes;
             if (string.IsNullOrWhiteSpace(oldNotes))
-                oldNotes = "\n\n\n\n--- DO NOT REMOVE NEXT LINE - REQUIRED FOR HAIPA ---\n";
+                oldNotes = "\n\n\n\n--- DO NOT REMOVE NEXT LINE - REQUIRED FOR ERYPH ---\n";
 
-            var startPos = oldNotes.IndexOf("Eryph metadata id: ", StringComparison.Ordinal);
+            var startPos = oldNotes.IndexOf("eryph metadata id: ", StringComparison.Ordinal);
 
             var notesBeforeMetaData = oldNotes;
             var notesAfterMetaData = "";
@@ -169,13 +169,13 @@ namespace Eryph.Modules.VmHostAgent
             if (startPos > -1)
             {
                 notesBeforeMetaData = oldNotes.Substring(0, startPos);
-                var endPos = startPos + "Eryph metadata id: ".Length + Guid.Empty.ToString().Length;
+                var endPos = startPos + "eryph metadata id: ".Length + Guid.Empty.ToString().Length;
 
                 if (endPos < oldNotes.Length)
                     notesAfterMetaData = oldNotes.Substring(endPos, oldNotes.Length - endPos);
             }
 
-            var newNotes = notesBeforeMetaData + $"Eryph metadata id: {metadataId}" + notesAfterMetaData;
+            var newNotes = notesBeforeMetaData + $"eryph metadata id: {metadataId}" + notesAfterMetaData;
 
 
             return Engine.RunAsync(new PsCommandBuilder().AddCommand("Set-VM").AddParameter("VM", vmInfo.PsObject)


### PR DESCRIPTION
In case adapter is invalid and switch could not be read a Exception will occur in type mapping. To prevent this switch settings are now only fetched on demand by cast to new type ConnectVMNetworkAdapter. 

fixes #47 