### PR TITLE
Default hostname from slug

### DIFF
--- a/src/core/src/Eryph.VmConfig.Primitives/Resources/Disks/DiskInfo.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/Resources/Disks/DiskInfo.cs
@@ -12,6 +12,9 @@ namespace Eryph.Resources.Disks
         public string ProjectName { get; set; }
         public string Environment { get; set; }
 
+        public bool Frozen { get; set; }
+
+
         [PrivateIdentifier]
 
         public string Path { get; set; }

--- a/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/VirtualMachineData.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/VirtualMachineData.cs
@@ -12,6 +12,14 @@ namespace Eryph.Resources.Machines
         public VmStatus Status { get; set; }
         public TimeSpan UpTime { get; set; }
 
+        public string DataStore { get; set; }
+        public string ProjectName { get; set; }
+        public string Environment { get; set; }
+
+        public bool Frozen { get; set; }
+        public string VMPath { get; set; }
+        public string StorageIdentifier { get; set; }
+
         public VirtualMachineNetworkAdapterData[] NetworkAdapters { get; set; }
         public VirtualMachineDriveData[] Drives { get; set; }
 

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeCloudInitDisk.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeCloudInitDisk.cs
@@ -55,7 +55,7 @@ namespace Eryph.VmManagement.Converging
                         from networkData in GenerateNetworkData(vmInfo).ToAsync()
                         from _ in GenerateConfigDriveDisk(configDriveIsoPath,
                             Context.Metadata.SensitiveDataHidden,
-                            Context.Config.Raising.Hostname,
+                            string.IsNullOrWhiteSpace(Context.Config.Raising.Hostname) ? storageIdentifier : Context.Config.Raising.Hostname,
                             networkData,
                             Context.Config.Raising.Config).ToAsync()
                         from newVmInfo in InsertConfigDriveDisk(configDriveIsoPath, vmInfo).ToAsync()

--- a/src/data/src/Eryph.StateDb/Migrations/20230808161935_StorageIds.Designer.cs
+++ b/src/data/src/Eryph.StateDb/Migrations/20230808161935_StorageIds.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eryph.StateDb;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Eryph.StateDb.Migrations
 {
     [DbContext(typeof(StateStoreContext))]
-    partial class StateStoreContextModelSnapshot : ModelSnapshot
+    [Migration("20230808161935_StorageIds")]
+    partial class StorageIds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.11");

--- a/src/data/src/Eryph.StateDb/Migrations/20230808161935_StorageIds.cs
+++ b/src/data/src/Eryph.StateDb/Migrations/20230808161935_StorageIds.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eryph.StateDb.Migrations
+{
+    public partial class StorageIds : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Frozen",
+                table: "VDisks",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DataStore",
+                table: "VCatlets",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Environment",
+                table: "VCatlets",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Frozen",
+                table: "VCatlets",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "StorageIdentifier",
+                table: "VCatlets",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Frozen",
+                table: "VDisks");
+
+            migrationBuilder.DropColumn(
+                name: "DataStore",
+                table: "VCatlets");
+
+            migrationBuilder.DropColumn(
+                name: "Environment",
+                table: "VCatlets");
+
+            migrationBuilder.DropColumn(
+                name: "Frozen",
+                table: "VCatlets");
+
+            migrationBuilder.DropColumn(
+                name: "StorageIdentifier",
+                table: "VCatlets");
+        }
+    }
+}

--- a/src/data/src/Eryph.StateDb/Model/VirtualCatlet.cs
+++ b/src/data/src/Eryph.StateDb/Model/VirtualCatlet.cs
@@ -15,6 +15,10 @@ namespace Eryph.StateDb.Model
         public Guid MetadataId { get; set; }
 
         public string Path { get; set; }
+        public string StorageIdentifier { get; set; }
+        public string DataStore { get; set; }
+        public string Environment { get; set; }
+        public bool Frozen { get; set; }
         public virtual VirtualCatletHost Host { get; set; }
 
 

--- a/src/data/src/Eryph.StateDb/Model/VirtualDisk.cs
+++ b/src/data/src/Eryph.StateDb/Model/VirtualDisk.cs
@@ -12,6 +12,7 @@ namespace Eryph.StateDb.Model
         }
 
         public string StorageIdentifier { get; set; }
+        public bool Frozen { get; set; }
 
         public string Path { get; set; }
         public string FileName { get; set; }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetVirtualCatletConfigurationHandler.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetVirtualCatletConfigurationHandler.cs
@@ -52,7 +52,11 @@ namespace Eryph.Modules.ComputeApi.Handlers
                 Name = vCatlet.Name,
                 Project = vCatlet.Project.Name != "default" ? vCatlet.Project.Name: null,
                 Version = "1.0",
