### PR TITLE
winsrv-2016 issue - adapters of switches not found

### DIFF
--- a/src/apps/src/Eryph-zero/ConsoleRuntime.cs
+++ b/src/apps/src/Eryph-zero/ConsoleRuntime.cs
@@ -30,12 +30,13 @@ public readonly struct ConsoleRuntime :
     public ConsoleRuntime(
         ILoggerFactory loggerFactory,
         IPowershellEngine engine,
+        ISysEnvironment sysEnv,
         CancellationTokenSource cancellationTokenSource)
     {
         _loggerFactory = loggerFactory;
         _engine = engine;
         CancellationTokenSource = cancellationTokenSource;
-        _sysEnv = new SystemEnvironment(loggerFactory);
+        _sysEnv = sysEnv;
     }
 
     public Eff<ConsoleRuntime, IPowershellEngine> Powershell =>
@@ -48,7 +49,7 @@ public readonly struct ConsoleRuntime :
         SuccessEff<IHostNetworkCommands<ConsoleRuntime>>(
             new HostNetworkCommands<ConsoleRuntime>());
 
-    public ConsoleRuntime LocalCancel => new(_loggerFactory,_engine, CancellationTokenSource);
+    public ConsoleRuntime LocalCancel => new(_loggerFactory,_engine, _sysEnv, CancellationTokenSource);
 
     public CancellationToken CancellationToken => CancellationTokenSource.Token;
     public CancellationTokenSource CancellationTokenSource { get; }

--- a/src/apps/src/Eryph-zero/EryphOVSEnvironment.cs
+++ b/src/apps/src/Eryph-zero/EryphOVSEnvironment.cs
@@ -1,0 +1,37 @@
+﻿using System.Runtime.InteropServices;
+using Dbosoft.OVN;
+using Microsoft.Extensions.Logging;
+
+namespace Eryph.Runtime.Zero;
+
+public class EryphOVSEnvironment : SystemEnvironment
+{
+    private readonly EryphOvsPathProvider _runPathProvider;
+
+    public EryphOVSEnvironment(EryphOvsPathProvider runPathProvider, ILoggerFactory loggerFactory) : base(
+        loggerFactory)
+    {
+        _runPathProvider = runPathProvider;
+    }
+
+    public override IFileSystem FileSystem => new EryphOVsFileSystem(_runPathProvider);
+
+
+    private class EryphOVsFileSystem : DefaultFileSystem
+    {
+        private readonly EryphOvsPathProvider _runPathProvider;
+
+        public EryphOVsFileSystem(EryphOvsPathProvider runPathProvider) : base(OSPlatform.Windows)
+        {
+            _runPathProvider = runPathProvider;
+        }
+
+        protected override string FindBasePath(string pathRoot)
+        {
+            if (!pathRoot.StartsWith("usr")) return base.FindBasePath(pathRoot);
+
+            return _runPathProvider.OvsRunPath;
+
+        }
+    }
+}

--- a/src/apps/src/Eryph-zero/EryphOvsPathProvider.cs
+++ b/src/apps/src/Eryph-zero/EryphOvsPathProvider.cs
@@ -1,0 +1,11 @@
+﻿namespace Eryph.Runtime.Zero;
+
+public class EryphOvsPathProvider
+{
+    public string OvsRunPath { get; }
+
+    public EryphOvsPathProvider(string runPath)
+    {
+        OvsRunPath = runPath;
+    }
+}

--- a/src/apps/src/Eryph-zero/OVSPackage.cs
+++ b/src/apps/src/Eryph-zero/OVSPackage.cs
@@ -74,11 +74,11 @@ internal class OVSPackage
 
             if (!ovsPackageExists && !ovsBackupExists)
                 throw new IOException(
-                    "Could not find existing OpenVSwitch run directory and ovs package to install ovs.");
+                    "Could not find existing OpenVSwitch run directory and ovs package to create it from.");
 
             if (ovsBackupExists && relativePackagePath== null)
             {
-                log.Information("No OVS Installation folder found. Trying to recreate from backup.");
+                log.Information("No OpenVSwitch Installation folder found. Trying to recreate from backup.");
                 File.Move(ovsPackageBackupFile, ovsPackageFile);
                 ovsPackageExists = true;
             }

--- a/src/apps/src/Eryph-zero/ZeroContainerExtensions.cs
+++ b/src/apps/src/Eryph-zero/ZeroContainerExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.InteropServices;
 using Dbosoft.OVN;
 using Eryph.Core;
 using Eryph.ModuleCore.Networks;
