### PR TITLE
Image sources

### DIFF
--- a/Eryph.sln
+++ b/Eryph.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30320.27
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5161FD3F-5E58-4C46-9EC5-DC275266583A}"
 	ProjectSection(SolutionItems) = preProject
@@ -71,6 +71,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.Core", "src\core\src\Eryph.Core\Eryph.Core.csproj", "{1BC81BC6-C5D8-4F07-90DE-CABCA9BBC2DA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eryph.ModuleCore", "src\modules\src\Eryph.ModuleCore\Eryph.ModuleCore.csproj", "{A90AF0DD-866A-4D16-938D-9E66649BB8D6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "eryph-packer", "src\apps\src\eryph-packer\eryph-packer.csproj", "{52FC6159-8AC0-4A9E-BA43-07EE43AD10F3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -182,6 +184,10 @@ Global
 		{A90AF0DD-866A-4D16-938D-9E66649BB8D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A90AF0DD-866A-4D16-938D-9E66649BB8D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A90AF0DD-866A-4D16-938D-9E66649BB8D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52FC6159-8AC0-4A9E-BA43-07EE43AD10F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52FC6159-8AC0-4A9E-BA43-07EE43AD10F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52FC6159-8AC0-4A9E-BA43-07EE43AD10F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52FC6159-8AC0-4A9E-BA43-07EE43AD10F3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -213,6 +219,7 @@ Global
 		{27279203-AD89-4FD0-B44C-21F7678CB076} = {7F64364D-A6A2-441C-9F30-3702BF35A02F}
 		{1BC81BC6-C5D8-4F07-90DE-CABCA9BBC2DA} = {07B818A5-B186-4D09-A766-9E4963F3C07E}
 		{A90AF0DD-866A-4D16-938D-9E66649BB8D6} = {E889B549-C333-46DC-B71F-9608CBA1FBAA}
+		{52FC6159-8AC0-4A9E-BA43-07EE43AD10F3} = {5F41CD29-E6EF-4810-8A84-8B9E52AEAE70}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D7530B6E-8072-405A-97B5-322190C6109E}

--- a/src/apps/src/Eryph-zero/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/apps/src/Eryph-zero/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>bin\Release\net6.0-windows\win7-x64\publish\win7-x64\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+    <PublishReadyToRun>False</PublishReadyToRun>
+  </PropertyGroup>
+</Project>

--- a/src/apps/src/eryph-packer/ArtifactManifest.cs
+++ b/src/apps/src/eryph-packer/ArtifactManifest.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Eryph.Packer;
+
+internal class ArtifactManifest
+{
+    [JsonPropertyName("format")]
+    public string? Format { get; set; }
+
+    [JsonPropertyName("path")]
+    public string? Path { get; set; }
+
+    [JsonPropertyName("filename")]
+    public string? FileName { get; set; }
+
+    [JsonPropertyName("size")]
+    public long? Size { get; set; }
+
+    [JsonPropertyName("parts")]
+    public string[]? Parts { get; set; }
+}

--- a/src/apps/src/eryph-packer/ConsoleExtensions.cs
+++ b/src/apps/src/eryph-packer/ConsoleExtensions.cs
@@ -1,0 +1,59 @@
+﻿using System.CommandLine;
+
+namespace Eryph.Packer;
+
+internal static class ConsoleExtensions
+{
+    internal static void SetTerminalForegroundRed(this IConsole console)
+    {
+        if (Platform.IsConsoleRedirectionCheckSupported &&
+            !Console.IsOutputRedirected)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+        }
+        else if (Platform.IsConsoleRedirectionCheckSupported)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+        }
+    }
+
+    internal static void ResetTerminalForegroundColor(this IConsole console)
+    {
+        if (Platform.IsConsoleRedirectionCheckSupported &&
+            !Console.IsOutputRedirected)
+        {
+            Console.ResetColor();
+        }
+        else if (Platform.IsConsoleRedirectionCheckSupported)
+        {
+            Console.ResetColor();
+        }
+    }
+}
+
+internal static class Platform
+{
+    private static bool? _isConsoleRedirectionCheckSupported;
+
+    public static bool IsConsoleRedirectionCheckSupported
+    {
+        get
+        {
+            if (_isConsoleRedirectionCheckSupported is null)
+            {
+                try
+                {
+                    var check = Console.IsOutputRedirected;
+                    _isConsoleRedirectionCheckSupported = true;
+                }
+
+                catch (PlatformNotSupportedException)
+                {
+                    _isConsoleRedirectionCheckSupported = false;
+                }
+            }
+
+            return _isConsoleRedirectionCheckSupported.Value;
+        }
+    }
+}

--- a/src/apps/src/eryph-packer/ImageInfo.cs
+++ b/src/apps/src/eryph-packer/ImageInfo.cs
@@ -1,0 +1,160 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Eryph.Packer;
+
+public class ImageInfo
+{
+    public string ImageName { get; }
+    public string Organization { get; }
+    public string Id { get; }
+
+    public string Tag { get; }
+
+
+    public ImageInfo(string image)
+    {
+        ImageName = image.ToLowerInvariant();
+        var imageParts = image.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (imageParts.Length != 3 && imageParts.Length != 2)
+        {
+            throw new ArgumentException($"invalid image name '{image}'", nameof(image));
+        }
+
+        Organization = imageParts[0];
+        Id = imageParts[1];
+        Tag = imageParts.Length == 3 ? imageParts[2] : "latest";
+    }
+
+    public string GetImagePath()
+    {
+        if(File.Exists("manifest.json"))
+        {
+            var currentManifest = ReadManifest(".");
+            if (currentManifest?.Image != ImageName)
+            {
+                if (currentManifest != null)
+                {
+                    throw new InvalidOperationException(
+                        $"Directory already contains a manifest for image '{currentManifest.Image}' but you trying to access image '{ImageName}'. Make sure that you are in the right folder.");
+                }
+                throw new InvalidOperationException(
+                    $"Directory already contains a invalid manifest.");
+
+            }
+
+            return ".";
+        }
+
+        return Path.Combine(Organization, Id, Tag);
+    }
+
+    public bool Exists()
+    {
+
+        if (!Directory.Exists(GetImagePath()))
+            return false;
+
+        if(!File.Exists(Path.Combine(GetImagePath(), "manifest.json")))
+            return false;
+
+        return true;
+    }
+
+    public void Create()
+    {
+        if (Exists())
+            throw new InvalidOperationException($"Image {ImageName} already exists.");
+
+        var directoryInfo = new DirectoryInfo(GetImagePath());
+        if (!directoryInfo.Exists)
+            directoryInfo.Create();
+
+        if (!File.Exists(Path.Combine(GetImagePath(), "manifest.json")))
+        {
+            WriteManifest(new ImageManifest());
+        }
+    }
+
+    public void EnsureCreated()
+    {
+        if(!Exists())
+            Create();
+
+    }
+
+    public void SetReference(string referencedImage)
+    {
+        EnsureCreated();
+        WriteManifest(new ImageManifest
+        {
+            Reference = referencedImage
+        });
+    }
+
+    public void SetArtifacts(string[] artifacts)
+    {
+        EnsureCreated();
+        WriteManifest(new ImageManifest
+        {
+            Artifacts = artifacts
+        });
+    }
+
+    private void WriteManifest(ImageManifest manifest)
+    {
+        if (manifest.Image != ImageName)
+            manifest.Image = ImageName;
+
+        var jsonString = JsonSerializer.Serialize(manifest);
+        File.WriteAllText(Path.Combine(GetImagePath(), "manifest.json"), jsonString);
+    }
+
+    public ImageManifest? GetManifest()
+    {
+        if(!Exists())
+            return new ImageManifest { Image = ImageName };
+
+        return ReadManifest(GetImagePath());
+    }
+
+    private ImageManifest? ReadManifest(string path)
+    {
+        try
+        {
+            var jsonString = File.ReadAllText(Path.Combine(path, "manifest.json"));
+
+            var manifest = JsonSerializer.Deserialize<ImageManifest>(jsonString);
+            return manifest;
+
+        }
+        catch
+        {
+            return new ImageManifest();
+        }
+
+    }
+
+    public override string ToString()
+    {
+        return ToString(false);
+    }
+
+    public string ToString(bool pretty)
+    {
+        return JsonSerializer.Serialize(GetManifest(), new JsonSerializerOptions { WriteIndented = pretty });
+    }
+}
+
+public class ImageManifest
+{
+    [JsonPropertyName("image")]
+    public string Image { get; set; }
+
+    [JsonPropertyName("ref")]
+    public string Reference { get; set; }
+
+    [JsonPropertyName("artifacts")]
+    public string[] Artifacts { get; set; }
+
+}

--- a/src/apps/src/eryph-packer/Program.cs
+++ b/src/apps/src/eryph-packer/Program.cs
@@ -1,0 +1,212 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Invocation;
+using System.CommandLine.IO;
+using System.CommandLine.Parsing;
+using System.CommandLine.Rendering;
+using System.Diagnostics;
+using Eryph.Packer;
+
+var imageArgument = new Argument<string>("image", "name of image in format organization/id/[tag]");
+var refArgument = new Argument<string>("referenced image", "name of referenced image in format organization/id/tag");
+var vmExportArgument = new Argument<DirectoryInfo>("vm export", "path to exported VM");
+var b2UploadArgument = new Argument<FileInfo>("b2 upload");
+
+vmExportArgument.ExistingOnly();
+
+var debugOption =
+    new Option<bool>("--debug", "Enables debug output.");
+
+
+var workDirOption =
+    new Option<DirectoryInfo>("--workdir", "work directory")
+        .ExistingOnly();
+    
+workDirOption.SetDefaultValue(new DirectoryInfo(Environment.CurrentDirectory));
+
+
+var rootCommand = new RootCommand();
+rootCommand.AddGlobalOption(workDirOption);
+rootCommand.AddGlobalOption(debugOption);
+
+var infoCommand = new Command("info", "This command reads the metadata of a image.");
+infoCommand.AddArgument(imageArgument);
+rootCommand.AddCommand(infoCommand);
+
+var initCommand = new Command("init", "This command initializes the filesystem structure for a image.");
+initCommand.AddArgument(imageArgument);
+rootCommand.Add(initCommand);
+
+var refCommand = new Command("ref", "This command adds a reference to another image to the image.");
+refCommand.AddArgument(imageArgument);
+refCommand.AddArgument(refArgument);
+rootCommand.Add(refCommand);
+
+var packCommand = new Command("pack", "This command packs a exported Virtual Machine into the image.");
+packCommand.AddArgument(imageArgument);
+packCommand.AddArgument(vmExportArgument);
+rootCommand.Add(packCommand);
+
+var pushCommand = new Command("push", "This command uploads a image to eryph-cloud");
+pushCommand.AddArgument(imageArgument);
+pushCommand.AddArgument(b2UploadArgument);
+rootCommand.Add(pushCommand);
+
+
+
+// init command
+// ------------------------------
+initCommand.SetHandler((string image, DirectoryInfo workdir) =>
+{
+    Directory.SetCurrentDirectory(workdir.FullName);
+    
+    var imageInfo = new ImageInfo(image);
+    if (!imageInfo.Exists())
+    {
+        imageInfo.Create();
+        Console.WriteLine(imageInfo.ToString(true));
+        return;
+    }
+
+    throw new InvalidOperationException("Image already initialized.");
+}, imageArgument, workDirOption);
+
+// ref command
+// ------------------------------
+refCommand.SetHandler( (string image, string refImage, DirectoryInfo workdir) =>
+{
+    Directory.SetCurrentDirectory(workdir.FullName);
+
+    var imageInfo = new ImageInfo(image);
+    if (!imageInfo.Exists())
+    {
+        throw new InvalidOperationException($"Image {image} not found");
+    }
+
+    imageInfo.SetReference(refImage);
+    Console.WriteLine(imageInfo.ToString(true));
+
+}, imageArgument, refArgument, workDirOption);
+
+
+// info command
+// ------------------------------
+infoCommand.SetHandler((string image, DirectoryInfo workdir) =>
+{
+    Directory.SetCurrentDirectory(workdir.FullName);
+
+    var imageInfo = new ImageInfo(image);
+    if (!imageInfo.Exists())
+    {
+        throw new InvalidOperationException($"Image {image} not found");
+    }
+
+
+    Console.WriteLine(imageInfo.ToString(true));    
+
+}, imageArgument, workDirOption);
+
+
+// pack command
+// ------------------------------
+packCommand.SetHandler(async (string image, DirectoryInfo vmExportDir, DirectoryInfo workdir, CancellationToken cancel) =>
+{
+    Directory.SetCurrentDirectory(workdir.FullName);
+
+    var imageInfo = new ImageInfo(image);
+    if (!imageInfo.Exists())
+    {
+        throw new InvalidOperationException($"Image {image} not found");
+    }
+
+    var vmPacker = new VMExportPacker();
+
+    var absoluteImagePath = Path.GetFullPath(imageInfo.GetImagePath());
+    var artifacts = await vmPacker.PackToArtifacts(vmExportDir, absoluteImagePath, cancel);
+
+    imageInfo.SetArtifacts(artifacts.ToArray());
+    Console.WriteLine(imageInfo.ToString(true));
+
+
+}, imageArgument, vmExportArgument, workDirOption);
+
+
+// push command
+// ------------------------------
+pushCommand.SetHandler(async (string image, FileInfo b2Uploader, DirectoryInfo workdir, CancellationToken cancel, InvocationContext context) =>
+{
+    try
+    {
+        Directory.SetCurrentDirectory(workdir.FullName);
+
+        var imageInfo = new ImageInfo(image);
+        if (!imageInfo.Exists())
+        {
+            throw new InvalidOperationException($"Image {image} not found");
+        }
+
+        context.Console.ResetTerminalForegroundColor();
+        context.Console.WriteLine("This command is currently working only for internal testing and is not supported for general use.");
+        context.Console.SetTerminalForegroundRed();
+        context.Console.ResetTerminalForegroundColor();
+
+        var imageDir = new DirectoryInfo(imageInfo.GetImagePath());
+        foreach (var fileInfo in imageDir.GetFiles("*", SearchOption.AllDirectories))
+        {
+            var relativeName = Path.GetRelativePath(imageDir.FullName, fileInfo.FullName);
+            Console.WriteLine($"Uploading: {relativeName}");
+
+            var relativeUploadName =
+                $"{imageInfo.Organization}/{imageInfo.Id}/{imageInfo.Tag}/{relativeName.Replace('\\', '/')}";
+
+            var startedProcess = Process.Start(b2Uploader.FullName,
+                $"upload-file eryph-images-staging \"{fileInfo.FullName}\" \"{relativeUploadName}\" ");
+            await startedProcess.WaitForExitAsync();
+
+            if (startedProcess.ExitCode != 0)
+            {
+                Console.WriteLine($"Upload of file {relativeName} failed");
+                return;
+            }
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine(ex.Message);
+    }
+
+}, imageArgument, b2UploadArgument, workDirOption);
+
+var commandLineBuilder = new CommandLineBuilder(rootCommand);
+commandLineBuilder.UseDefaults();
+commandLineBuilder.UseAnsiTerminalWhenAvailable();
+commandLineBuilder.UseExceptionHandler((ex, context) =>
+{
+    if (ex is not OperationCanceledException)
+    {
+        context.Console.ResetTerminalForegroundColor();
+        context.Console.SetTerminalForegroundRed();
+
+
+        if (context.BindingContext.ParseResult.HasOption(debugOption))
+        {
+            context.Console.Error.Write(context.LocalizationResources.ExceptionHandlerHeader());
+            context.Console.Error.WriteLine(ex.ToString());
+        }
+        else
+        {
+            context.Console.Error.WriteLine(ex.Message);
+        }
+
+        context.Console.ResetTerminalForegroundColor();
+    }
+
+    context.ExitCode = 1;
+
+});
+
+var parser = commandLineBuilder.Build();
+
+return await parser.InvokeAsync(args);

--- a/src/apps/src/eryph-packer/Program.cs
+++ b/src/apps/src/eryph-packer/Program.cs
@@ -162,7 +162,7 @@ pushCommand.SetHandler(async (string image, FileInfo b2Uploader, DirectoryInfo w
                 $"{imageInfo.Organization}/{imageInfo.Id}/{imageInfo.Tag}/{relativeName.Replace('\\', '/')}";
 
             var startedProcess = Process.Start(b2Uploader.FullName,
-                $"upload-file eryph-images-staging \"{fileInfo.FullName}\" \"{relativeUploadName}\" ");
+                $"upload-file eryph-staging-eu \"{fileInfo.FullName}\" \"{relativeUploadName}\" ");
             await startedProcess.WaitForExitAsync();
 
             if (startedProcess.ExitCode != 0)

--- a/src/apps/src/eryph-packer/Properties/launchSettings.json
+++ b/src/apps/src/eryph-packer/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "eryph-packer": {
+      "commandName": "Project",
+      "commandLineArgs": "push dbosoft/winsrv2016-standard/v1 \"T:\\Downloads\\b2-windows.exe\"",
+      "workingDirectory": "S:\\eryph\\images\\work"
+    }
+  }
+}

