### PR TITLE
compute_api: update endpoint invalid

### DIFF
--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Update.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Update.cs
@@ -43,7 +43,7 @@ namespace Eryph.Modules.ComputeApi.Endpoints.V1.Catlets
         }
 
         [Authorize(Policy = "compute:catlets:write")]
-        [HttpPut("catlet")]
+        [HttpPut("catlets/{id}")]
         [SwaggerOperation(
             Summary = "Updates a catlet",
             Description = "Updates a catlet",


### PR DESCRIPTION
Fixed invalid api spec for update endpoint

This issue caused invalid generated clients that don't pass the catlet id.