@@ -10,7 +9,6 @@ using Eryph.Security.Cryptography;
 using Eryph.StateDb;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Hosting.WindowsServices;
-using Microsoft.Extensions.Logging;
 using Rebus.Persistence.InMem;
 using Rebus.Transport.InMem;
 using SimpleInjector;
@@ -63,46 +61,5 @@ namespace Eryph.Runtime.Zero
             return container;
         }
 
-        private class EryphOVSEnvironment : SystemEnvironment
-        {
-            private readonly EryphOvsPathProvider _runPathProvider;
-
-            public EryphOVSEnvironment(EryphOvsPathProvider runPathProvider, ILoggerFactory loggerFactory) : base(loggerFactory)
-            {
-                _runPathProvider = runPathProvider;
-            }
-
-            public override IFileSystem FileSystem => new EryphOVsFileSystem(_runPathProvider);
-        }
-
-        private class EryphOVsFileSystem : DefaultFileSystem
-        {
-            private readonly EryphOvsPathProvider _runPathProvider;
-
-            public EryphOVsFileSystem(EryphOvsPathProvider runPathProvider) : base(OSPlatform.Windows)
-            {
-                _runPathProvider = runPathProvider;
-            }
-
-            protected override string FindBasePath(string pathRoot)
-            {
-                if (!pathRoot.StartsWith("usr")) return base.FindBasePath(pathRoot);
-
-                return _runPathProvider.OvsRunPath;
-
-            }
-        }
-
-        private class EryphOvsPathProvider
-        {
-            public string OvsRunPath { get; }
-
-            public EryphOvsPathProvider(string runPath)
-            {
-                OvsRunPath = runPath;
-            }
-        }
     }
