### PR TITLE
Rebuild valid default network config

### DIFF
--- a/src/data/src/Eryph.StateDb/Model/VirtualNetwork.cs
+++ b/src/data/src/Eryph.StateDb/Model/VirtualNetwork.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Eryph.Resources;
+using JetBrains.Annotations;
 
 namespace Eryph.StateDb.Model;
 

--- a/src/modules/src/Eryph.ModuleCore/Networks/VirtualNetworksExtensions.cs
+++ b/src/modules/src/Eryph.ModuleCore/Networks/VirtualNetworksExtensions.cs
@@ -49,7 +49,7 @@ namespace Eryph.ModuleCore.Networks
                                 }).ToArray() : null
 
                             };
-                        }).ToArray() : Array.Empty<NetworkSubnetConfig>()
+                        }).ToArray() : null
 
                     };
 


### PR DESCRIPTION
In case of switching from overlay to flat network the default subnet is removed from default project. 
If switched back to nat overlay afterwards the default settings are not restored correctly.

Network realizer was improved to generate at least one valid subnet even if network config is initial. It also now ensures that DNS and MTU settings for default project are restored.