--- a/src/apps/src/eryph-packer/VMExportPacker.cs
+++ b/src/apps/src/eryph-packer/VMExportPacker.cs
@@ -104,7 +104,7 @@ public class VMExportPacker
         var fileInfo = new FileInfo(compressedPath);
         var totalSize = fileInfo.Length;
 
-        var splitFiles = await SplitFile(compressedPath, 1024 * 1024 * 64, token);
+        var splitFiles = await SplitFile(compressedPath, 1024 * 1024 * 120, token);
         token.ThrowIfCancellationRequested();
 
 
@@ -124,7 +124,7 @@ public class VMExportPacker
             var hashString = GetHashString(hashAlg.Hash!);
 
             var splitFileDir = Path.GetDirectoryName(splitFile);
-            File.Move(splitFile, Path.Combine(splitFileDir, hashString));
+            File.Move(splitFile, Path.Combine(splitFileDir, $"{hashString}.part"));
             parts.Add($"sha1:{hashString}");
         }
 

--- a/src/apps/src/eryph-packer/VMExportPacker.cs
+++ b/src/apps/src/eryph-packer/VMExportPacker.cs
@@ -1,0 +1,241 @@
+﻿using System.IO.Compression;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Joveler.Compression.XZ;
+
+namespace Eryph.Packer;
+
+public class VMExportPacker
+{
+    public async Task<IEnumerable<string>> PackToArtifacts(DirectoryInfo vmExport, string artifactsFolder, CancellationToken token)
+    {
+        InitNativeLibrary();
+        
+        var vhdFiles = vmExport.GetFiles("*.vhdx", SearchOption.AllDirectories);
+
+        var processedFiles = new List<string>();
+        var artifacts = new List<string>();
+        foreach (var vhdFile in vhdFiles)
+        {
+            token.ThrowIfCancellationRequested();
+
+            artifacts.Add(await CreateFileArtifact(vhdFile.FullName, vmExport.FullName, artifactsFolder, token));
+            var relativePath = Path.GetRelativePath(vmExport.FullName, vhdFile.FullName);
+            processedFiles.Add(relativePath);
+
+        }
+
+        artifacts.Add(await CreateDirectoryArtifact(vmExport.FullName, artifactsFolder, processedFiles.ToArray(), token));
+
+        return artifacts;
+
+    }
+
+    static async Task<string> CreateDirectoryArtifact(string directory, string outputDir, string[] ignoredFiles, CancellationToken token)
+    {
+        var tempName = Guid.NewGuid().ToString();
+        var tempDir = Path.Combine(outputDir, tempName);
+        Directory.CreateDirectory(tempDir);
+        var compressedPath = Path.Combine(tempDir, "compressed");
+
+        await using var zipStream = File.Create(compressedPath);
+        var dirInfo = new DirectoryInfo(directory);
+
+        using (var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Create, false))
+        {
+            foreach (var fileInfo in dirInfo.GetFiles("*", SearchOption.AllDirectories))
+            {
+                var relativePath = Path.GetRelativePath(dirInfo.FullName, fileInfo.FullName);
+                if (ignoredFiles.Contains(relativePath))
+                    continue;
+
+                var zipEntry = zipArchive.CreateEntry(relativePath, CompressionLevel.Optimal);
+                await using var zipEntryStream = zipEntry.Open();
+                await using var fileStream = fileInfo.OpenRead();
+                await fileStream.CopyToAsync(zipEntryStream);
+            }
+        }
+
+        return await CreateArtifactFromTempDir(tempDir, null, false, token);
+    }
+
+    static async Task<string> CreateFileArtifact(string filePath, string sourceDir, string outputDir, CancellationToken token)
+    {
+        await using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+        var relativePath = Path.GetRelativePath(sourceDir, filePath);
+
+        var tempName = Guid.NewGuid().ToString();
+        var tempDir = Path.Combine(outputDir, tempName);
+        Directory.CreateDirectory(tempDir);
+        var compressedPath = Path.Combine(tempDir, "compressed");
+
+        var compOpts = new XZCompressOptions
+        {
+            Level = LzmaCompLevel.Default,
+            ExtremeFlag = true,
+            LeaveOpen = true,
+        };
+        var threadOpts = new XZThreadedCompressOptions
+        {
+            Threads = Environment.ProcessorCount > 8
+                ? Environment.ProcessorCount - 2
+                : Environment.ProcessorCount > 2 ? Environment.ProcessorCount - 1 : 1
+        };
+
+        Console.WriteLine($"compressing {relativePath}");
+        await using (var targetStream = new FileStream(compressedPath,
+                         FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            await using var xzs = new XZStream(targetStream, compOpts, threadOpts);
+            await fileStream.CopyToAsync(xzs, token);
+            await xzs.FlushAsync(token);
+        }
+
+        return await CreateArtifactFromTempDir(tempDir, relativePath, true, token);
+    }
+
+    static async Task<string> CreateArtifactFromTempDir(string tempDir, string? relativePath, bool singleFile, CancellationToken token)
+    {
+        var compressedPath = Path.Combine(tempDir, "compressed");
+
+        var fileInfo = new FileInfo(compressedPath);
+        var totalSize = fileInfo.Length;
+
+        var splitFiles = await SplitFile(compressedPath, 1024 * 1024 * 64, token);
+        token.ThrowIfCancellationRequested();
+
+
+        File.Delete(compressedPath);
+
+        var parts = new List<string>();
+        foreach (var splitFile in splitFiles)
+        {
+            token.ThrowIfCancellationRequested();
+
+            var hashAlg = SHA1.Create();
+            await using (var dataStream = File.OpenRead(splitFile))
+            {
+                await hashAlg.ComputeHashAsync(dataStream, token);
+            }
+
+            var hashString = GetHashString(hashAlg.Hash!);
+
+            var splitFileDir = Path.GetDirectoryName(splitFile);
+            File.Move(splitFile, Path.Combine(splitFileDir, hashString));
+            parts.Add($"sha1:{hashString}");
+        }
+
+        token.ThrowIfCancellationRequested();
+
+        var manifestData = new ArtifactManifest
+        {
+            Path = singleFile ? Path.GetDirectoryName(relativePath) : relativePath,
+            FileName = singleFile ? Path.GetFileName(relativePath) : null,
+            Size = totalSize,
+            Format = singleFile ? "xz" : "zip",
+            Parts = parts.ToArray()
+        };
+
+        var jsonString = JsonSerializer.Serialize(manifestData);
+
+        var sha256 = SHA256.Create();
+        var manifestHash = GetHashString(sha256.ComputeHash(Encoding.UTF8.GetBytes(jsonString)));
+        await File.WriteAllTextAsync(Path.Combine(tempDir, "manifest.json"), jsonString, token);
+
+        Directory.Move(tempDir, Path.Combine(Path.GetDirectoryName(tempDir)!, manifestHash));
+
+        return $"sha256:{manifestHash}";
+
+    }
+
+    static string GetHashString(byte[] hashBytes)
+    {
+        return BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
+    }
+
+    private static async Task<IEnumerable<string>> SplitFile(string inputFile, int chunkSize, CancellationToken token)
+    {
+        const int bufferSize = 20 * 1024;
+        var buffer = (new byte[bufferSize]).AsMemory();
+
+        await using Stream input = File.OpenRead(inputFile);
+        var index = 0;
+        var fileNames = new List<string>();
+        while (input.Position < input.Length)
+        {
+            if (token.IsCancellationRequested)
+                break;
+
+            var fileName = $"{inputFile}.{index}";
+            fileNames.Add(fileName);
+            await using (Stream output = File.Create(fileName))
+            {
+                int remaining = chunkSize, bytesRead;
+                while (remaining > 0 && (bytesRead = await input.ReadAsync(buffer[..Math.Min(remaining, bufferSize)], token)) > 0)
+                {
+                    if (token.IsCancellationRequested)
+                        break;
+
+                    await output.WriteAsync(buffer[..bytesRead], token);
+                    remaining -= bytesRead;
+                }
+            }
+            index++;
+        }
+
+        return fileNames;
+    }
+
+    private static bool NativeInitialized;
+
+    static void InitNativeLibrary()
+    {
+        if(NativeInitialized)
+            return;
+
+        NativeInitialized = true;
+
+        string libDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory ,"runtimes");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            libDir = Path.Combine(libDir, "win-");
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            libDir = Path.Combine(libDir, "linux-");
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            libDir = Path.Combine(libDir, "osx-");
+
+        switch (RuntimeInformation.ProcessArchitecture)
+        {
+            case Architecture.X86:
+                libDir += "x86";
+                break;
+            case Architecture.X64:
+                libDir += "x64";
+                break;
+            case Architecture.Arm:
+                libDir += "arm";
+                break;
+            case Architecture.Arm64:
+                libDir += "arm64";
+                break;
+        }
+        libDir = Path.Combine(libDir, "native");
+
+        string libPath = null;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            libPath = Path.Combine(libDir, "liblzma.dll");
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            libPath = Path.Combine(libDir, "liblzma.so");
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            libPath = Path.Combine(libDir, "liblzma.dylib");
+
+        if (libPath == null)
+            throw new PlatformNotSupportedException($"Unable to find native library.");
+        if (!File.Exists(libPath))
+            throw new PlatformNotSupportedException($"Unable to find native library [{libPath}].");
+
+        XZInit.GlobalInit(libPath);
+    }
+}

--- a/src/apps/src/eryph-packer/eryph-packer.csproj
+++ b/src/apps/src/eryph-packer/eryph-packer.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <RootNamespace>Eryph.Packer</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Joveler.Compression.XZ" Version="4.1.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
+    <PackageReference Include="System.CommandLine.Rendering" Version="0.4.0-alpha.22114.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/core/src/Eryph.Core/FileSystemService.cs
+++ b/src/core/src/Eryph.Core/FileSystemService.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Eryph.Core
+{
+    public class FileSystemService : IFileSystemService
+    {
+
+        public bool FileExists(string filePath)
+        {
+            return File.Exists(filePath);
+        }
+
+        public bool DirectoryExists(string path)
+        {
+            return Directory.Exists(path);
+        }
+
+        public void WriteAllBytes(string filePath, byte[] data)
+        {
+            File.WriteAllBytes(filePath, data);
+        }
+
+        public byte[] ReadAllBytes(string filePath)
+        {
+            return FileExists(filePath) ? File.ReadAllBytes(filePath) : new byte[0];
+        }
+
+        public string ReadText(string filePath)
+        {
+            return FileExists(filePath) ? File.ReadAllText(filePath) : "";
+        }
+
+        public void WriteText(string filePath, string data)
+        { 
+            File.WriteAllText(filePath, data);
+        }
+
+        public void FileDelete(string filePath)
+        {
+            File.Delete(filePath);
+        }
+
+        public IEnumerable<string> GetFiles(string path, string pattern)
+        {
+            return !Directory.Exists(path) ? new string[0] : Directory.GetFiles(path, pattern);
+        }
+
+        public void MoveFile(string path, string newPath)
+        {
+
+            var directory = Path.GetDirectoryName(newPath);
+
+            if(directory!= null)
+                Directory.CreateDirectory(directory);
+
+            File.Move(path, newPath);
+
+            var fi = new FileInfo(path);
+            for (var di = fi.Directory; di?.Parent != null && !di.EnumerateFileSystemInfos().Any(); di = di.Parent)
+            {
+                di.Delete();
+            }
+        }
+
+        public long GetFileSize(string filePath)
+        {
+
+            var fInfo = new FileInfo(filePath);
+            return fInfo.Length;
+        }
+
+        public void EnsureDirectoryExists(string path)
+        {
+            if (!Directory.Exists(path))
+                Directory.CreateDirectory(path);
+        }
+
+        public void DeleteOldestFiles(string path, string pattern, int filesToKeep)
+        {
+            foreach (var fileInfo in Directory.GetFiles(path, pattern).Select(x=>new FileInfo(x)).OrderByDescending(x=>x.LastAccessTime).Skip(filesToKeep))
+            {
+                fileInfo.Delete();
+            }
+
+        }
+
+        public Stream OpenRead(string path)
+        {
+            return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 0x1000);
+        }
+
+        public Stream OpenWrite(string path)
+        {
+            return new FileStream(path, FileMode.Create, FileAccess.Write);
+        }
+
+        public void DirectoryDelete(string directoryPath)
+        {
+            Directory.Delete(directoryPath, true);
+        }
+    }
+}