-
-
 }

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -1,0 +1,559 @@
+﻿<#
+    .SYNOPSIS
+    Downloads and installs eryph-zero on the local machine.
+
+    .DESCRIPTION
+    Retrieves the eryph-zero package for the latest or a specified version,
+    and downloads and installs the application to the local machine.
+
+    .NOTES
+    =====================================================================
+
+    Copyright 2022 dbosoft GmbH,
+
+    Based on Chocolatey installation script, original copyright:
+
+    Copyright 2017 - 2020 Chocolatey Software, Inc, and the
+    original authors/contributors from ChocolateyGallery
+    Copyright 2011 - 2017 RealDimensions Software, LLC, and the
+    original authors/contributors from ChocolateyGallery
+    at https://github.com/chocolatey/chocolatey.org
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    =====================================================================
+
+    Environment Variables, specified as $env:NAME in PowerShell.exe and %NAME% in cmd.exe.
+    For explicit proxy, please set $env:eryphProxyLocation and optionally $env:eryphProxyUser and $env:eryphProxyPassword
+    For an explicit version of eryph, please set $env:eryphVersion = 'versionnumber'
+    To target a different url for eryph.zip, please set $env:eryphDownloadUrl = 'full url to zip file'
+    NOTE: $env:eryphDownloadUrl does not work with $env:eryphVersion.
+    To bypass the use of any proxy, please set $env:eryphIgnoreProxy = 'true'
+
+
+#>
+[CmdletBinding(DefaultParameterSetName = 'Default')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
+
+param(
+    # The URL to download eryph from. This defaults to the value of
+    # $env:eryphDownloadUrl, if it is set, and otherwise falls back to the
+    # official eryph community repository to download the eryph package.
+    # Can be used for offline installation by providing a path to a eryph.zip
+    [Parameter(Mandatory = $false)]
+    [string]
+    $DownloadUrl = $env:eryphDownloadUrl,
+
+    # Specifies a target version of eryph to install. By default, the latest
+    # stable version is installed. This will use the value in
+    # $env:eryphVersion by default, if that environment variable is present.
+    # This parameter is ignored if -eryphDownloadUrl is set.
+    [Parameter(Mandatory = $false)]
+    [string]
+    $Version = $env:eryphVersion,
+
+    # If set, ignores any configured proxy. This will override any proxy
+    # environment variables or parameters. This will be set by default if
+    # $env:eryphIgnoreProxy is set to a value other than 'false' or '0'.
+    [Parameter(Mandatory = $false)]
+    [switch]
+    $IgnoreProxy = $(
+        $envVar = "$env:eryphIgnoreProxy".Trim()
+        $value = $null
+        if ([bool]::TryParse($envVar, [ref] $value)) {
+            $value
+        }
+        elseif ([int]::TryParse($envVar, [ref] $value)) {
+            [bool]$value
+        }
+        else {
+            [bool]$envVar
+        }
+    ),
+
+    # Specifies the proxy URL to use during the download. This will default to
+    # the value of $env:eryphProxyLocation, if any is set.
+    [Parameter(ParameterSetName = 'Proxy', Mandatory = $false)]
+    [string]
+    $ProxyUrl = $env:eryphProxyLocation,
+
+    # Specifies the credential to use for an authenticated proxy. By default, a
+    # proxy credential will be constructed from the $env:eryphProxyUser and
+    # $env:eryphProxyPassword environment variables, if both are set.
+    [Parameter(ParameterSetName = 'Proxy', Mandatory = $false)]
+    [System.Management.Automation.PSCredential]
+    $ProxyCredential,
+
+    [Parameter(Mandatory = $false)]
+    [switch]
+    $Force
+)
+
+#region Functions
+
+Function Test-CommandExist {
+[CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $command
+    )
+
+    $oldPreference = $ErrorActionPreference
+    $ErrorActionPreference = "stop"
+
+    try {
+        if(Get-Command $command){
+            $true
+        }
+    } catch {
+        $false
+    } finally {
+        $ErrorActionPreference=$oldPreference
+    }
+
+}
+
+
+function Get-Downloader {
+    <#
+    .SYNOPSIS
+    Gets a System.Net.WebClient that respects relevant proxies to be used for
+    downloading data.
+
+    .DESCRIPTION
+    Retrieves a WebClient object that is pre-configured according to specified
+    environment variables for any proxy and authentication for the proxy.
+    Proxy information may be omitted if the target URL is considered to be
+    bypassed by the proxy (originates from the local network.)
+
+    .PARAMETER Url
+    Target URL that the WebClient will be querying. This URL is not queried by
+    the function, it is only a reference to determine if a proxy is needed.
+
+    .EXAMPLE
+    Get-Downloader -Url $fileUrl
+
+    Verifies whether any proxy configuration is needed, and/or whether $fileUrl
+    is a URL that would need to bypass the proxy, and then outputs the
+    already-configured WebClient object.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]
+        $Url,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $ProxyUrl,
+
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]
+        $ProxyCredential
+    )
+
+    $downloader = New-Object System.Net.WebClient
+
+    $defaultCreds = [System.Net.CredentialCache]::DefaultCredentials
+    if ($defaultCreds) {
+        $downloader.Credentials = $defaultCreds
+    }
+
+    if ($ProxyUrl) {
+        # Use explicitly set proxy.
+        Write-Verbose "Using explicit proxy server '$ProxyUrl'."
+        $proxy = New-Object System.Net.WebProxy -ArgumentList $ProxyUrl, <# bypassOnLocal: #> $true
+
+        $proxy.Credentials = if ($ProxyCredential) {
+            $ProxyCredential.GetNetworkCredential()
+        } elseif ($defaultCreds) {
+            $defaultCreds
+        } else {
+            Write-Warning "Default credentials were null, and no explicitly set proxy credentials were found. Attempting backup method."
+            (Get-Credential).GetNetworkCredential()
+        }
+
+        if (-not $proxy.IsBypassed($Url)) {
+            $downloader.Proxy = $proxy
+        }
+    }
+
+    $downloader
+}
+
+function Request-String {
+    <#
+    .SYNOPSIS
+    Downloads content from a remote server as a string.
+
+    .DESCRIPTION
+    Downloads target string content from a URL and outputs the resulting string.
+    Any existing proxy that may be in use will be utilised.
+
+    .PARAMETER Url
+    URL to download string data from.
+
+    .PARAMETER ProxyConfiguration
+    A hashtable containing proxy parameters (ProxyUrl and ProxyCredential)
+
+    .EXAMPLE
+    Request-String https://community.eryph.org/install.ps1
+
+    Retrieves the contents of the string data at the targeted URL and outputs
+    it to the pipeline.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Url,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]
+        $ProxyConfiguration
+    )
+
+    (Get-Downloader $url @ProxyConfiguration).DownloadString($url)
+}
+
+function Request-File {
+    <#
+    .SYNOPSIS
+    Downloads a file from a given URL.
+
+    .DESCRIPTION
+    Downloads a target file from a URL to the specified local path.
+    Any existing proxy that may be in use will be utilised.
+
+    .PARAMETER Url
+    URL of the file to download from the remote host.
+
+    .PARAMETER File
+    Local path for the file to be downloaded to.
+
+    .PARAMETER ProxyConfiguration
+    A hashtable containing proxy parameters (ProxyUrl and ProxyCredential)
+
+    .EXAMPLE
+    Request-File -Url https://community.eryph.org/install.ps1 -File $targetFile
+
+    Downloads the install.ps1 script to the path specified in $targetFile.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]
+        $Url,
+
+        [Parameter(Mandatory = $false)]
+        [string]
+        $File,
+
+        [Parameter(Mandatory = $false)]
+        [hashtable]
+        $ProxyConfiguration
+    )
+
+    Write-Verbose "Downloading $url to $file"
+    (Get-Downloader $url @ProxyConfiguration).DownloadFile($url, $file)
+}
+
+function Enable-PSConsoleWriter {
+    <#
+    .SYNOPSIS
+    Workaround for a bug in output stream handling PS v2 or v3.
+
+    .DESCRIPTION
+    PowerShell v2/3 caches the output stream. Then it throws errors due to the
+    FileStream not being what is expected. Fixes "The OS handle's position is
+    not what FileStream expected. Do not use a handle simultaneously in one
+    FileStream and in Win32 code or another FileStream." error.
+
+    .EXAMPLE
+    Enable-PSConsoleWriter
+
+    .NOTES
+    General notes
+    #>
+
+    [CmdletBinding()]
+    param()
+    if ($PSVersionTable.PSVersion.Major -gt 3) {
+        return
+    }
+
+    try {
+        # http://www.leeholmes.com/blog/2008/07/30/workaround-the-os-handles-position-is-not-what-filestream-expected/ plus comments
+        $bindingFlags = [Reflection.BindingFlags] "Instance,NonPublic,GetField"
+        $objectRef = $host.GetType().GetField("externalHostRef", $bindingFlags).GetValue($host)
+
+        $bindingFlags = [Reflection.BindingFlags] "Instance,NonPublic,GetProperty"
+        $consoleHost = $objectRef.GetType().GetProperty("Value", $bindingFlags).GetValue($objectRef, @())
+        [void] $consoleHost.GetType().GetProperty("IsStandardOutputRedirected", $bindingFlags).GetValue($consoleHost, @())
+
+        $bindingFlags = [Reflection.BindingFlags] "Instance,NonPublic,GetField"
+        $field = $consoleHost.GetType().GetField("standardOutputWriter", $bindingFlags)
+        $field.SetValue($consoleHost, [Console]::Out)
+
+        [void] $consoleHost.GetType().GetProperty("IsStandardErrorRedirected", $bindingFlags).GetValue($consoleHost, @())
+        $field2 = $consoleHost.GetType().GetField("standardErrorWriter", $bindingFlags)
+        $field2.SetValue($consoleHost, [Console]::Error)
+    } catch {
+        Write-Warning "Unable to apply redirection fix."
+    }
+}
+
+function Test-EryphInstalled {
+    [CmdletBinding()]
+    param()
+
+    $checkPath = if ($env:eryphInstall) { $env:eryphInstall } else { "$env:PROGRAMFILES\eryph\zero" }
+
+
+
+    if ($Command = Get-Command eryph-zero -CommandType Application -ErrorAction Ignore) {
+        # eryph-zero is on the PATH, assume it's installed
+        Write-Warning "'eryph-zero' was found at '$($Command.Path)'."
+        $true
+    }
+    elseif (-not (Test-Path $checkPath)) {
+        # eryph-zero doesn't exist
+        $false
+    }
+    elseif (-not (Get-ChildItem -Path $checkPath)) {
+        # Install folder exists but is empty
+        $false
+    }
+    else {
+        # Install folder exists and is not empty
+        Write-Warning "Files from a previous installation of eryph-zero were found at '$($CheckPath)'."
+        $true
+    }
+}
+
+#endregion Functions
+
+#region Pre-check
+
+# Ensure we have all our streams setup correctly, needed for older PSVersions.
+Enable-PSConsoleWriter
+
+if (Test-EryphInstalled) {
+
+    if(-not $Force)
+    {
+    $message = @(
+        "An existing eryph installation was detected. Installation will not continue."
+        "For security reasons, this script will not overwrite existing installations."
+        ""
+    ) -join [Environment]::NewLine } else{
+    $message = @(
+        "An existing eryph installation was detected. Installation will continue"
+        "due to -Force argument. The existing installation will be overwritten."
+        ""
+    ) -join [Environment]::NewLine
+    }
+
+    Write-Warning $message
+
+    if(-not $Force){
+        return
+    }
+}
+
+#endregion Pre-check
+
+#region Setup
+
+$proxyConfig = if ($IgnoreProxy -or -not $ProxyUrl) {
+    @{}
+} else {
+    $config = @{
+        ProxyUrl = $ProxyUrl
+    }
+
+    if ($ProxyCredential) {
+        $config['ProxyCredential'] = $ProxyCredential
+    } elseif ($env:eryphProxyUser -and $env:eryphProxyPassword) {
+        $securePass = ConvertTo-SecureString $env:eryphProxyPassword -AsPlainText -Force
+        $config['ProxyCredential'] = [System.Management.Automation.PSCredential]::new($env:eryphProxyUser, $securePass)
+    }
+
+    $config
+}
+
+# Attempt to set highest encryption available for SecurityProtocol.
+# PowerShell will not set this by default (until maybe .NET 4.6.x). This
+# will typically produce a message for PowerShell v2 (just an info
+# message though)
+try {
+    # Set TLS 1.2 (3072) as that is the minimum required by eryph.org.
+    # Use integers because the enumeration value for TLS 1.2 won't exist
+    # in .NET 4.0, even though they are addressable if .NET 4.5+ is
+    # installed (.NET 4.5 is an in-place upgrade).
+    Write-Verbose "Forcing web requests to allow TLS v1.2 (Required for requests to releases.dbosoft.eu)"
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+}
+catch {
+    $errorMessage = @(
+        'Unable to set PowerShell to use TLS 1.2. This is required for contacting eryph as of 03 FEB 2020.'
+        'https://blog.eryph.org/2020/01/remove-support-for-old-tls-versions/.'
+        'If you see underlying connection closed or trust errors, you may need to do one or more of the following:'
+        '(1) upgrade to .NET Framework 4.5+ and PowerShell v3+,'
+        '(2) Call [System.Net.ServicePointManager]::SecurityProtocol = 3072; in PowerShell prior to attempting installation,'
+        '(3) specify internal eryph package location (set $env:eryphDownloadUrl prior to install or host the package internally),'
+        '(4) use the Download + PowerShell method of install.'
+    ) -join [Environment]::NewLine
+    Write-Warning $errorMessage
+}
+
+if ($DownloadUrl) {
+    if ($Version) {
+        Write-Warning "Ignoring -Version parameter ($Version) because -DownloadUrl is set."
+    }
+
+    Write-Information "Downloading eryph-zero from: $DownloadUrl" -InformationAction Continue
+} elseif ($Version) {
+    Write-Information "Downloading specific version of eryph-zero: $Version" -InformationAction Continue
+} else {
+    Write-Information "Getting latest version of eryph-zero." -InformationAction Continue
+}
+
+if(-not $DownloadUrl){
+    $productJsonUrl = 'https://releases.dbosoft.eu/eryph/zero/index.json'
+    $productJson = Request-String -Url $productJsonUrl -ProxyConfiguration $proxyConfig | ConvertFrom-Json
+
+    if(-not $productJson){
+        return
+    }
+
+    $latestVersion = $productJson.latestVersion
+    Write-Verbose "Latest version of eryph: ${latestVersion}"
+
+    if(-not $Version){
+        $Version = $latestVersion
+    }
+
+    $productFile = $productJson.versions."$Version".files | Where-Object arch -eq 'amd64' | Select-Object -First 1
+
+    if(!$productFile){
+        Write-Error "Version {$Version} not found"
+        return
+    }
+
+    $DownloadUrl = $productFile.url
+
+
+}
+
+if (-not $env:TEMP) {
+    $env:TEMP = Join-Path $env:SystemDrive -ChildPath 'temp'
+}
+
+$eryphTempDir = Join-Path $env:TEMP -ChildPath "eryph"
+$tempDir = Join-Path $eryphTempDir -ChildPath "eryphInstall"
+
+if (-not (Test-Path $tempDir -PathType Container)) {
+    $null = New-Item -Path $tempDir -ItemType Directory
+}
+
+#endregion Setup
+
+#region Download & Extract eryph
+
+# If we are passed a valid local path, we do not need to download it.
+if (Test-Path $DownloadUrl) {
+    $file = $DownloadUrl
+    
+    Write-Information "Using eryph from $DownloadUrl." -InformationAction Continue
+} else {
+    $file = Join-Path $tempDir "eryph.zip"
+    $deleteFile = $true
+    Write-Information "Getting eryph from $DownloadUrl." -InformationAction Continue
+    Request-File -Url $DownloadUrl -File $file -ProxyConfiguration $proxyConfig
+}
+
+
+if((Test-CommandExist "Get-FileHash") -and $productFile) {
+    Write-Verbose "Validating checksum of downloaded file."
+    $expectedChecksum =  $productFile.sha256Checksum
+    $actualChecksum = (Get-FileHash $file -Algorithm SHA256).Hash.ToLowerInvariant()
+
+    if($expectedChecksum -ne $actualChecksum){
+        Write-Error "Checksum of downloaded file doesn't match expected hash."
+        return
+    }
+}
+
+Write-Verbose "Extracting $file to $tempDir"
+if ($PSVersionTable.PSVersion.Major -lt 5) {
+    # Determine unzipping method
+    Write-Verbose 'Using built-in compression to unzip'
+
+    try {
+        $shellApplication = New-Object -ComObject Shell.Application
+        $zipPackage = $shellApplication.NameSpace($file)
+        $destinationFolder = $shellApplication.NameSpace($tempDir)
+        $destinationFolder.CopyHere($zipPackage.Items(), 0x10)
+    } catch {
+        Write-Warning "Unable to unzip package using built-in compression. "
+        throw $_
+    }
+} else {
+    Microsoft.PowerShell.Archive\Expand-Archive -Path $file -DestinationPath $tempDir -Force
+}
+
+if($deleteFile) {
+    Remove-Item $file
+}
+#endregion Download & Extract eryph
+
+#region Install eryph
+
+Write-Information "Starting eryph-zero installation." -InformationAction Continue
+Write-Host
+
+$toolsFolder = Join-Path $tempDir -ChildPath "bin"
+$eryphInstallExe = Join-Path $toolsFolder -ChildPath "eryph-zero.exe"
+
+$installLogFile = Join-Path $eryphTempDir "install.log"
+$process = Start-Process $eryphInstallExe -ArgumentList @("install --outFile ""${installLogFile}"" --deleteOutFile") -Verb runas -WindowStyle Hidden 
+
+while(!(Test-Path $installLogFile)){
+    Start-Sleep -Milliseconds 100
+}
+
+Get-Content $installLogFile -Wait -Tail 1 -ErrorAction SilentlyContinue | % {
+    $parts = $_.ToString().Split(']')
+
+    if($parts.Length -lt 2){
+        Write-Information $line -InformationAction Continue
+    } else{
+        $line = $parts[1].TrimStart()
+        Write-Information $line  -InformationAction Continue
+    }
+}
+
+Write-Verbose 'Cleanup temporary files'
+Remove-Item $eryphTempDir -Recurse -ErrorAction Continue
+
+
+Write-Verbose 'Ensuring eryph commands are on the path'
+
+$eryphPath = "$env:PROGRAMFILES\eryph\zero"
+$eryphExePath = Join-Path $eryphPath -ChildPath 'bin'
+
+# Update current process PATH environment variable if it needs updating.
+if ($env:Path -notlike "*$eryphExePath*") {
+    $env:Path = [Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::Machine);
+}