-                VCatlet = new VirtualCatletConfig()
+                Environment = vCatlet.Environment != "default" ? vCatlet.Environment : null,
+                VCatlet = new VirtualCatletConfig
+                {
+                    Slug = vCatlet.StorageIdentifier,
+                }
             };
 
 

--- a/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetVirtualCatletConfigurationHandler.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetVirtualCatletConfigurationHandler.cs
@@ -175,7 +175,7 @@ namespace Eryph.Modules.ComputeApi.Handlers
                 if (config.Raising != null)
                 {
                     // remove default hostname config
-                    if (config.Raising.Hostname == config.Name)
+                    if (config.Raising.Hostname == config.VCatlet.Slug)
                         config.Raising.Hostname = null;
 
                     foreach (var raisingConfig in config.Raising.Config)

--- a/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
@@ -107,6 +107,7 @@ namespace Eryph.Modules.Controller.Inventory
                         Name = diskInfo.Name,
                         DataStore = diskInfo.DataStore,
                         Environment = diskInfo.Environment,
+                        Frozen = diskInfo.Frozen,
                         StorageIdentifier = diskInfo.StorageIdentifier,
                         Project = await FindRequiredProject(diskInfo.ProjectName)
                     };
@@ -182,8 +183,8 @@ namespace Eryph.Modules.Controller.Inventory
                         if (metadata.MachineId == Guid.Empty)
                             metadata.MachineId = Guid.NewGuid();
 
-                        // TODO: add lookup of project from vm location
-                        var project = await FindRequiredProject("default");
+                        
+                        var project = await FindRequiredProject(vmInfo.ProjectName);
 
                         await _vmDataService.AddNewVM(
                             VirtualMachineInfoToVCatlet(vmInfo, hostMachine, metadata.MachineId, project),
@@ -205,7 +206,11 @@ namespace Eryph.Modules.Controller.Inventory
                         existingMachine.Status = newMachine.Status;
                         existingMachine.Host = hostMachine;
                         existingMachine.AgentName = newMachine.AgentName;
-
+                        existingMachine.Frozen = newMachine.Frozen;
+                        existingMachine.DataStore = newMachine.DataStore;
+                        existingMachine.Environment = newMachine.Environment;
+                        existingMachine.Path = newMachine.Path;
+                        existingMachine.StorageIdentifier = newMachine.StorageIdentifier;
                         existingMachine.ReportedNetworks = newMachine.ReportedNetworks;
                         existingMachine.NetworkAdapters = newMachine.NetworkAdapters;
                         existingMachine.Drives = newMachine.Drives;
@@ -255,6 +260,11 @@ namespace Eryph.Modules.Controller.Inventory
                 Status = MapVmStatusToMachineStatus(vmInfo.Status),
                 Host = hostMachine,
                 AgentName = hostMachine.AgentName,
+                DataStore = vmInfo.DataStore,
+                Environment = vmInfo.Environment,
+                Path = vmInfo.VMPath,
+                Frozen = vmInfo.Frozen,
+                StorageIdentifier = vmInfo.StorageIdentifier,
                 MetadataId = vmInfo.MetadataId,
                 UpTime = vmInfo.UpTime,
                 CpuCount = vmInfo.Cpu?.Count ?? 0,

--- a/src/modules/src/Eryph.Modules.Controller/Operations/ValidateMachineConfigCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Operations/ValidateMachineConfigCommandHandler.cs
@@ -68,7 +68,7 @@ namespace Eryph.Modules.Controller.Operations
             }
 
             if (string.IsNullOrWhiteSpace(machineConfig.Raising.Hostname))
-                machineConfig.Raising.Hostname = machineConfig.Name;
+                machineConfig.Raising.Hostname = machineConfig.VCatlet.Slug;
 
             foreach (var adapterConfig in machineConfig.VCatlet.NetworkAdapters)
             {

--- a/src/modules/src/Eryph.Modules.Controller/Operations/ValidateMachineConfigCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Operations/ValidateMachineConfigCommandHandler.cs
@@ -68,7 +68,7 @@ namespace Eryph.Modules.Controller.Operations
             }
 
             if (string.IsNullOrWhiteSpace(machineConfig.Raising.Hostname))
-                machineConfig.Raising.Hostname = machineConfig.VCatlet.Slug;
+                machineConfig.Raising.Hostname =  machineConfig.VCatlet.Slug;
 
             foreach (var adapterConfig in machineConfig.VCatlet.NetworkAdapters)
             {


### PR DESCRIPTION
Currently, the hostname is initialized with the catlet name, resulting in duplicate hostnames for multiple catlets with the same name. 
For vcatlets, hostnames are now initialized from the slug instead, if not set. 