--- a/src/core/src/Eryph.Core/IFileSystemService.cs
+++ b/src/core/src/Eryph.Core/IFileSystemService.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace Eryph.Core
+{
+    public interface IFileSystemService
+    {
+        bool FileExists(string filePath);
+        bool DirectoryExists(string path);
+        byte[] ReadAllBytes(string filePath);
+
+        void WriteAllBytes(string filePath, byte[] data);
+        string ReadText(string filePath);
+        void WriteText(string filePath, string data);
+
+        void FileDelete(string filePath);
+        IEnumerable<string> GetFiles(string path, string pattern);
+
+        void MoveFile(string path, string newPath);
+        long GetFileSize(string filePath);
+
+        void EnsureDirectoryExists(string path);
+        void DeleteOldestFiles(string path, string pattern, int filesToKeep);
+        Stream OpenRead(string path);
+        Stream OpenWrite(string path);
+
+        void DirectoryDelete(string directoryPath);
+
+    }
+
+    public enum FileSizeType { MB, GB };
+
+}

--- a/src/core/src/Eryph.Messages/Resources/Images/Commands/PrepareVirtualMachineImageCommand.cs
+++ b/src/core/src/Eryph.Messages/Resources/Images/Commands/PrepareVirtualMachineImageCommand.cs
@@ -7,7 +7,7 @@ namespace Eryph.Messages.Resources.Images.Commands
     [SendMessageTo(MessageRecipient.VMHostAgent)]
     public class PrepareVirtualMachineImageCommand: IHostAgentCommand
     {
-        public MachineImageConfig ImageConfig { get; set; }
+        public string Image { get; set; }
 
         [PrivateIdentifier]
         public string AgentName { get; set; }

--- a/src/core/src/Eryph.VmConfig.Primitives/BackgroundTaskQueue.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/BackgroundTaskQueue.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Eryph;
+
+public class BackgroundTaskQueue : IBackgroundTaskQueue
+{
+    private readonly Channel<Func<CancellationToken, ValueTask>> _queue;
+
+    public BackgroundTaskQueue(int capacity)
+    {
+        // Capacity should be set based on the expected application load and
+        // number of concurrent threads accessing the queue.            
+        // BoundedChannelFullMode.Wait will cause calls to WriteAsync() to return a task,
+        // which completes only when space became available. This leads to backpressure,
+        // in case too many publishers/calls start accumulating.
+        var options = new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait
+        };
+        _queue = Channel.CreateBounded<Func<CancellationToken, ValueTask>>(options);
+    }
+
+    public async ValueTask QueueBackgroundWorkItemAsync(
+        Func<CancellationToken, ValueTask> workItem)
+    {
+        if (workItem == null)
+        {
+            throw new ArgumentNullException(nameof(workItem));
+        }
+
+        await _queue.Writer.WriteAsync(workItem);
+    }
+
+    public async ValueTask<Func<CancellationToken, ValueTask>> DequeueAsync(
+        CancellationToken cancellationToken)
+    {
+        var workItem = await _queue.Reader.ReadAsync(cancellationToken);
+
+        return workItem;
+    }
+
+}

--- a/src/core/src/Eryph.VmConfig.Primitives/IBackgroundTaskQueue.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/IBackgroundTaskQueue.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Eryph;
+
+public interface IBackgroundTaskQueue
+{
+    ValueTask QueueBackgroundWorkItemAsync(Func<CancellationToken, ValueTask> workItem);
+
+    ValueTask<Func<CancellationToken, ValueTask>> DequeueAsync(
+        CancellationToken cancellationToken);
+
+}

--- a/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/Config/MachineConfig.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/Config/MachineConfig.cs
@@ -12,7 +12,7 @@ namespace Eryph.Resources.Machines.Config
         public string Environment { get; set; }
         public string Project { get; set; }
 
-        public MachineImageConfig Image { get; set; }
+        public string Image { get; set; }
 
         public VirtualMachineConfig VM { get; set; }
 

--- a/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/Config/MachineImageConfig.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/Config/MachineImageConfig.cs
@@ -1,9 +1,0 @@
-﻿namespace Eryph.Resources.Machines.Config
-{
-    public class MachineImageConfig
-    {
-        public MachineImageSource Source { get; set; }
-        public string Name { get; set; }
-        public string Tag { get; set; }
-    }
-}

--- a/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/Config/MachineImageSource.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/Config/MachineImageSource.cs
@@ -1,8 +1,0 @@
-﻿namespace Eryph.Resources.Machines.Config
-{
-    public enum MachineImageSource
-    {
-        Local,
-        VagrantVM
-    }
-}

--- a/src/core/src/Eryph.VmManagement/MachineConfigExtensions.cs
+++ b/src/core/src/Eryph.VmManagement/MachineConfigExtensions.cs
@@ -12,7 +12,7 @@ namespace Eryph.VmManagement
         public static Task<Either<PowershellFailure, MachineConfig>> MergeWithImageSettings(
             this MachineConfig machineConfig, Option<VirtualMachineConfig> optionalImageConfig)
         {
-            if (string.IsNullOrWhiteSpace(machineConfig.Image.Name))
+            if (string.IsNullOrWhiteSpace(machineConfig.Image))
                 return Prelude.RightAsync<PowershellFailure, MachineConfig>(machineConfig).ToEither();
 
             //copy machine config to a new object

--- a/src/core/src/Eryph.VmManagement/VirtualMachine.cs
+++ b/src/core/src/Eryph.VmManagement/VirtualMachine.cs
@@ -71,15 +71,16 @@ namespace Eryph.VmManagement
         public static Task<Either<PowershellFailure, Option<TypedPsObject<PlannedVirtualMachineInfo>>>> TemplateFromImage(
             IPowershellEngine engine,
             HostSettings hostSettings,
-            MachineImageConfig imageConfig)
+            string image)
         {
-            if (string.IsNullOrWhiteSpace(imageConfig?.Name))
+            if (string.IsNullOrWhiteSpace(image))
                 return RightAsync<PowershellFailure, Option<TypedPsObject<PlannedVirtualMachineInfo>>>(None).ToEither();
 
 
             var imageRootPath = Path.Combine(hostSettings.DefaultVirtualHardDiskPath, "Images");
-            var imagePath = Path.Combine(imageRootPath,
-                $"{imageConfig.Name}\\{imageConfig.Tag}\\");
+            var imagePathName = image.Replace('/', '\\');
+
+            var imagePath = Path.Combine(imageRootPath, imagePathName);
 
             var configRootPath = Path.Combine(imagePath, "Virtual Machines");
 

--- a/src/modules/src/Eryph.Modules.Controller/Operations/ValidateMachineConfigCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Operations/ValidateMachineConfigCommandHandler.cs
@@ -41,9 +41,6 @@ namespace Eryph.Modules.Controller.Operations
                 //TODO generate a random name here
                 machineConfig.Name = "eryph-machine";
 
-            if (machineConfig.Image == null)
-                machineConfig.Image = new MachineImageConfig();
-
 
             if (machineConfig.VM.Cpu == null)
                 machineConfig.VM.Cpu = new VirtualMachineCpuConfig();

--- a/src/modules/src/Eryph.Modules.Controller/Operations/Workflows/CreateMachineSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Operations/Workflows/CreateMachineSaga.cs
@@ -72,7 +72,7 @@ namespace Eryph.Modules.Controller.Operations.Workflows
 
                 return _taskDispatcher.StartNew(Data.OperationId,new PrepareVirtualMachineImageCommand
                 {
-                    ImageConfig = Data.Config?.Image,
+                    Image = Data.Config?.Image,
                     AgentName = r.AgentName
                 });
             });
@@ -83,10 +83,13 @@ namespace Eryph.Modules.Controller.Operations.Workflows
             if (Data.State >= CreateVMState.ImagePrepared)
                 return Task.CompletedTask;
 