--- a/src/core/src/Eryph.VmManagement/Data/Core/VMSwitch.cs
+++ b/src/core/src/Eryph.VmManagement/Data/Core/VMSwitch.cs
@@ -12,7 +12,8 @@ public class VMSwitch
     [PrivateIdentifier]
     public string Name { get; init; }
 
-    public Guid[] NetAdapterInterfaceGuid { get; init; }
+    public string NetAdapterInterfaceDescription { get; init; }
+    public Guid[] NetAdapterInterfaceGuid { get; set; }
 
 }
 

--- a/src/core/src/Eryph.VmManagement/Data/Core/VMSwitchExtensions.cs
+++ b/src/core/src/Eryph.VmManagement/Data/Core/VMSwitchExtensions.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Eryph.VmManagement.Data.Core
+{
+    public static class VMSwitchExtensions
+    {
+        public static Guid[] GetNetAdapterInterfaceGuid(this TypedPsObject<VMSwitch> vmSwitch)
+        {
+            if (string.IsNullOrWhiteSpace(vmSwitch.Value.NetAdapterInterfaceDescription) ||
+                vmSwitch.Value.NetAdapterInterfaceGuid != null) 
+                
+                return vmSwitch.Value.NetAdapterInterfaceGuid;
+            
+            // NetAdapterInterfaceGuid as property is not available, so fetch it via reflection
+            // this has been added for Server 2016 compatibility so it can be removed
+            // when 2016 is out of extended support (year 2027)
+            // never windows version expose this property directly
+            var baseObject = vmSwitch.PsObject?.BaseObject;
+            if (baseObject != null)
+            {
+                var getAdaptersMethod = baseObject.GetType().GetMethod("GetAndOrganizeNetworkAdapters",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+
+                if (getAdaptersMethod != null)
+                {
+                    var param = new object[2];
+                    getAdaptersMethod.Invoke(baseObject, param);
+                    // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+                    if (param[0] != null)
+                    {
+                        var externalPort = param[0];
+
+                        var externalAdapterAccessorField = externalPort.GetType()
+                            .GetField("m_ExternalNetworkAdapters",
+                                BindingFlags.Instance | BindingFlags.NonPublic);
+
+                        object[] externalAdapters = null;
+                        if (externalAdapterAccessorField != null)
+                        {
+                            // their is either a list of external network adapters 
+                            var externalAdapterAccessor = externalAdapterAccessorField.GetValue(externalPort);
+                            var externalAdapterAccessorDataField = externalAdapterAccessor?.GetType().BaseType?
+                                .GetField("m_Value", BindingFlags.Instance | BindingFlags.NonPublic);
+
+                            externalAdapters =
+                                externalAdapterAccessorDataField?.GetValue(externalAdapterAccessor) as object[];
+                        }
+                        else
+                        {
+                            //or a single external adapter field
+                            externalAdapterAccessorField = externalPort.GetType()
+                                .GetField("m_ExternalNetworkAdapter",
+                                    BindingFlags.Instance | BindingFlags.NonPublic);
+
+                            var externalAdapterAccessor = externalAdapterAccessorField?.GetValue(externalPort);
+                            var externalAdapterAccessorDataField = externalAdapterAccessor?.GetType().BaseType?
+                                .GetField("m_Value", BindingFlags.Instance | BindingFlags.NonPublic);
+
+                            var externalAdapter =
+                                externalAdapterAccessorDataField?.GetValue(externalAdapterAccessor);
+                            if (externalAdapter != null)
+                                externalAdapters = new[] { externalAdapter };
+                        }
+
+                        if (externalAdapters != null)
+                        {
+                            var deviceList = new List<Guid>();
+                            foreach (var externalAdapter in externalAdapters)
+                            {
+                                var deviceIdProperty = externalAdapter.GetType().GetProperty("DeviceId");
+                                var deviceId = deviceIdProperty?.GetValue(externalAdapter) as string;
+                                if (string.IsNullOrWhiteSpace(deviceId)) continue;
+
+                                deviceId = deviceId.Replace("Microsoft:", string.Empty);
+                                if (Guid.TryParse(deviceId, out var deviceGuid))
+                                {
+                                    deviceList.Add(deviceGuid);
+                                }
+                            }
+                            return deviceList.ToArray();
+                        }
+                    }
+                }
+            }
+
+            throw new Exception($"Failed to identify physical adapters of switch '{vmSwitch.Value.Name}'");
+
+        }
+
+    }
+}

--- a/src/core/src/Eryph.VmManagement/Data/Core/VMSwitchExtensions.cs
+++ b/src/core/src/Eryph.VmManagement/Data/Core/VMSwitchExtensions.cs
@@ -16,7 +16,7 @@ namespace Eryph.VmManagement.Data.Core
             // NetAdapterInterfaceGuid as property is not available, so fetch it via reflection
             // this has been added for Server 2016 compatibility so it can be removed
             // when 2016 is out of extended support (year 2027)
-            // never windows version expose this property directly
+            // newer windows version expose this property directly
             var baseObject = vmSwitch.PsObject?.BaseObject;
             if (baseObject != null)
             {


### PR DESCRIPTION
On Windows Server 2016 adapters of switches cannot be found. 
The property NetAdapterInterfaceGuid is missing in this version. As workaround the value is now retrieved via reflection if necessary.

In addition setup script was added to project and self install command was optimized for better integration with setup script.