-            return FailOrRun(message, () =>
+            return FailOrRun<PrepareVirtualMachineImageCommand, string>(message, (image) =>
             {
                 Data.State = CreateVMState.ImagePrepared;
                 Data.MachineId = Guid.NewGuid();
+
+                if(Data.Config!= null)
+                    Data.Config.Image = image;
 
                 return _taskDispatcher.StartNew(Data.OperationId,new CreateVirtualMachineCommand
                 {

--- a/src/modules/src/Eryph.Modules.VmHostAgent/CreateVirtualMachineCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/CreateVirtualMachineCommandHandler.cs
@@ -77,10 +77,10 @@ namespace Eryph.Modules.VmHostAgent
         private static Task<Either<PowershellFailure, Option<TypedPsObject<PlannedVirtualMachineInfo>>>> GetTemplate(
             IPowershellEngine engine,
             HostSettings hostSettings,
-            MachineImageConfig imageConfig)
+            string image)
         {
             //add a cache lookup here, as image data should not change
-            return VirtualMachine.TemplateFromImage(engine, hostSettings, imageConfig);
+            return VirtualMachine.TemplateFromImage(engine, hostSettings, image);
         }
 
         private static Task<Either<PowershellFailure, TypedPsObject<VirtualMachineInfo>>> CreateVM(MachineConfig config,

--- a/src/modules/src/Eryph.Modules.VmHostAgent/DiagnosticTraceWriter.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/DiagnosticTraceWriter.cs
@@ -100,18 +100,3 @@ internal class DiagnosticTraceWriter : ITraceWriter
  
 
     }
-
-    public class PrivateIdentifier
-    {
-        [JsonProperty("_pi")]
-        public PrivateIdentifierValue Value { get; set; }
-
-
-}
-
-public class PrivateIdentifierValue
-    {
-        public object Value { get; set; }
-        public bool Critical { get; set; }
-
-}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -5,6 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.2" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\core\src\Eryph.Messages\Eryph.Messages.csproj" />
     <ProjectReference Include="..\Eryph.ModuleCore\Eryph.ModuleCore.csproj" />
     <ProjectReference Include="..\..\..\infrastructure\src\Eryph.Rebus\Eryph.Rebus.csproj" />

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Joveler.Compression.XZ" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.2" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ArtifactDecompression.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ArtifactDecompression.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.IO.Compression;
+using System.Threading;
 using System.Threading.Tasks;
 using Eryph.Core;
 using Joveler.Compression.XZ;
@@ -16,7 +17,7 @@ namespace Eryph.Modules.VmHostAgent.Images
             _fileSystemService = fileSystemService;
         }
 
-        public async Task Decompress(ArtifactManifestData artifactManifest, Stream stream, string imageDirectory)
+        public async Task Decompress(ArtifactManifestData artifactManifest, Stream stream, string imageDirectory, CancellationToken cancel)
         {
             switch (artifactManifest.Format)
             {
@@ -24,7 +25,7 @@ namespace Eryph.Modules.VmHostAgent.Images
                     DecompressZip(artifactManifest, stream, imageDirectory);
                     break;
                 case "xz":
-                    await DecompressXz(artifactManifest, stream, imageDirectory);
+                    await DecompressXz(artifactManifest, stream, imageDirectory, cancel);
                     break;
             }
         }
@@ -44,7 +45,7 @@ namespace Eryph.Modules.VmHostAgent.Images
 
         }
 
-        private async Task DecompressXz(ArtifactManifestData artifactManifest, Stream stream, string imageDirectory)
+        private async Task DecompressXz(ArtifactManifestData artifactManifest, Stream stream, string imageDirectory, CancellationToken cancel)
         {
             InitNativeLibrary();
 
@@ -58,7 +59,7 @@ namespace Eryph.Modules.VmHostAgent.Images
             await using var fileStream = _fileSystemService.OpenWrite(fileName);
 
             await using var xzs = new XZStream(stream, new XZDecompressOptions());
-            await xzs.CopyToAsync(fileStream);
+            await xzs.CopyToAsync(fileStream, cancel);
         }
 
         private static bool _nativeInitialized;

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ArtifactDecompression.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ArtifactDecompression.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using Eryph.Core;
+using Joveler.Compression.XZ;
+
+namespace Eryph.Modules.VmHostAgent.Images
+{
+    internal class ArtifactDecompression
+    {
+        private readonly IFileSystemService _fileSystemService;
+
+        public ArtifactDecompression(IFileSystemService fileSystemService)
+        {
+            _fileSystemService = fileSystemService;
+        }
+
+        public async Task Decompress(ArtifactManifestData artifactManifest, Stream stream, string imageDirectory)
+        {
+            switch (artifactManifest.Format)
+            {
+                case "zip":
+                    DecompressZip(artifactManifest, stream, imageDirectory);
+                    break;
+                case "xz":
+                    await DecompressXz(artifactManifest, stream, imageDirectory);
+                    break;
+            }
+        }
+
+        private void DecompressZip(ArtifactManifestData artifactManifest, Stream stream, string imageDirectory)
+        {
+            using var zipArchive = new ZipArchive(stream, ZipArchiveMode.Read);
+
+            var path = imageDirectory;
+            if (artifactManifest?.Path != null)
+            {
+                path = Path.Combine(path, artifactManifest.Path);
+                _fileSystemService.EnsureDirectoryExists(path);
+            }
+
+            zipArchive.ExtractToDirectory(path,true);
+
+        }
+
+        private async Task DecompressXz(ArtifactManifestData artifactManifest, Stream stream, string imageDirectory)
+        {
+            InitNativeLibrary();
+
+            var folderName = Path.Combine(imageDirectory, artifactManifest.Path);
+            _fileSystemService.EnsureDirectoryExists(folderName);
+
+            if (artifactManifest.FileName == null)
+                throw new InvalidOperationException("Missing filename for single file compressed artifact.");
+
+            var fileName = Path.Combine(folderName, artifactManifest.FileName);
+            await using var fileStream = _fileSystemService.OpenWrite(fileName);
+
+            await using var xzs = new XZStream(stream, new XZDecompressOptions());
+            await xzs.CopyToAsync(fileStream);
+        }
+
+        private static bool _nativeInitialized;
+
+        private static void InitNativeLibrary()
+        {
+            if (_nativeInitialized)
+                return;
+
+            _nativeInitialized = true;
+
+            var libPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "liblzma.dll");
+            
+            if (!File.Exists(libPath))
+                throw new PlatformNotSupportedException($"Unable to find native library [{libPath}].");
+
+            XZInit.GlobalInit(libPath);
+        }
+    }
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ArtifactInfo.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ArtifactInfo.cs
@@ -1,0 +1,18 @@
+﻿using JetBrains.Annotations;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+public record ArtifactInfo(ImageIdentifier ImageId, string Hash, string HashAlg, ArtifactManifestData MetaData, string LocalPath, bool MergedWithImage)
+{
+    public readonly ImageIdentifier ImageId = ImageId;
+    public readonly string Hash = Hash;
+    public readonly string HashAlg = HashAlg;
+    public readonly string LocalPath = LocalPath;
+    [CanBeNull] public readonly ArtifactManifestData MetaData = MetaData;
+    public readonly bool MergedWithImage = MergedWithImage;
+
+    public override string ToString()
+    {
+        return $"{ImageId.Name}/{Hash[..12]}";
+    }
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ArtifactManifestData.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ArtifactManifestData.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+public class ArtifactManifestData
+{
+    [JsonPropertyName("format")]
+    public string Format { get; set; }
+
+    [JsonPropertyName("path")]
+    public string Path { get; set; }
+
+    [JsonPropertyName("filename")]
+    public string FileName { get; set; }
+
+
+    [JsonPropertyName("parts")]
+    public string[] Parts { get; set; }
+
+
+
+    [JsonPropertyName("size")]
+    public long Size { get; set; }
+
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageProvider.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+using Eryph.VmManagement;
+using LanguageExt;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+public interface IImageProvider
+
+{
+    Task<Either<PowershellFailure, string>> ProvideImage(string path, string imageName, Func<string,Task<Unit>> reportProgress);
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageProvider.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Eryph.VmManagement;
 using LanguageExt;
@@ -8,5 +9,5 @@ namespace Eryph.Modules.VmHostAgent.Images;
 public interface IImageProvider
 
 {
-    Task<Either<PowershellFailure, string>> ProvideImage(string path, string imageName, Func<string,Task<Unit>> reportProgress);
+    Task<Either<PowershellFailure, string>> ProvideImage(string imageName, Func<string,Task<Unit>> reportProgress, CancellationToken cancel);
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageRequestDispatcher.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageRequestDispatcher.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Eryph.Modules.VmHostAgent;
+
+public interface IImageRequestDispatcher
+{
+    void NewImageRequestTask(Guid operationId, Guid taskId, string image);
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageSource.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageSource.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Eryph.VmManagement;
+using LanguageExt;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+public record ImageInfo(ImageIdentifier Id, string LocalPath, ManifestData MetaData)
+{
+    public readonly ImageIdentifier Id = Id;
+    public readonly string LocalPath = LocalPath;
+    public readonly ManifestData MetaData = MetaData;
+}
+
+public class ManifestData
+{
+    [JsonPropertyName("image")]
+    public string Image { get; set; }
+
+    [JsonPropertyName("alias")]
+    public string Alias { get; set; }
+
+    [JsonPropertyName("artifacts")]
+    public string[] Artifacts { get; set; }
+
+}
+
+internal interface IImageSource
+{
+    Task<Either<PowershellFailure, ImageInfo>> ProvideImage(string path, ImageIdentifier imageIdentifier, Func<string, Task<Unit>> reportProgress);
+
+    Task<Either<PowershellFailure, string>> RetrieveArtifact(string artifactsFolder, ImageInfo imageInfo,
+        string artifact, Func<string, Task<Unit>> reportProgress);
+
+    public string SourceName { get; set; }
+}
+
+internal interface ILocalImageSource: IImageSource
+{
+    Task<Either<PowershellFailure, Unit>> MergeArtifact(string artifact, string artifactPath, ImageInfo imageInfo, Func<string, Task<Unit>> reportProgress);
+    Task<Either<PowershellFailure, ImageInfo>> ProvideFallbackImage(string path, ImageIdentifier imageIdentifier, Func<string, Task<Unit>> reportProgress);
+
+    Task<Either<PowershellFailure, ImageInfo>> CacheImage(string path, ImageInfo imageInfo);
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageSource.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageSource.cs
@@ -1,45 +1,17 @@
 ﻿using System;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Eryph.VmManagement;
 using LanguageExt;
 
 namespace Eryph.Modules.VmHostAgent.Images;
 
-public record ImageInfo(ImageIdentifier Id, string LocalPath, ManifestData MetaData)
-{
-    public readonly ImageIdentifier Id = Id;
-    public readonly string LocalPath = LocalPath;
-    public readonly ManifestData MetaData = MetaData;
-}
-
-public class ManifestData
-{
-    [JsonPropertyName("image")]
-    public string Image { get; set; }
-
-    [JsonPropertyName("alias")]
-    public string Alias { get; set; }
-
-    [JsonPropertyName("artifacts")]
-    public string[] Artifacts { get; set; }
-
-}
-
 internal interface IImageSource
 {
-    Task<Either<PowershellFailure, ImageInfo>> ProvideImage(string path, ImageIdentifier imageIdentifier, Func<string, Task<Unit>> reportProgress);
+    Task<Either<PowershellFailure, ImageInfo>> ProvideImage(string path, ImageIdentifier imageIdentifier);
 
-    Task<Either<PowershellFailure, string>> RetrieveArtifact(string artifactsFolder, ImageInfo imageInfo,
-        string artifact, Func<string, Task<Unit>> reportProgress);
+    Task<Either<PowershellFailure, ArtifactInfo>> RetrieveArtifact(ImageInfo imageInfo, string artifact);
+
+    Task<Either<PowershellFailure, long>> RetrieveArtifactPart(ArtifactInfo artifact, string artifactPart, long availableSize, long totalSize, Func<string, Task<Unit>> reportProgress);
 
     public string SourceName { get; set; }
-}
-
-internal interface ILocalImageSource: IImageSource
-{
-    Task<Either<PowershellFailure, Unit>> MergeArtifact(string artifact, string artifactPath, ImageInfo imageInfo, Func<string, Task<Unit>> reportProgress);
-    Task<Either<PowershellFailure, ImageInfo>> ProvideFallbackImage(string path, ImageIdentifier imageIdentifier, Func<string, Task<Unit>> reportProgress);
-
-    Task<Either<PowershellFailure, ImageInfo>> CacheImage(string path, ImageInfo imageInfo);
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageSource.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageSource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Eryph.VmManagement;
 using LanguageExt;
@@ -7,11 +8,11 @@ namespace Eryph.Modules.VmHostAgent.Images;
 
 internal interface IImageSource
 {
-    Task<Either<PowershellFailure, ImageInfo>> ProvideImage(string path, ImageIdentifier imageIdentifier);
+    Task<Either<PowershellFailure, ImageInfo>> ProvideImage(string path, ImageIdentifier imageIdentifier, CancellationToken cancel);
 
-    Task<Either<PowershellFailure, ArtifactInfo>> RetrieveArtifact(ImageInfo imageInfo, string artifact);
+    Task<Either<PowershellFailure, ArtifactInfo>> RetrieveArtifact(ImageInfo imageInfo, string artifact, CancellationToken cancel);
 
-    Task<Either<PowershellFailure, long>> RetrieveArtifactPart(ArtifactInfo artifact, string artifactPart, long availableSize, long totalSize, Func<string, Task<Unit>> reportProgress);
+    Task<Either<PowershellFailure, long>> RetrieveArtifactPart(ArtifactInfo artifact, string artifactPart, long availableSize, long totalSize, Func<string, Task<Unit>> reportProgress, CancellationToken cancel);
 
     public string SourceName { get; set; }
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageSourceFactory.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/IImageSourceFactory.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+internal interface IImageSourceFactory
+{
+    IEnumerable<string> RemoteSources { get; }
+    IImageSource CreateNew(string name);
+    ILocalImageSource CreateLocal();
+
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ILocalImageSource.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ILocalImageSource.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Eryph.VmManagement;
 using LanguageExt;
@@ -8,10 +9,10 @@ namespace Eryph.Modules.VmHostAgent.Images;
 internal interface ILocalImageSource: IImageSource
 {
     Task<Either<PowershellFailure, Unit>> MergeArtifact(ArtifactInfo artifactInfo, ImageInfo imageInfo,
-        Func<string, Task<Unit>> reportProgress);
-    Task<Either<PowershellFailure, ImageInfo>> ProvideFallbackImage(string path, ImageIdentifier imageIdentifier);
+        Func<string, Task<Unit>> reportProgress, CancellationToken cancel);
+    Task<Either<PowershellFailure, ImageInfo>> ProvideFallbackImage(string path, ImageIdentifier imageIdentifier, CancellationToken cancel);
 
-    Task<Either<PowershellFailure, ImageInfo>> CacheImage(string path, ImageInfo imageInfo);
-    Task<Either<PowershellFailure, ArtifactInfo>> CacheArtifact(ArtifactInfo artifactInfo, ImageInfo imageInfo);
+    Task<Either<PowershellFailure, ImageInfo>> CacheImage(string path, ImageInfo imageInfo, CancellationToken cancel);
+    Task<Either<PowershellFailure, ArtifactInfo>> CacheArtifact(ArtifactInfo artifactInfo, ImageInfo imageInfo, CancellationToken cancel);
 
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ILocalImageSource.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ILocalImageSource.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+using Eryph.VmManagement;
+using LanguageExt;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+internal interface ILocalImageSource: IImageSource
+{
+    Task<Either<PowershellFailure, Unit>> MergeArtifact(ArtifactInfo artifactInfo, ImageInfo imageInfo,
+        Func<string, Task<Unit>> reportProgress);
+    Task<Either<PowershellFailure, ImageInfo>> ProvideFallbackImage(string path, ImageIdentifier imageIdentifier);
+
+    Task<Either<PowershellFailure, ImageInfo>> CacheImage(string path, ImageInfo imageInfo);
+    Task<Either<PowershellFailure, ArtifactInfo>> CacheArtifact(ArtifactInfo artifactInfo, ImageInfo imageInfo);
+
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageBackgroundTaskQueue.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageBackgroundTaskQueue.cs
@@ -1,0 +1,10 @@
+﻿using Eryph.Modules.VmHostAgent.Images;
+
+namespace Eryph.Modules.VmHostAgent;
+
+internal class ImageBackgroundTaskQueue : BackgroundTaskQueue, IImageRequestBackgroundQueue
+{
+    public ImageBackgroundTaskQueue() : base(3)
+    {
+    }
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageIdentifier.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageIdentifier.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Eryph.VmManagement;
+using LanguageExt;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+public record ImageIdentifier(string Organization, string ImageId, string Tag)
+{
+    public readonly string Organization = Organization;
+    public readonly string ImageId = ImageId;
+    public readonly string Tag = Tag;
+
+    public string Name => $"{Organization}/{ImageId}/{Tag}";
+
+    public static Either<PowershellFailure, ImageIdentifier> Parse(string imageName)
+    {
+        imageName = imageName.ToLowerInvariant();
+        var imageParts = imageName.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (imageParts.Length != 3 && imageParts.Length != 2)
+            return new PowershellFailure { Message = $"Invalid image name '{imageName}'" };
+
+        var imageOrg = imageParts[0];
+        var imageId = imageParts[1];
+        var imageTag = imageParts.Length == 3 ? imageParts[2] : "latest";
+
+        return new ImageIdentifier(imageOrg, imageId, imageTag);
+    }
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageInfo.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace Eryph.Modules.VmHostAgent.Images;
+
+public record ImageInfo(ImageIdentifier Id, string LocalPath, ImageManifestData MetaData)
+{
+    public readonly ImageIdentifier Id = Id;
+    public readonly string LocalPath = LocalPath;
+    public readonly ImageManifestData MetaData = MetaData;
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageManifestData.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageManifestData.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+public class ImageManifestData
+{
+    [JsonPropertyName("image")]
+    public string Image { get; set; }
+
+    [JsonPropertyName("ref")]
+    public string Reference { get; set; }
+
+    [JsonPropertyName("artifacts")]
+    public string[] Artifacts { get; set; }
+
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageRequestRegistry.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageRequestRegistry.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Eryph.Messages;
+using Eryph.Messages.Operations.Events;
+using Eryph.VmManagement;
+using LanguageExt;
+using Rebus.Bus;
+using Rebus.Transport;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+internal class ImageRequestRegistry : IImageRequestDispatcher
+{
+    private readonly IBus _bus;
+    private readonly IImageRequestBackgroundQueue _queue;
+    private readonly IImageProvider _imageProvider;
+
+    public ImageRequestRegistry(IBus bus, IImageRequestBackgroundQueue queue, IImageProvider imageProvider)
+    {
+        _bus = bus;
+        _queue = queue;
+        _imageProvider = imageProvider;
+    }
+
+    private readonly Atom<HashMap<string, Arr<ListingTask>>> _imageQueue = Prelude.Atom(HashMap<string, Arr<ListingTask>>.Empty);
+
+    public void NewImageRequestTask(Guid operationId, Guid taskId, string image)
+    {
+        _imageQueue.Swap(queue => queue.AddOrUpdate(image,
+            Some: td => td.Add(new ListingTask(operationId, taskId)),
+            None: () =>
+            {
+                _queue.QueueBackgroundWorkItemAsync(token => ProvideImage(image, token));
+                return new Arr<ListingTask>(new[] { new ListingTask(operationId, taskId) });
+            }));
+
+
+    }
+
+    private async ValueTask ProvideImage(string image, CancellationToken cancel)
+    {
+
+        try
+        {
+            var result = await _imageProvider.ProvideImage(
+                image,
+                (message) => ReportProgress(image, message), cancel);
+            await EndRequest(image, result);
+        }
+        catch (Exception ex)
+        {
+            await EndRequest(image, new PowershellFailure { Message = ex.Message });
+        }
+
+
+    }
+
+
+    private record ListingTask(Guid OperationId, Guid TaskId)
+    {
+        public readonly Guid OperationId = OperationId;
+        public readonly Guid TaskId = TaskId;
+    }
+
+    public Task<Unit> ReportProgress(string image, string message)
+    {
+        return _imageQueue.Value.Find(image).IfSomeAsync(async  listening =>
+        {
+            foreach (var (operationId, taskId) in listening)
+            {
+                await ProgressMessage(operationId, taskId, message);
+            }
+
+            return Unit.Default;
+        });
+    }
+
+    private async Task ProgressMessage(Guid operationId, Guid taskId, string message)
+    {
+        using var scope = new RebusTransactionScope();
+        await _bus.Publish(new OperationTaskProgressEvent
+        {
+            Id = Guid.NewGuid(),
+            OperationId = operationId,
+            TaskId = taskId,
+            Message = message,
+            Timestamp = DateTimeOffset.UtcNow
+        }).ConfigureAwait(false);
+
+        // commit it like this
+        await scope.CompleteAsync().ConfigureAwait(false);
+    }
+
+    public Task EndRequest(string image, Either<PowershellFailure, string> result)
+    {
+        return _imageQueue.Value.Find(image).IfSomeAsync(async listening =>
+        {
+            _imageQueue.Swap(queue => queue.Remove(image));
+            foreach (var (operationId, taskId) in listening)
+            {
+                await result.ToAsync()
+                    .MatchAsync(r =>
+                            _bus.Publish(OperationTaskStatusEvent.Completed(operationId, taskId, r)),
+                        l =>
+                        {
+                            return _bus.Publish(OperationTaskStatusEvent.Failed(operationId, taskId,
+                                new ErrorData { ErrorMessage = l.Message }));
+                        });
+
+            }
+        });
+    }
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageRequestWatcherService.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageRequestWatcherService.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+internal interface IImageRequestBackgroundQueue : IBackgroundTaskQueue
+{
+
+}
+
+internal class ImageRequestWatcherService : BackgroundService
+{
+    private readonly ILogger _log;
+    private readonly IImageRequestBackgroundQueue _backgroundQueue;
+
+    public ImageRequestWatcherService(ILogger log, IImageRequestBackgroundQueue backgroundQueue)
+    {
+        _log = log;
+        _backgroundQueue = backgroundQueue;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await BackgroundProcessing(stoppingToken);
+    }
+
+    private async Task BackgroundProcessing(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var workItem =
+                await _backgroundQueue.DequeueAsync(stoppingToken);
+
+            try
+            {
+                await workItem(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _log.LogError(ex,
+                    "Error occurred executing {WorkItem}.", nameof(workItem));
+            }
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken stoppingToken)
+    {
+        _log.LogInformation("ImageRequestWatcherService is stopping.");
+
+        await base.StopAsync(stoppingToken);
+    }
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageSourceBase.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageSourceBase.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Text.Json;
+using Eryph.VmManagement;
+using LanguageExt;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+public abstract class ImageSourceBase
+{
+    protected Either<PowershellFailure, string> ParseArtifactName(string artifact)
+    {
+        var artifactParts = artifact.Split(':', StringSplitOptions.RemoveEmptyEntries);
+        if (artifactParts.Length != 3 || artifactParts[0] != "zip" || artifactParts[1] != "sha256")
+            return new PowershellFailure { Message = $"Invalid artifact name '{artifact}'" };
+
+        return artifactParts[2];
+    }
+
+    protected ManifestData ReadManifest(string json)
+    {
+        return JsonSerializer.Deserialize<ManifestData>(json, new JsonSerializerOptions{IncludeFields = true});
+    }
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageSourceFactory.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImageSourceFactory.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SimpleInjector;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+
+internal class ImageSourceFactory: IImageSourceFactory
+{
+    readonly Container _container;
+    readonly Dictionary<string, InstanceProducer<IImageSource>> _producers =
+        new(
+            StringComparer.OrdinalIgnoreCase);
+
+    public ImageSourceFactory(Container container)
+    {
+        _container = container;
+    }
+
+    public IEnumerable<string> RemoteSources => _producers.Keys.Where(x=> x!=ImagesSources.Local);
+
+    IImageSource IImageSourceFactory.CreateNew(string name)
+    {
+        var result = _producers[name].GetInstance();
+        result.SourceName  = name;
+        return result;
+    }
+
+    ILocalImageSource IImageSourceFactory.CreateLocal() =>
+        (ILocalImageSource) _producers[ImagesSources.Local].GetInstance();
+
+    public void Register<TImplementation>(string name)
+        where TImplementation : class, IImageSource
+    {
+        var producer = Lifestyle.Transient
+            .CreateProducer<IImageSource, TImplementation>(_container);
+
+        _producers.Add(name, producer);
+    }
+
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImagesSources.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/ImagesSources.cs
@@ -1,0 +1,7 @@
+﻿namespace Eryph.Modules.VmHostAgent.Images;
+
+internal static class ImagesSources
+{
+    public const string Local = "local";
+    public const string EryphHub = "eryph-hub";
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/LocalFirstImageProvider.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/LocalFirstImageProvider.cs
@@ -1,20 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Eryph.VmManagement;
 using LanguageExt;
+using Microsoft.Extensions.Logging;
 
 namespace Eryph.Modules.VmHostAgent.Images
 {
     internal class LocalFirstImageProvider : IImageProvider
     {
         private readonly IImageSourceFactory _sourceFactory;
+        private readonly ILogger _log;
 
-        public LocalFirstImageProvider(IImageSourceFactory sourceFactory)
+        public LocalFirstImageProvider(IImageSourceFactory sourceFactory, ILogger log)
         {
             _sourceFactory = sourceFactory;
+            _log = log;
         }
 
         public Task<Either<PowershellFailure, string>> ProvideImage(string path, string imageName, Func<string, Task<Unit>> reportProgress)
@@ -28,10 +30,10 @@ namespace Eryph.Modules.VmHostAgent.Images
                         .MapAsync(i =>
                         {
                             if (i.Id.Name != imageName)
-                                reportProgress($"resolved image '{imageName}' as '{i.Id.Name}'");
+                                reportProgress($"Resolved image '{imageName}' as '{i.Id.Name}'");
                             return i;
                         })
-                        .BindAsync(imageInfo => EnsureArtifacts(path, imageInfo, reportProgress))
+                        .BindAsync(imageInfo => EnsureArtifacts(imageInfo, reportProgress))
                         .MapAsync(imageInfo => imageInfo.Id.Name);
 
                 }
@@ -47,34 +49,49 @@ namespace Eryph.Modules.VmHostAgent.Images
             var imageRefs = previousRefs as string[] ?? previousRefs.ToArray();
             if (imageRefs.Contains(imageId.Name))
             {
-                var imageNames = string.Join(',', imageRefs, imageRefs.Append(new[] { imageId.Name }));
+                var imageNames = string.Join('?', imageRefs.Append(new[] { imageId.Name })).Replace("?", " => ");
                 return new PowershellFailure
                 {
                     Message =
-                        $"Detected circular reference in image aliases. Contact organization '{imageId.Organization}' to resolve invalid image references of images '{imageNames}'"
+                        $"Detected circular image references. Contact organization '{imageId.Organization}' to resolve invalid image references of '{imageNames}'"
                 };
             }
 
             var localSource = _sourceFactory.CreateLocal();
 
-            return await localSource.ProvideImage(path, imageId, reportProgress) //found locally? (will not resolve 'latest' tag)
+            return await localSource.ProvideImage(path, imageId).WriteTrace() //found locally? (will not resolve 'latest' tag)
                 .ToAsync()
-                .BindLeft(l => ProvideImageFromRemote(path, imageId, reportProgress).ToAsync()) // fetch remote image
-                .BindLeft(l => localSource.ProvideFallbackImage(path, imageId, reportProgress).ToAsync()) //local fallback (will resolve 'latest' tag)
-                .MapLeft(l => new PowershellFailure { Message = $"could not find image '{imageId.Name}' on any source." })
+                .BindLeft(l =>
+                {
+                    _log.LogDebug("Failed to find image on local source. Local result: {message}", l.Message);
+
+                    return ProvideImageFromRemote(path, imageId).ToAsync();
+                }) // fetch remote image
+                .BindLeft(l =>
+                {
+                    _log.LogDebug("Failed to find image on remote sources. Remote sources result: {message}", l.Message);
+                    return localSource.ProvideFallbackImage(path, imageId).ToAsync();
+                }) //local fallback (will resolve 'latest' tag)
+                .MapLeft(l =>
+                {
+                    _log.LogInformation("Failed to find image on any source. Local fallback result: {message}", l.Message);
+                    return new PowershellFailure
+                            { Message = $"could not find image '{imageId.Name}' on any source." };
+                })
                 .ToEither()
-                .BindAsync(imageInfo => localSource.CacheImage(path,imageInfo)) // cache anything received in local store
-                .BindAsync(r =>
+                .BindAsync(imageInfo => localSource.CacheImage(path,imageInfo)).WriteTrace() // cache anything received in local store
+                .BindAsync(async r =>
                     {
-                        if (!string.IsNullOrWhiteSpace(r.MetaData.Alias))
+                        if (!string.IsNullOrWhiteSpace(r.MetaData.Reference))
                         {
-                            //resolve image alias
-                            return ImageIdentifier.Parse(r.MetaData.Alias)
+                            await reportProgress($"Image '{r.Id.Name}' references '{r.MetaData.Reference}'");
+                            //resolve image reference
+                            return await ImageIdentifier.Parse(r.MetaData.Reference)
                                 .BindAsync(aliasId => ProvideImage(path, aliasId, reportProgress,
-                                    imageRefs.Append(new[] { imageId.Name })));
+                                    imageRefs.Append(new[] { imageId.Name }))).WriteTrace();
                         }
 
-                        return Prelude.RightAsync<PowershellFailure, ImageInfo>(r).ToEither();
+                        return await Prelude.RightAsync<PowershellFailure, ImageInfo>(r).ToEither();
 
                     });
 
@@ -82,65 +99,164 @@ namespace Eryph.Modules.VmHostAgent.Images
         }
 
 
-        private async Task<Either<PowershellFailure, ImageInfo>> ProvideImageFromRemote(string path, ImageIdentifier imageId,
-            Func<string, Task<Unit>> reportProgress)
+        private async Task<Either<PowershellFailure, ImageInfo>> ProvideImageFromRemote(string path, ImageIdentifier imageId)
         {
+            _log.LogDebug("Trying to find image {image} on remote sources", imageId.Name);
             foreach (var sourceName in _sourceFactory.RemoteSources)
             {
                 var imageSource = _sourceFactory.CreateNew(sourceName);
-                var result = await imageSource.ProvideImage(path, imageId, reportProgress);
-                if (result.IsRight)
-                    return result;
+                var result = await imageSource.ProvideImage(path, imageId);
 
+                result.IfLeft(l =>
+                {
+                    _log.LogInformation("Failed to lookup image {image} on source {source}. Message: {message}", imageId.Name,
+                        sourceName, l.Message);
+                });
+
+                if (result.IsRight)
+                {
+                    _log.LogDebug("{image} found on source {source}", imageId.Name, sourceName);
+
+                    return result;
+                }
             }
 
             return new PowershellFailure{ Message = $"could not find image {imageId.Name} on any source."};
         }
 
-        private async Task<Either<PowershellFailure, ImageInfo>> EnsureArtifacts(string path, ImageInfo imageInfo,
+        private async Task<Either<PowershellFailure, ImageInfo>> EnsureArtifacts(ImageInfo imageInfo,
             Func<string, Task<Unit>> reportProgress)
         {
             var localSource = _sourceFactory.CreateLocal();
 
-            if (imageInfo?.MetaData?.Artifacts == null || imageInfo.MetaData.Artifacts.Length == 0)
+            if (imageInfo.MetaData?.Artifacts == null || imageInfo.MetaData.Artifacts.Length == 0)
                 return new PowershellFailure
                     { Message = $"Invalid image '{imageInfo.Id.Name}': no artifacts in image" };
 
-            var artifactsFolder = Path.Combine(path, imageInfo.Id.Organization, "_a");
-            if (!Directory.Exists(artifactsFolder))
-                Directory.CreateDirectory(artifactsFolder);
-
-
             foreach (var artifact in imageInfo.MetaData.Artifacts)
             {
-                var result = await localSource.RetrieveArtifact(artifactsFolder, imageInfo, artifact, reportProgress)
+
+                var result = await localSource.RetrieveArtifact(imageInfo, artifact)
                     .ToAsync()
                     .BindLeft(l =>
-                        ProvideArtifactFromRemote(artifactsFolder, imageInfo, artifact, reportProgress).ToAsync())
-                    .Bind(artifactPath => localSource.MergeArtifact(artifact, artifactPath, imageInfo, reportProgress).ToAsync());
+                        ProvideArtifactFromRemote(imageInfo, artifact).ToAsync())
+                    .Bind(artifactInfo => localSource.CacheArtifact(artifactInfo, imageInfo).ToAsync())
+                    .Bind(artifactInfo => EnsureArtifactParts(artifactInfo, reportProgress).ToAsync())
+                    .Bind(artifactInfo => localSource.MergeArtifact(artifactInfo, imageInfo, reportProgress).ToAsync());
 
-                if (result.IsRight)
+                result.IfLeft(l =>
+                {
+                    _log.LogInformation("Failed to retrieve artifact {artifact}. Message: {message}", artifact, l.Message);
+                });
+
+                if (!result.IsRight)
                     return result.Map(_ => imageInfo);
             }
 
-            return new PowershellFailure { Message = $"could not find artifact on any source." };
+            return imageInfo;
 
         }
 
-        private async Task<Either<PowershellFailure, string>> ProvideArtifactFromRemote(string artifactsFolder, ImageInfo imageInfo,
-            string artifact, Func<string, Task<Unit>> reportProgress)
+        private async Task<Either<PowershellFailure, ArtifactInfo>> EnsureArtifactParts(ArtifactInfo artifactInfo, Func<string, Task<Unit>> reportProgress)
+        {
+            var localSource = _sourceFactory.CreateLocal();
+            var parts = (artifactInfo.MetaData?.Parts ?? Array.Empty<string>()).ToList();
+            var retries = 0;
+
+            var partsMissingLocal = new List<string>();
+            var sizeAvailableLocal = 0L;
+
+            foreach (var artifactPart in parts.ToArray())
+            {
+                var res = await localSource.RetrieveArtifactPart(artifactInfo, artifactPart, sizeAvailableLocal, artifactInfo.MetaData?.Size ?? 0, reportProgress);
+
+                res.IfRight( r =>
+                {
+                    sizeAvailableLocal += r;
+                });
+
+                res.IfLeft(l =>
+                {
+                    partsMissingLocal.Add(artifactPart);
+                });
+
+            }
+
+
+            while (partsMissingLocal.Count > 0 && retries < 5)
+            {
+                foreach (var artifactPart in partsMissingLocal.ToArray())
+                {
+                    var res = await ProvideArtifactPartFromRemote(artifactInfo, artifactPart, sizeAvailableLocal, artifactInfo.MetaData?.Size ?? 0, reportProgress);
+
+                    res.IfRight(r =>
+                    {
+                        partsMissingLocal.Remove(artifactPart);
+                        sizeAvailableLocal += r;
+                    });
+                }
+
+                if (partsMissingLocal.Count > 0)
+                {
+                    await Task.Delay(2000);
+                    retries++;
+                }
+            }
+
+            if (partsMissingLocal.Count > 0)
+            {
+                return new PowershellFailure
+                {
+                    Message =
+                        $"Failed to provide all part of artifact {artifactInfo} from sources."
+                };
+            }
+            return artifactInfo;
+        }
+
+        private async Task<Either<PowershellFailure, ArtifactInfo>> ProvideArtifactFromRemote(ImageInfo imageInfo, string artifact)
         {
 
             foreach (var sourceName in _sourceFactory.RemoteSources)
             {
                 var imageSource = _sourceFactory.CreateNew(sourceName);
-                var result = await imageSource.RetrieveArtifact(artifactsFolder, imageInfo, artifact, reportProgress);
+                var result = await imageSource.RetrieveArtifact(imageInfo, artifact);
+
+                result.IfLeft(l =>
+                {
+                    _log.LogInformation("Failed to retrieve artifact {artifact} on source {source}. Message: {message}", artifact, sourceName, l.Message);
+                });
+
                 if (result.IsRight)
                     return result;
 
             }
 
             return new PowershellFailure { Message = $"could not find artifact on any remote source." };
+
+        }
+
+
+        private async Task<Either<PowershellFailure, long>> ProvideArtifactPartFromRemote(
+            ArtifactInfo artifactInfo, string artifactPart, long availableSize, long totalSize, Func<string, Task<Unit>> reportProgress)
+        {
+
+            foreach (var sourceName in _sourceFactory.RemoteSources)
+            {
+                var imageSource = _sourceFactory.CreateNew(sourceName);
+                var result = await imageSource.RetrieveArtifactPart(artifactInfo, artifactPart, availableSize, totalSize, reportProgress);
+
+                result.IfLeft(l =>
+                {
+                    _log.LogInformation("Failed to retrieve artifact part {artifactPart} of artifact {artifact} on source {source}. Message: {message}", artifactPart, artifactInfo, sourceName, l.Message);
+                });
+
+                if (result.IsRight)
+                    return result;
+
+            }
+
+            return new PowershellFailure { Message = $"could not find artifact part on any remote source." };
 
         }
     }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/LocalFirstImageProvider.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/LocalFirstImageProvider.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Eryph.VmManagement;
+using LanguageExt;
+
+namespace Eryph.Modules.VmHostAgent.Images
+{
+    internal class LocalFirstImageProvider : IImageProvider
+    {
+        private readonly IImageSourceFactory _sourceFactory;
+
+        public LocalFirstImageProvider(IImageSourceFactory sourceFactory)
+        {
+            _sourceFactory = sourceFactory;
+        }
+
+        public Task<Either<PowershellFailure, string>> ProvideImage(string path, string imageName, Func<string, Task<Unit>> reportProgress)
+        {
+            return ImageIdentifier.Parse(imageName).MatchAsync(
+                Left: l => l,
+                RightAsync: imageId =>
+                {
+                    
+                    return ProvideImage(path, imageId, reportProgress, Array.Empty<string>())
+                        .MapAsync(i =>
+                        {
+                            if (i.Id.Name != imageName)
+                                reportProgress($"resolved image '{imageName}' as '{i.Id.Name}'");
+                            return i;
+                        })
+                        .BindAsync(imageInfo => EnsureArtifacts(path, imageInfo, reportProgress))
+                        .MapAsync(imageInfo => imageInfo.Id.Name);
+
+                }
+
+            );
+            
+        }
+
+
+        private async Task<Either<PowershellFailure, ImageInfo>> ProvideImage(string path, ImageIdentifier imageId,
+            Func<string, Task<Unit>> reportProgress, IEnumerable<string> previousRefs)
+        {
+            var imageRefs = previousRefs as string[] ?? previousRefs.ToArray();
+            if (imageRefs.Contains(imageId.Name))
+            {
+                var imageNames = string.Join(',', imageRefs, imageRefs.Append(new[] { imageId.Name }));
+                return new PowershellFailure
+                {
+                    Message =
+                        $"Detected circular reference in image aliases. Contact organization '{imageId.Organization}' to resolve invalid image references of images '{imageNames}'"
+                };
+            }
+
+            var localSource = _sourceFactory.CreateLocal();
+
+            return await localSource.ProvideImage(path, imageId, reportProgress) //found locally? (will not resolve 'latest' tag)
+                .ToAsync()
+                .BindLeft(l => ProvideImageFromRemote(path, imageId, reportProgress).ToAsync()) // fetch remote image
+                .BindLeft(l => localSource.ProvideFallbackImage(path, imageId, reportProgress).ToAsync()) //local fallback (will resolve 'latest' tag)
+                .MapLeft(l => new PowershellFailure { Message = $"could not find image '{imageId.Name}' on any source." })
+                .ToEither()
+                .BindAsync(imageInfo => localSource.CacheImage(path,imageInfo)) // cache anything received in local store
+                .BindAsync(r =>
+                    {
+                        if (!string.IsNullOrWhiteSpace(r.MetaData.Alias))
+                        {
+                            //resolve image alias
+                            return ImageIdentifier.Parse(r.MetaData.Alias)
+                                .BindAsync(aliasId => ProvideImage(path, aliasId, reportProgress,
+                                    imageRefs.Append(new[] { imageId.Name })));
+                        }
+
+                        return Prelude.RightAsync<PowershellFailure, ImageInfo>(r).ToEither();
+
+                    });
+
+
+        }
+
+
+        private async Task<Either<PowershellFailure, ImageInfo>> ProvideImageFromRemote(string path, ImageIdentifier imageId,
+            Func<string, Task<Unit>> reportProgress)
+        {
+            foreach (var sourceName in _sourceFactory.RemoteSources)
+            {
+                var imageSource = _sourceFactory.CreateNew(sourceName);
+                var result = await imageSource.ProvideImage(path, imageId, reportProgress);
+                if (result.IsRight)
+                    return result;
+
+            }
+
+            return new PowershellFailure{ Message = $"could not find image {imageId.Name} on any source."};
+        }
+
+        private async Task<Either<PowershellFailure, ImageInfo>> EnsureArtifacts(string path, ImageInfo imageInfo,
+            Func<string, Task<Unit>> reportProgress)
+        {
+            var localSource = _sourceFactory.CreateLocal();
+
+            if (imageInfo?.MetaData?.Artifacts == null || imageInfo.MetaData.Artifacts.Length == 0)
+                return new PowershellFailure
+                    { Message = $"Invalid image '{imageInfo.Id.Name}': no artifacts in image" };
+
+            var artifactsFolder = Path.Combine(path, imageInfo.Id.Organization, "_a");
+            if (!Directory.Exists(artifactsFolder))
+                Directory.CreateDirectory(artifactsFolder);
+
+
+            foreach (var artifact in imageInfo.MetaData.Artifacts)
+            {
+                var result = await localSource.RetrieveArtifact(artifactsFolder, imageInfo, artifact, reportProgress)
+                    .ToAsync()
+                    .BindLeft(l =>
+                        ProvideArtifactFromRemote(artifactsFolder, imageInfo, artifact, reportProgress).ToAsync())
+                    .Bind(artifactPath => localSource.MergeArtifact(artifact, artifactPath, imageInfo, reportProgress).ToAsync());
+
+                if (result.IsRight)
+                    return result.Map(_ => imageInfo);
+            }
+
+            return new PowershellFailure { Message = $"could not find artifact on any source." };
+
+        }
+
+        private async Task<Either<PowershellFailure, string>> ProvideArtifactFromRemote(string artifactsFolder, ImageInfo imageInfo,
+            string artifact, Func<string, Task<Unit>> reportProgress)
+        {
+
+            foreach (var sourceName in _sourceFactory.RemoteSources)
+            {
+                var imageSource = _sourceFactory.CreateNew(sourceName);
+                var result = await imageSource.RetrieveArtifact(artifactsFolder, imageInfo, artifact, reportProgress);
+                if (result.IsRight)
+                    return result;
+
+            }
+
+            return new PowershellFailure { Message = $"could not find artifact on any remote source." };
+
+        }
+    }
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/LocalFirstImageProvider.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/LocalFirstImageProvider.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Eryph.VmManagement;
 using LanguageExt;
@@ -19,21 +21,25 @@ namespace Eryph.Modules.VmHostAgent.Images
             _log = log;
         }
 
-        public Task<Either<PowershellFailure, string>> ProvideImage(string path, string imageName, Func<string, Task<Unit>> reportProgress)
+        public Task<Either<PowershellFailure, string>> ProvideImage(string imageName, Func<string, Task<Unit>> reportProgress, CancellationToken cancel)
         {
+            var hostSettings = HostSettingsBuilder.GetHostSettings();
+
+            var path = Path.Combine(hostSettings.DefaultVirtualHardDiskPath, "Images");
+
             return ImageIdentifier.Parse(imageName).MatchAsync(
                 Left: l => l,
                 RightAsync: imageId =>
                 {
                     
-                    return ProvideImage(path, imageId, reportProgress, Array.Empty<string>())
+                    return ProvideImage(path, imageId, reportProgress, Array.Empty<string>(), cancel)
                         .MapAsync(i =>
                         {
                             if (i.Id.Name != imageName)
                                 reportProgress($"Resolved image '{imageName}' as '{i.Id.Name}'");
                             return i;
                         })
-                        .BindAsync(imageInfo => EnsureArtifacts(imageInfo, reportProgress))
+                        .BindAsync(imageInfo => EnsureArtifacts(imageInfo, reportProgress, cancel))
                         .MapAsync(imageInfo => imageInfo.Id.Name);
 
                 }
@@ -44,7 +50,7 @@ namespace Eryph.Modules.VmHostAgent.Images
 
 
         private async Task<Either<PowershellFailure, ImageInfo>> ProvideImage(string path, ImageIdentifier imageId,
-            Func<string, Task<Unit>> reportProgress, IEnumerable<string> previousRefs)
+            Func<string, Task<Unit>> reportProgress, IEnumerable<string> previousRefs, CancellationToken cancel)
         {
             var imageRefs = previousRefs as string[] ?? previousRefs.ToArray();
             if (imageRefs.Contains(imageId.Name))
@@ -59,18 +65,18 @@ namespace Eryph.Modules.VmHostAgent.Images
 
             var localSource = _sourceFactory.CreateLocal();
 
-            return await localSource.ProvideImage(path, imageId).WriteTrace() //found locally? (will not resolve 'latest' tag)
+            return await localSource.ProvideImage(path, imageId, cancel) //found locally? (will not resolve 'latest' tag)
                 .ToAsync()
                 .BindLeft(l =>
                 {
                     _log.LogDebug("Failed to find image on local source. Local result: {message}", l.Message);
 
-                    return ProvideImageFromRemote(path, imageId).ToAsync();
+                    return ProvideImageFromRemote(path, imageId, cancel).ToAsync();
                 }) // fetch remote image
                 .BindLeft(l =>
                 {
                     _log.LogDebug("Failed to find image on remote sources. Remote sources result: {message}", l.Message);
-                    return localSource.ProvideFallbackImage(path, imageId).ToAsync();
+                    return localSource.ProvideFallbackImage(path, imageId, cancel).ToAsync();
                 }) //local fallback (will resolve 'latest' tag)
                 .MapLeft(l =>
                 {
@@ -79,7 +85,7 @@ namespace Eryph.Modules.VmHostAgent.Images
                             { Message = $"could not find image '{imageId.Name}' on any source." };
                 })
                 .ToEither()
-                .BindAsync(imageInfo => localSource.CacheImage(path,imageInfo)).WriteTrace() // cache anything received in local store
+                .BindAsync(imageInfo => localSource.CacheImage(path,imageInfo, cancel)) // cache anything received in local store
                 .BindAsync(async r =>
                     {
                         if (!string.IsNullOrWhiteSpace(r.MetaData.Reference))
@@ -88,7 +94,7 @@ namespace Eryph.Modules.VmHostAgent.Images
                             //resolve image reference
                             return await ImageIdentifier.Parse(r.MetaData.Reference)
                                 .BindAsync(aliasId => ProvideImage(path, aliasId, reportProgress,
-                                    imageRefs.Append(new[] { imageId.Name }))).WriteTrace();
+                                    imageRefs.Append(new[] { imageId.Name }), cancel));
                         }
 
                         return await Prelude.RightAsync<PowershellFailure, ImageInfo>(r).ToEither();
@@ -99,13 +105,15 @@ namespace Eryph.Modules.VmHostAgent.Images
         }
 
 
-        private async Task<Either<PowershellFailure, ImageInfo>> ProvideImageFromRemote(string path, ImageIdentifier imageId)
+        private async Task<Either<PowershellFailure, ImageInfo>> ProvideImageFromRemote(string path, ImageIdentifier imageId, CancellationToken cancel)
         {
             _log.LogDebug("Trying to find image {image} on remote sources", imageId.Name);
             foreach (var sourceName in _sourceFactory.RemoteSources)
             {
+                cancel.ThrowIfCancellationRequested();
+
                 var imageSource = _sourceFactory.CreateNew(sourceName);
-                var result = await imageSource.ProvideImage(path, imageId);
+                var result = await imageSource.ProvideImage(path, imageId, cancel);
 
                 result.IfLeft(l =>
                 {
@@ -125,7 +133,7 @@ namespace Eryph.Modules.VmHostAgent.Images
         }
 
         private async Task<Either<PowershellFailure, ImageInfo>> EnsureArtifacts(ImageInfo imageInfo,
-            Func<string, Task<Unit>> reportProgress)
+            Func<string, Task<Unit>> reportProgress, CancellationToken cancel)
         {
             var localSource = _sourceFactory.CreateLocal();
 
@@ -135,14 +143,15 @@ namespace Eryph.Modules.VmHostAgent.Images
 
             foreach (var artifact in imageInfo.MetaData.Artifacts)
             {
+                cancel.ThrowIfCancellationRequested();
 
-                var result = await localSource.RetrieveArtifact(imageInfo, artifact)
+                var result = await localSource.RetrieveArtifact(imageInfo, artifact, cancel)
                     .ToAsync()
                     .BindLeft(l =>
-                        ProvideArtifactFromRemote(imageInfo, artifact).ToAsync())
-                    .Bind(artifactInfo => localSource.CacheArtifact(artifactInfo, imageInfo).ToAsync())
-                    .Bind(artifactInfo => EnsureArtifactParts(artifactInfo, reportProgress).ToAsync())
-                    .Bind(artifactInfo => localSource.MergeArtifact(artifactInfo, imageInfo, reportProgress).ToAsync());
+                        ProvideArtifactFromRemote(imageInfo, artifact, cancel).ToAsync())
+                    .Bind(artifactInfo => localSource.CacheArtifact(artifactInfo, imageInfo, cancel).ToAsync())
+                    .Bind(artifactInfo => EnsureArtifactParts(artifactInfo, reportProgress, cancel).ToAsync())
+                    .Bind(artifactInfo => localSource.MergeArtifact(artifactInfo, imageInfo, reportProgress, cancel).ToAsync());
 
                 result.IfLeft(l =>
                 {
@@ -157,7 +166,7 @@ namespace Eryph.Modules.VmHostAgent.Images
 
         }
 
-        private async Task<Either<PowershellFailure, ArtifactInfo>> EnsureArtifactParts(ArtifactInfo artifactInfo, Func<string, Task<Unit>> reportProgress)
+        private async Task<Either<PowershellFailure, ArtifactInfo>> EnsureArtifactParts(ArtifactInfo artifactInfo, Func<string, Task<Unit>> reportProgress, CancellationToken cancel)
         {
             var localSource = _sourceFactory.CreateLocal();
             var parts = (artifactInfo.MetaData?.Parts ?? Array.Empty<string>()).ToList();
@@ -168,7 +177,9 @@ namespace Eryph.Modules.VmHostAgent.Images
 
             foreach (var artifactPart in parts.ToArray())
             {
-                var res = await localSource.RetrieveArtifactPart(artifactInfo, artifactPart, sizeAvailableLocal, artifactInfo.MetaData?.Size ?? 0, reportProgress);
+                cancel.ThrowIfCancellationRequested();
+
+                var res = await localSource.RetrieveArtifactPart(artifactInfo, artifactPart, sizeAvailableLocal, artifactInfo.MetaData?.Size ?? 0, reportProgress, cancel);
 
                 res.IfRight( r =>
                 {
@@ -185,9 +196,13 @@ namespace Eryph.Modules.VmHostAgent.Images
 
             while (partsMissingLocal.Count > 0 && retries < 5)
             {
+                cancel.ThrowIfCancellationRequested();
+
                 foreach (var artifactPart in partsMissingLocal.ToArray())
                 {
-                    var res = await ProvideArtifactPartFromRemote(artifactInfo, artifactPart, sizeAvailableLocal, artifactInfo.MetaData?.Size ?? 0, reportProgress);
+                    cancel.ThrowIfCancellationRequested();
+
+                    var res = await ProvideArtifactPartFromRemote(artifactInfo, artifactPart, sizeAvailableLocal, artifactInfo.MetaData?.Size ?? 0, reportProgress, cancel);
 
                     res.IfRight(r =>
                     {
@@ -214,13 +229,13 @@ namespace Eryph.Modules.VmHostAgent.Images
             return artifactInfo;
         }
 
-        private async Task<Either<PowershellFailure, ArtifactInfo>> ProvideArtifactFromRemote(ImageInfo imageInfo, string artifact)
+        private async Task<Either<PowershellFailure, ArtifactInfo>> ProvideArtifactFromRemote(ImageInfo imageInfo, string artifact, CancellationToken cancel)
         {
 
             foreach (var sourceName in _sourceFactory.RemoteSources)
             {
                 var imageSource = _sourceFactory.CreateNew(sourceName);
-                var result = await imageSource.RetrieveArtifact(imageInfo, artifact);
+                var result = await imageSource.RetrieveArtifact(imageInfo, artifact, cancel);
 
                 result.IfLeft(l =>
                 {
@@ -238,13 +253,13 @@ namespace Eryph.Modules.VmHostAgent.Images
 
 
         private async Task<Either<PowershellFailure, long>> ProvideArtifactPartFromRemote(
-            ArtifactInfo artifactInfo, string artifactPart, long availableSize, long totalSize, Func<string, Task<Unit>> reportProgress)
+            ArtifactInfo artifactInfo, string artifactPart, long availableSize, long totalSize, Func<string, Task<Unit>> reportProgress, CancellationToken cancel)
         {
 
             foreach (var sourceName in _sourceFactory.RemoteSources)
             {
                 var imageSource = _sourceFactory.CreateNew(sourceName);
-                var result = await imageSource.RetrieveArtifactPart(artifactInfo, artifactPart, availableSize, totalSize, reportProgress);
+                var result = await imageSource.RetrieveArtifactPart(artifactInfo, artifactPart, availableSize, totalSize, reportProgress, cancel);
 
                 result.IfLeft(l =>
                 {

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/LocalImageSource.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/LocalImageSource.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Eryph.VmManagement;
+using LanguageExt;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+internal class LocalImageSource : ImageSourceBase, ILocalImageSource
+{
+    private bool _keepArtifacts = true;
+
+    public LocalImageSource()
+    {
+        
+    }
+
+    private static string BuildImagePath(ImageIdentifier imageIdentifier, string basePath, bool shouldExists = false)
+    {
+        var orgDirectory = Path.Combine(basePath, imageIdentifier.Organization);
+        if (shouldExists && !Directory.Exists(orgDirectory)) Directory.CreateDirectory(orgDirectory);
+        var imageBaseDirectory = Path.Combine(orgDirectory, imageIdentifier.ImageId);
+        if (shouldExists && !Directory.Exists(imageBaseDirectory)) Directory.CreateDirectory(imageBaseDirectory);
+        var imageTagDirectory = Path.Combine(imageBaseDirectory, imageIdentifier.Tag);
+        if (shouldExists && !Directory.Exists(imageTagDirectory)) Directory.CreateDirectory(imageTagDirectory);
+
+        return imageTagDirectory;
+    }
+
+    private static async Task<ArtifactInfo> ReadArtifactInfo(ImageInfo imageInfo)
+    {
+        if (!File.Exists(Path.Combine(imageInfo.LocalPath, "artifacts.json")))
+            return new ArtifactInfo{MergedArtifacts = Array.Empty<string>()};
+
+        await using var stream = File.OpenRead(Path.Combine(imageInfo.LocalPath, "artifacts.json"));
+        var artifacts = await JsonSerializer.DeserializeAsync<ArtifactInfo>(stream);
+
+        if(artifacts == null || artifacts.MergedArtifacts == null)
+            return new ArtifactInfo { MergedArtifacts = Array.Empty<string>() };
+
+        return artifacts;
+    }
+
+    public async Task<Either<PowershellFailure, string>> RetrieveArtifact(string artifactsFolder, ImageInfo imageInfo, string artifact, Func<string, Task<Unit>> reportProgress)
+    {
+
+        var artifactsInfo = await ReadArtifactInfo(imageInfo);
+        if (artifactsInfo.MergedArtifacts.Contains(artifact))
+            return "merged";
+
+        return await ParseArtifactName(artifact).BindAsync(async artifactId =>
+        {
+
+            var cacheArtifactFile = Path.Combine(artifactsFolder, $"{artifactId[..12]}.zip");
+
+            if(!File.Exists(cacheArtifactFile))
+                return new PowershellFailure { Message = $"artifact '{imageInfo.Id.Organization}/{artifactId[..12]}' not available on local store" };
+
+
+            return await Prelude.TryAsync(async () =>
+                {
+                    var hashAlg = SHA256.Create();
+
+                    await reportProgress(
+                        $"Verifying integrity artifact '{imageInfo.Id.Organization}/{artifactId[..12]}'. This could take a while...");
+
+                    await using (var dataStream = File.OpenRead(cacheArtifactFile))
+                    {
+                        await hashAlg.ComputeHashAsync(dataStream);
+                    }
+                    
+                    var hashString = BitConverter.ToString(hashAlg.Hash!).Replace("-", string.Empty).ToLowerInvariant();
+
+                    if (hashString == artifactId)
+                        return await Prelude.RightAsync<PowershellFailure, string>(cacheArtifactFile);
+
+                    if(!_keepArtifacts)
+                        File.Delete(cacheArtifactFile);
+
+                    return new PowershellFailure
+                    {
+                        Message =
+                            $"Failed to verify hash of artifact '{imageInfo.Id.Organization}/{artifactId[..12]}'"
+                    };
+
+
+                }).ToEither(ex => new PowershellFailure { Message = ex.Message })
+                .Bind(e => e.ToAsync())
+                .ToEither();
+
+        });
+
+    }
+
+    public string SourceName { get; set; }
+
+
+    public async Task<Either<PowershellFailure, Unit>> MergeArtifact(string artifact, string artifactPath, ImageInfo imageInfo, Func<string, Task<Unit>> reportProgress)
+    {
+        var artifactsInfo = await ReadArtifactInfo(imageInfo);
+
+        if (artifactsInfo.MergedArtifacts.Contains(artifact))
+            return Unit.Default;
+
+
+        return await Prelude.TryAsync(() =>
+            {
+                return ParseArtifactName(artifact).MapAsync(async artifactId =>
+                {
+                    await using var artifactsInfoStream = File.Open(Path.Combine(imageInfo.LocalPath, "artifacts.json"),
+                        FileMode.Create);
+                    await reportProgress(
+                        $"Extracting artifact '{imageInfo.Id.Organization}/{artifactId[..12]}' to image '{imageInfo.Id.Name}'...");
+
+                    ZipFile.ExtractToDirectory(artifactPath, imageInfo.LocalPath);
+
+                    artifactsInfo.MergedArtifacts = artifactsInfo.MergedArtifacts.Append(new[] { artifact }).ToArray();
+                    await JsonSerializer.SerializeAsync(artifactsInfoStream, artifactsInfo);
+
+                    if(!_keepArtifacts)
+                        File.Delete(artifactPath);
+
+                    return Unit.Default;
+                });
+            })
+
+            .ToEither(ex => new PowershellFailure { Message = ex.Message })
+            .Bind(e => e.ToAsync())
+            .ToEither();
+
+
+
+    }
+
+    public Task<Either<PowershellFailure, ImageInfo>> ProvideImage(string path, ImageIdentifier imageIdentifier, Func<string, Task<Unit>> reportProgress)
+    {
+        return ProvideImage(path, imageIdentifier, reportProgress, false);
+    }
+
+
+    public Task<Either<PowershellFailure, ImageInfo>> ProvideFallbackImage(string path, ImageIdentifier imageIdentifier, Func<string, Task<Unit>> reportProgress)
+    {
+        return ProvideImage(path, imageIdentifier, reportProgress, true);
+    }
+
+
+    private async Task<Either<PowershellFailure, ImageInfo>> ProvideImage(string path, ImageIdentifier imageIdentifier,
+        Func<string, Task<Unit>> reportProgress, bool fallbackMode)
+    {
+        if (!fallbackMode && imageIdentifier.Tag == "latest")
+            return new PowershellFailure { Message = "latest image version will be look up first on remote sources." };
+
+        return await Prelude.TryAsync(async () =>
+            {
+                var imagePath = BuildImagePath(imageIdentifier, path);
+                if (!File.Exists(Path.Combine(imagePath, "manifest.json")))
+                    return await Prelude.LeftAsync<PowershellFailure, ImageInfo>(new PowershellFailure
+                        { Message = $"Image '{imageIdentifier.Name}' not found in local store." }).ToEither();
+
+                await using var manifestStream = File.OpenRead(Path.Combine(imagePath, "manifest.json"));
+                var manifest = await JsonSerializer.DeserializeAsync<ManifestData>(manifestStream);
+
+                return await Prelude
+                    .RightAsync<PowershellFailure, ImageInfo>(new ImageInfo(imageIdentifier, imagePath, manifest))
+                    .ToEither();
+
+            })
+            .ToEither(ex => new PowershellFailure { Message = ex.Message })
+            .Bind(e => e.ToAsync())
+            .ToEither();
+
+    }
+
+    public Task<Either<PowershellFailure, ImageInfo>> CacheImage(string path, ImageInfo imageInfo)
+    {
+        return Prelude.TryAsync(async () =>
+            {
+                var imagePath = BuildImagePath(imageInfo.Id, path, true);
+
+                await using var manifestStream = File.Create(Path.Combine(imagePath, "manifest.json"));
+                await JsonSerializer.SerializeAsync(manifestStream, imageInfo.MetaData);
+                return new ImageInfo(imageInfo.Id, imagePath, imageInfo.MetaData);
+
+            }).ToEither(ex => new PowershellFailure{Message = ex.Message})
+            .ToEither();
+
+        
+    }
+
+    private class ArtifactInfo
+    {
+        public string[] MergedArtifacts { get; set; }
+    }
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/MultiStream.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/MultiStream.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+internal class MultiStream : Stream
+{
+    private readonly Stream[] _streams;
+    private long _position;
+    private int _currentStreamIndex = 0;
+    private long _length = 0;
+
+    public MultiStream(IEnumerable<Stream> streams)
+    {
+        _streams = streams.ToArray();
+
+        foreach (var stream in _streams)
+        {
+            _length += stream.Length;
+        }
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        switch (origin)
+        {
+            case SeekOrigin.Begin:
+                _currentStreamIndex = 0;
+                _position = 0;
+                _streams[_currentStreamIndex].Seek(0, SeekOrigin.Begin);
+                break;
+            case SeekOrigin.Current:
+                break;
+            case SeekOrigin.End:
+                _currentStreamIndex = _streams.Length - 1;
+                _streams[_currentStreamIndex].Seek(0, SeekOrigin.End);
+
+                _position = _length;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(origin), origin, null);
+        }
+
+        var offsetLeft = offset;
+        var seekBack = offsetLeft < 0;
+
+        if (seekBack)
+        {
+            while (offsetLeft < 0)
+            {
+                var currentStream = _streams[_currentStreamIndex];
+                if (currentStream.Length < (offsetLeft)*-1)
+                {
+                    offsetLeft += currentStream.Length;
+                    _position -= currentStream.Length;
+                    _currentStreamIndex--;
+                    _streams[_currentStreamIndex].Seek(0, SeekOrigin.End);
+                    continue;
+                }
+
+                currentStream.Seek(offsetLeft, SeekOrigin.Current);
+                _position += offsetLeft;
+                offsetLeft = 0;
+
+            }
+        }
+        else
+        {
+            while (offsetLeft > 0)
+            {
+                var currentStream = _streams[_currentStreamIndex];
+                if (currentStream.Length < offsetLeft)
+                {
+                    offsetLeft -= currentStream.Length;
+                    _position += currentStream.Length;
+                    _currentStreamIndex++;
+                    _streams[_currentStreamIndex].Seek(0, SeekOrigin.Begin);
+                    continue;
+                }
+
+                currentStream.Seek(offsetLeft, SeekOrigin.Current);
+                _position += offsetLeft;
+                offsetLeft = 0;
+
+            }
+        }
+
+        return _position;
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Flush()
+    {
+        
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var result = 0;
+        var position = offset;
+
+        while (count > 0)
+        {
+            var currentStream = _streams[_currentStreamIndex];
+            var bytesRead = currentStream.Read(buffer, position, count);
+            result += bytesRead;
+            position += bytesRead;
+            _position += bytesRead;
+
+            if (bytesRead <= count)
+                count -= bytesRead;
+
+            if (count <= 0) continue;
+
+
+            if (_currentStreamIndex == _streams.Length-1)
+                break;
+
+            _currentStreamIndex++;
+            _streams[_currentStreamIndex].Seek(0, SeekOrigin.Begin);
+        }
+
+        return result;
+    }
+
+
+    public override async System.Threading.Tasks.Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        var result = 0;
+        var position = offset;
+
+        while (count > 0)
+        {
+            var currentStream = _streams[_currentStreamIndex];
+
+            var bytesRead = await currentStream.ReadAsync(buffer, position, count, cancellationToken);
+            result += bytesRead;
+            position += bytesRead;
+            _position += bytesRead;
+
+            if (bytesRead <= count)
+                count -= bytesRead;
+
+            if (count <= 0) continue;
+
+            if (_currentStreamIndex == _streams.Length - 1)
+                break;
+
+            _currentStreamIndex++;
+            _streams[_currentStreamIndex].Seek(0, SeekOrigin.Begin);
+
+        }
+
+        return result;
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new InvalidOperationException();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        foreach (var stream in _streams)
+        {
+            stream.Dispose();
+        }
+
+    }
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => true;
+
+    public override bool CanWrite => false;
+
+    public override long Length => _length;
+
+    public override long Position
+    {
+        get => _position;
+        set => Seek(value, SeekOrigin.Begin);
+    }
+
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Images/RepositoryImageSource.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Images/RepositoryImageSource.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.Intrinsics.Arm;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Eryph.VmManagement;
+using LanguageExt;
+
+namespace Eryph.Modules.VmHostAgent.Images;
+
+internal class RepositoryImageSource : ImageSourceBase, IImageSource
+{
+    public string SourceName { get; set; }
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public RepositoryImageSource(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<Either<PowershellFailure, ImageInfo>> ProvideImage(string path, ImageIdentifier imageIdentifier, Func<string, Task<Unit>> reportProgress)
+    {
+        var manifestUrl = $"{imageIdentifier.Organization}/{imageIdentifier.ImageId}/{imageIdentifier.Tag}/manifest.json";
+        using var httpClient = _httpClientFactory.CreateClient(SourceName);
+
+        var response = await httpClient.GetAsync(manifestUrl);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+            return new PowershellFailure { Message = $"Could not find image '{imageIdentifier.Name}' on {SourceName}." };
+
+        if (response.StatusCode != HttpStatusCode.OK)
+        {
+            return new PowershellFailure { Message = $"Failed to connect to {SourceName}. Received a {response.StatusCode} HTTP response." };
+        }
+
+        var contentLength = response.Content.Headers.ContentLength.GetValueOrDefault(0);
+        if (contentLength == 0)
+            return new PowershellFailure { Message = $"Could not find image '{imageIdentifier.Name}' on {SourceName}." };
+
+        var manifest = ReadManifest(await response.Content.ReadAsStringAsync());
+
+        if (manifest?.Image != imageIdentifier.Name)
+        {
+            return new PowershellFailure { Message = $"Invalid manifest for image '{imageIdentifier.Name}'." };
+        }
+
+        return new ImageInfo(imageIdentifier, "", manifest);
+    }
+
+    public Task<Either<PowershellFailure, string>> RetrieveArtifact(string artifactsFolder, ImageInfo imageInfo, string artifact, Func<string, Task<Unit>> reportProgress)
+    {
+
+        return ParseArtifactName(artifact).BindAsync(async artifactId =>
+        {
+
+            var artifactUrl = $"{imageInfo.Id.Organization}/_a/sha256/{artifactId[..2]}/{artifactId}.zip";
+
+            using var httpClient = _httpClientFactory.CreateClient(SourceName);
+            var response = await httpClient.GetAsync(artifactUrl, HttpCompletionOption.ResponseHeadersRead);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+                return new PowershellFailure
+                    { Message = $"Could not find artifact '{imageInfo.Id.Organization}/{artifactId[..12]}' on {SourceName}." };
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                return new PowershellFailure
+                    { Message = $"Failed to connect to eryph hub. Received a {response.StatusCode} HTTP response." };
+            }
+
+            var contentLength = response.Content.Headers.ContentLength.GetValueOrDefault(0);
+            if (contentLength == 0)
+                return new PowershellFailure
+                    { Message = $"Could not find artifact '{imageInfo.Id.Organization}/{artifact[..12]}' on {SourceName}." };
+
+            var artifactFile = Path.Combine(artifactsFolder, $"{artifactId[..12]}.zip");
+
+            await using var responseStream = await response.Content.ReadAsStreamAsync();
+            var hashAlg = SHA256.Create();
+            // ReSharper disable once ConvertToUsingDeclaration
+            await using (var tempFileStream = new FileStream(artifactFile, FileMode.Create, FileAccess.Write))
+            {
+
+                var cryptoStream = new CryptoStream(responseStream, hashAlg, CryptoStreamMode.Read);
+                await CopyToAsync(cryptoStream, tempFileStream, reportProgress,
+                    $"artifact '{imageInfo.Id.Organization}/{artifactId[..12]}'",
+                    contentLength);
+
+            }
+
+            var hashString = BitConverter.ToString(hashAlg.Hash!).Replace("-", string.Empty).ToLowerInvariant();
+
+            if (hashString != artifactId)
+            {
+                File.Delete(artifactFile);
+                return new PowershellFailure
+                    { Message = $"Failed to verify hash of artifact '{imageInfo.Id.Organization}/{artifactId[..12]}'" };
+            }
+
+            return await Prelude.RightAsync<PowershellFailure, string>(artifactFile).ToEither();
+        });
+    }
+
+
+    private static async Task CopyToAsync(Stream source, Stream destination, Func<string, Task<Unit>> reportProgress, string name, long contentLength, int bufferSize = 65536)
+    {
+        var buffer = new byte[bufferSize];
+        int bytesRead;
+        long totalRead = 0;
+        var totalMb = contentLength / 1024d / 1024d;
+        var lastReport = DateTime.Now;
+
+        while ((bytesRead = await source.ReadAsync(buffer, 0, buffer.Length)) > 0)
+        {
+            await destination.WriteAsync(buffer, 0, bytesRead);
+            totalRead += bytesRead;
+
+            var timeSinceLastReport = DateTime.Now - lastReport;
+            if(timeSinceLastReport.TotalSeconds <= 10 || totalMb == 0)
+                continue;
+
+            var totalReadMb = Math.Round(totalRead / 1024d / 1024d, 0);
+            var percent = totalReadMb / totalMb;
+
+
+            await reportProgress($"pulling {name} ({totalReadMb:N0} MB / {totalMb:N0} MB) => {percent:P0} completed");
+            lastReport = DateTime.Now;
+
+        }
+    }
+
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/PrepareVirtualMachineImageCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/PrepareVirtualMachineImageCommandHandler.cs
@@ -1,18 +1,13 @@
 ﻿using System;
-using System.IO;
 using System.Threading.Tasks;
 using Eryph.Messages;
 using Eryph.Messages.Operations;
 using Eryph.Messages.Operations.Events;
 using Eryph.Messages.Resources.Images.Commands;
-using Eryph.Modules.VmHostAgent.Images;
-using Eryph.VmManagement;
 using JetBrains.Annotations;
-using LanguageExt;
 using Microsoft.Extensions.Logging;
 using Rebus.Bus;
 using Rebus.Handlers;
-using Rebus.Transport;
 
 namespace Eryph.Modules.VmHostAgent
 {
@@ -23,20 +18,16 @@ namespace Eryph.Modules.VmHostAgent
     {
         private readonly IBus _bus;
         private readonly ILogger _log;
-        private readonly IImageProvider _imageProvider;
-        public PrepareVirtualMachineImageCommandHandler(IBus bus, ILogger log, IImageProvider imageProvider)
+        private readonly IImageRequestDispatcher _imageRequestDispatcher;
+        public PrepareVirtualMachineImageCommandHandler(IBus bus, ILogger log, IImageRequestDispatcher imageRequestDispatcher)
         {
             _bus = bus;
             _log = log;
-            _imageProvider = imageProvider;
+            _imageRequestDispatcher = imageRequestDispatcher;
         }
 
         public async Task Handle(OperationTask<PrepareVirtualMachineImageCommand> message)
         {
-            Task<Unit> ReportProgress(string progressMessage)
-            {
-                return ProgressMessage(message.OperationId, message.TaskId, progressMessage);
-            }
 
             try
             {
@@ -47,20 +38,8 @@ namespace Eryph.Modules.VmHostAgent
                     return;
                 }
 
-                var hostSettings = HostSettingsBuilder.GetHostSettings();
-                var imageRootPath = Path.Combine(hostSettings.DefaultVirtualHardDiskPath, "Images");
+                _imageRequestDispatcher.NewImageRequestTask(message.OperationId, message.TaskId, message.Command.Image);
 
-                await _imageProvider.ProvideImage(imageRootPath, message.Command.Image, ReportProgress)
-                    .WriteTrace()
-                    .ToAsync()
-                    .MatchAsync(r => 
-                        _bus.Publish(OperationTaskStatusEvent.Completed(message.OperationId, message.TaskId, r)), 
-                        l=>
-                        {
-                            _log.LogInformation("Command '{command}' failed. Message: {message}", nameof(PrepareVirtualMachineImageCommand), l.Message);
-                            return _bus.Publish(OperationTaskStatusEvent.Failed(message.OperationId, message.TaskId,
-                                new ErrorData { ErrorMessage = l.Message }));
-                        });
 
             }
             catch (Exception ex)
@@ -70,26 +49,6 @@ namespace Eryph.Modules.VmHostAgent
                     message.TaskId,
                     new ErrorData {ErrorMessage = ex.Message}));
             }
-        }
-
-        protected async Task<Unit> ProgressMessage(Guid operationId, Guid taskId, string message)
-        {
-            using (var scope = new RebusTransactionScope())
-            {
-                await _bus.Publish(new OperationTaskProgressEvent
-                {
-                    Id = Guid.NewGuid(),
-                    OperationId = operationId,
-                    TaskId = taskId,
-                    Message = message,
-                    Timestamp = DateTimeOffset.UtcNow
-                }).ConfigureAwait(false);
-
-                // commit it like this
-                await scope.CompleteAsync().ConfigureAwait(false);
-            }
-
-            return Unit.Default;
         }
     }
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/PrivateIdentifier.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/PrivateIdentifier.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace Eryph.Modules.VmHostAgent;
+
+public class PrivateIdentifier
+{
+    [JsonProperty("_pi")]
+    public PrivateIdentifierValue Value { get; set; }
+
+
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/PrivateIdentifierValue.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/PrivateIdentifierValue.cs
@@ -1,0 +1,8 @@
+﻿namespace Eryph.Modules.VmHostAgent;
+
+public class PrivateIdentifierValue
+{
+    public object Value { get; set; }
+    public bool Critical { get; set; }
+
+}

--- a/src/modules/src/Eryph.Modules.VmHostAgent/VmHostAgentModule.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/VmHostAgentModule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using Dbosoft.Hosuto.HostedServices;
+using Eryph.Core;
 using Eryph.Messages;
 using Eryph.ModuleCore;
 using Eryph.Modules.VmHostAgent.Images;
@@ -49,6 +50,8 @@ namespace Eryph.Modules.VmHostAgent
 
         public void ConfigureContainer(IServiceProvider serviceProvider, Container container)
         {
+            container.RegisterSingleton<IFileSystemService, FileSystemService>();
+
 
             container.Register<StartBusModuleHandler>();
             container.RegisterSingleton<ITracer, Tracer>();
@@ -97,6 +100,10 @@ namespace Eryph.Modules.VmHostAgent
 
             return HttpPolicyExtensions
                 .HandleTransientHttpError()
+                .Or<HttpRequestException>(ex =>
+                {
+                    return true;
+                })
                 .WaitAndRetryAsync(6, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2,
                     retryAttempt)));
         }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/VmHostAgentModule.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/VmHostAgentModule.cs
@@ -33,7 +33,8 @@ namespace Eryph.Modules.VmHostAgent
         {
             services.AddHttpClient("eryph-hub", cfg =>
             {
-                cfg.BaseAddress = new Uri("https://eryph-images-staging.dbosoft.eu/file/eryph-images-staging/");
+                //cfg.BaseAddress = new Uri("https://eryph-images-staging.dbosoft.eu/file/eryph-images-staging/");
+                cfg.BaseAddress = new Uri("https://eryph-staging-b2.b-cdn.net");
             })
                 .SetHandlerLifetime(TimeSpan.FromMinutes(5))  //Set lifetime to five minutes
                 .AddPolicyHandler(GetRetryPolicy());
@@ -45,6 +46,7 @@ namespace Eryph.Modules.VmHostAgent
         public void AddSimpleInjector(SimpleInjectorAddOptions options)
         {
             options.AddHostedService<WmiWatcherModuleService>();
+            options.AddHostedService<ImageRequestWatcherService>();
             options.AddLogging();
         }
 
@@ -66,7 +68,9 @@ namespace Eryph.Modules.VmHostAgent
             imageSourceFactory.Register<LocalImageSource>(ImagesSources.Local);
             imageSourceFactory.Register<RepositoryImageSource>(ImagesSources.EryphHub);
             container.RegisterInstance<IImageSourceFactory>(imageSourceFactory);
-            container.Register<IImageProvider, LocalFirstImageProvider>();
+            container.RegisterSingleton<IImageProvider, LocalFirstImageProvider>();
+            container.RegisterSingleton<IImageRequestDispatcher, ImageRequestRegistry>();
+            container.RegisterSingleton<IImageRequestBackgroundQueue, ImageBackgroundTaskQueue>();
 
 
             container.Collection.Register(typeof(IHandleMessages<>), typeof(VmHostAgentModule).Assembly);


### PR DESCRIPTION
Added image local and remote sources support. Solves a large part of #10. 

- images can now be packaged from a exported virtual machine
- added feature to download images from remote repositories and to cache them locally. 

## short image spec
- a VM image is has a owner org, a identifier and a tag
- it consists either of artifacts or a reference to another image

## artifacts
- artifacts are identified by sha256 hashes of their manifest
- artifacts could contain a directory structure or a single file (like a vhd)
- artifacts for directories are zip/deflate compressed, single file artifacts are xz/lzma compressed
- artifacts are splitted into chunks (128 GB currently) 
- each chunk is verified by its hash (sha1 currently). 

