### PR TITLE
Improve creation of virtual disks

### DIFF
--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -7,9 +7,9 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.2.0" />
-    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.2.0" />
-    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.2.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.2.1-ci.1" />
+    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.2.1-ci.1" />
+    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.2.1-ci.1" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -7,9 +7,9 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.2.1-ci.1" />
-    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.2.1-ci.1" />
-    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.2.1-ci.1" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.3.0" />
+    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.3.0" />
+    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.3.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
@@ -115,9 +115,6 @@ namespace Eryph.VmManagement.Converging
                     x.Type is CatletDriveType.VHD or CatletDriveType.SharedVHD)
                 .Cast<HardDiskDriveStorageSettings>().ToSeq();
 
-            var attachedPaths = planedDiskSettings.Map(s => s.AttachPath).Map(x => x.IfNone(""))
-                .Where(x => !string.IsNullOrWhiteSpace(x));
-
             var frozenDiskIds = currentDiskStorageSettings.Where(x => x.Frozen).Map(x => x.AttachedVMId);
 
             return ConvergeHelpers.FindAndApply(vmInfo,
@@ -269,12 +266,12 @@ namespace Eryph.VmManagement.Converging
                                     driveSettings.Type is CatletDriveType.SharedVHD or CatletDriveType.VHDSet
                                         ? driveSettings.DiskSettings.ParentSettings.MatchAsync(async parentSettings =>
                                                 {
-                                                    // shared vhd and vhd sets set don't support differencing disks
-                                                    // so we need to to copy parent disks (and then convert it to vhds in case of a vhd set)
+                                                    // Shared VHDs and VHD sets don't support differencing disks.
+                                                    // Hence, we need to copy parent disks (and then convert it to .vhds in case of a VHD set)
                                                     var parentFilePath = Path.Combine(parentSettings.Path,
                                                         parentSettings.FileName);
 
-                                                    // var shared vhd this don't change path, but for a vhd set
+                                                    // For shared VHD this doesn't change the path, but for a VHD set it does.
                                                     var copyToPath = Path.ChangeExtension(vhdPath, "vhdx");
 
                                                     var commandConvert = PsCommandBuilder.Create()

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
@@ -273,17 +273,17 @@ namespace Eryph.VmManagement.Converging
                                                 .AddCommand("New-VHD")
                                                 .AddParameter("Path", vhdPath)
                                                 .AddParameter("ParentPath", parentFilePath)
-                                                .AddParameter("Differencing");
-
-                                                if (driveSettings.DiskSettings.SizeBytesCreate > 0)
-                                                    command.AddParameter("SizeBytes", driveSettings.DiskSettings.SizeBytesCreate);
+                                                .AddParameter("Differencing")
+                                                .AddParameter("SizeBytes", driveSettings.DiskSettings.SizeBytesCreate);
 
                                             return await Context.Engine.RunAsync(command);
                                         },
-                                        async () => await Context.Engine.RunAsync(PsCommandBuilder.Create().Script(
-                                            $"New-VHD -Path \"{vhdPath}\" -Dynamic -SizeBytes {driveSettings.DiskSettings.SizeBytesCreate}")))
+                                        async () => await Context.Engine.RunAsync(PsCommandBuilder.Create()
+                                            .AddCommand("New-VHD")
+                                            .AddParameter("Path", vhdPath)
+                                            .AddParameter("Dynamic")
+                                            .AddParameter("SizeBytes", driveSettings.DiskSettings.SizeBytesCreate)))
                                     .ToError().ToAsync()
-
                                 select Prelude.unit,
 
                             // file exists

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
@@ -379,7 +379,7 @@ namespace Eryph.VmManagement.Converging
                 .AddParameter("Path", vhdPath);
 
             if (driveSettings.Type == CatletDriveType.SharedVHD)
-                command.AddParameter("ShareVirtualDisk");
+                command.AddParameter("SupportPersistentReservations");
 
             command.AddParameter("ControllerNumber", driveSettings.ControllerNumber)
                 .AddParameter("ControllerLocation", driveSettings.ControllerLocation)

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
@@ -268,8 +268,17 @@ namespace Eryph.VmManagement.Converging
                                         {
                                             var parentFilePath = Path.Combine(parentSettings.Path,
                                                 parentSettings.FileName);
-                                            return await Context.Engine.RunAsync(PsCommandBuilder.Create().Script(
-                                                $"New-VHD -Path \"{vhdPath}\" -ParentPath \"{parentFilePath}\" -Differencing"));
+
+                                            var command = PsCommandBuilder.Create()
+                                                .AddCommand("New-VHD")
+                                                .AddParameter("Path", vhdPath)
+                                                .AddParameter("ParentPath", parentFilePath)
+                                                .AddParameter("Differencing");
+
+                                                if (driveSettings.DiskSettings.SizeBytesCreate > 0)
+                                                    command.AddParameter("SizeBytes", driveSettings.DiskSettings.SizeBytesCreate);
+
+                                            return await Context.Engine.RunAsync(command);
                                         },
                                         async () => await Context.Engine.RunAsync(PsCommandBuilder.Create().Script(
                                             $"New-VHD -Path \"{vhdPath}\" -Dynamic -SizeBytes {driveSettings.DiskSettings.SizeBytesCreate}")))

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
@@ -35,8 +35,8 @@ namespace Eryph.VmManagement.Converging
                     //prevent snapshots creating during running disk converge
                     from _ in SetVMCheckpointType(vmInfo, CheckpointType.Disabled, Context.Engine)
                     //make a plan
-                    from plannedDriveStorageSettings in VMDriveStorageSettings
-                        .PlanDriveStorageSettings(Context.VmHostAgentConfig, Context.Config, Context.StorageSettings) 
+                    from plannedDriveStorageSettings in VMDriveStorageSettings.PlanDriveStorageSettings(
+                        Context.VmHostAgentConfig, Context.Config, Context.StorageSettings, Context.Engine) 
                     //ensure that the changes reflect the current VM settings
                     from infoReloaded in vmInfo.Reload(Context.Engine)
                     //detach removed disks

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
@@ -36,7 +36,8 @@ namespace Eryph.VmManagement.Converging
                     from _ in SetVMCheckpointType(vmInfo, CheckpointType.Disabled, Context.Engine)
                     //make a plan
                     from plannedDriveStorageSettings in VMDriveStorageSettings.PlanDriveStorageSettings(
-                        Context.VmHostAgentConfig, Context.Config, Context.StorageSettings, Context.Engine) 
+                        Context.VmHostAgentConfig, Context.Config, Context.StorageSettings,
+                        path => VhdQuery.GetVhdInfo(Context.Engine, path).ToError().ToAsync().MapT(o => o.Value))
                     //ensure that the changes reflect the current VM settings
                     from infoReloaded in vmInfo.Reload(Context.Engine)
                     //detach removed disks

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
@@ -112,7 +112,7 @@ namespace Eryph.VmManagement.Converging
 
         {
             var planedDiskSettings = plannedStorageSettings.Where(x =>
-                    x.Type is CatletDriveType.VHD or CatletDriveType.SharedVHD)
+                    x.Type is CatletDriveType.VHD or CatletDriveType.SharedVHD or CatletDriveType.VHDSet)
                 .Cast<HardDiskDriveStorageSettings>().ToSeq();
 
             var frozenDiskIds = currentDiskStorageSettings.Where(x => x.Frozen).Map(x => x.AttachedVMId);
@@ -267,7 +267,7 @@ namespace Eryph.VmManagement.Converging
                                         ? driveSettings.DiskSettings.ParentSettings.MatchAsync(async parentSettings =>
                                                 {
                                                     // Shared VHDs and VHD sets don't support differencing disks.
-                                                    // Hence, we need to copy parent disks (and then convert it to .vhds in case of a VHD set)
+                                                    // Hence, we need to copy the parent disk (and then convert it to .vhds in case of a VHD set)
                                                     var parentFilePath = Path.Combine(parentSettings.Path,
                                                         parentSettings.FileName);
 

--- a/src/core/src/Eryph.VmManagement/Data/Core/VhdInfo.cs
+++ b/src/core/src/Eryph.VmManagement/Data/Core/VhdInfo.cs
@@ -6,7 +6,12 @@ namespace Eryph.VmManagement.Data.Core
     {
         [PrivateIdentifier]
         public string Path { get; set; }
+        
         public long Size { get; set; }
+
+        public long? MinimumSize { get; set; }
+
+        public long FileSize { get; set; }
 
         [PrivateIdentifier]
         public string ParentPath { get; set; }

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.NoCloud" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.WindowsImaging" Version="1.0.0-rc.12" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.2.1-ci.1" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.NoCloud" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.WindowsImaging" Version="1.0.0-rc.12" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.2.0" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.2.1-ci.1" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.VmManagement/MonadHelpers.cs
+++ b/src/core/src/Eryph.VmManagement/MonadHelpers.cs
@@ -9,26 +9,6 @@ namespace Eryph.VmManagement
 {
     public static class MonadHelpers
     {
-        public static Task<Either<TL, Option<TR>>> LastOrNone<TL, TR>(this Task<Either<TL, Seq<TR>>> either)
-        {
-            return either.MapAsync(s => s.LastOrNone());
-        }
-
-        public static Task<Either<TL, Seq<TR>>> MapToEitherAsync<TL, TR, TEntry>(this Seq<TEntry> sequence,
-            Func<int, TEntry, Task<Either<TL, TR>>> mapperFunc)
-        {
-            return sequence.Map(mapperFunc).ToImmutableArray()
-                .TraverseSerial(l => l)
-                .Bind(e =>
-                {
-                    var enumerable = e as Either<TL, TR>[] ?? e.ToArray();
-                    return enumerable.Lefts().HeadOrNone()
-                        .MatchAsync(
-                            s => LeftAsync<TL, Seq<TR>>(s).ToEither(),
-                            () => RightAsync<TL, Seq<TR>>(enumerable.Rights().ToSeq()).ToEither());
-                });
-        }
-
         public static Task<Either<TL, Seq<TR>>> MapToEitherAsync<TL, TR, TEntry>(this Seq<TEntry> sequence,
             Func<TEntry, Task<Either<TL, TR>>> mapperFunc)
         {

--- a/src/core/src/Eryph.VmManagement/PsCommandBuilder.cs
+++ b/src/core/src/Eryph.VmManagement/PsCommandBuilder.cs
@@ -33,7 +33,7 @@ public class PsCommandBuilder
 
     public PsCommandBuilder AddParameter(string parameter)
     {
-        _dataChain.Add(new ParameterPart { Parameter = parameter});
+        _dataChain.Add(new SwitchParameterPart { Parameter = parameter});
         return this;
     }
 
@@ -141,7 +141,4 @@ public class PsCommandBuilder
         public object Value { get; init; }
 
     }
-
-
 }
-

--- a/src/core/src/Eryph.VmManagement/Storage/VMDriveStorageSettings.cs
+++ b/src/core/src/Eryph.VmManagement/Storage/VMDriveStorageSettings.cs
@@ -5,7 +5,6 @@ using Eryph.Core.VmAgent;
 using Eryph.VmManagement.Data.Core;
 using LanguageExt;
 using LanguageExt.Common;
-using LanguageExt.UnsafeValueAccess;
 using static LanguageExt.Prelude;
 
 namespace Eryph.VmManagement.Storage
@@ -127,7 +126,7 @@ namespace Eryph.VmManagement.Storage
                         Name = driveConfig.Name,
                         SizeBytesCreate = (configuredSize | parentVhdInfo.Map(i => i.Size))
                             .IfNone(1 * 1024L * 1024 * 1024),
-                        SizeBytes = configuredSize.IsSome ? configuredSize.ValueUnsafe() : null,
+                        SizeBytes = configuredSize.Map(s => (long?)s).IfNoneUnsafe((long?)null),
                     },
                     ControllerNumber = controllerNumber,
                     ControllerLocation = controllerLocation

--- a/src/core/src/Eryph.VmManagement/Storage/VMDriveStorageSettings.cs
+++ b/src/core/src/Eryph.VmManagement/Storage/VMDriveStorageSettings.cs
@@ -44,7 +44,9 @@ namespace Eryph.VmManagement.Storage
             var controllerLocation = index;
 
             //if it is not a vhd, we only need controller settings
-            if (driveConfig.Type.HasValue && driveConfig.Type != CatletDriveType.VHD && driveConfig.Type != CatletDriveType.SharedVHD)
+            if (driveConfig.Type.HasValue && 
+                driveConfig.Type != CatletDriveType.VHD && driveConfig.Type != CatletDriveType.SharedVHD &&
+                driveConfig.Type != CatletDriveType.VHDSet)
             {
                 VMDriveStorageSettings result;
                 if (driveConfig.Type == CatletDriveType.DVD)
@@ -86,7 +88,7 @@ namespace Eryph.VmManagement.Storage
                 from resolvedPath in names.ResolveVolumeStorageBasePath(vmHostAgentConfig)
                 from identifier in storageIdentifier.ToEitherAsync(
                     Error.New($"Unexpected missing storage identifier for disk '{driveConfig.Name}'."))
-                let fileName = driveConfig.Type == CatletDriveType.SharedVHD ? $"{driveConfig.Name}.vhds" : $"{driveConfig.Name}.vhdx"
+                let fileName = driveConfig.Type == CatletDriveType.VHDSet ? $"{driveConfig.Name}.vhds" : $"{driveConfig.Name}.vhdx"
                 let attachPath = Path.Combine(resolvedPath, identifier, fileName)
                 let configuredSize = Optional(driveConfig.Size).Filter(notDefault).Map(s => s * 1024L * 1024 * 1024)
                 from vhdInfo in getVhdInfo(attachPath)

--- a/src/core/src/Eryph.VmManagement/Storage/VMDriveStorageSettings.cs
+++ b/src/core/src/Eryph.VmManagement/Storage/VMDriveStorageSettings.cs
@@ -15,8 +15,8 @@ namespace Eryph.VmManagement.Storage
         public CatletDriveType Type { get; set; }
 
         public int ControllerLocation { get; set; }
-        public int ControllerNumber { get; set; }
 
+        public int ControllerNumber { get; set; }
 
         public static EitherAsync<Error, Seq<VMDriveStorageSettings>> PlanDriveStorageSettings(
             VmHostAgentConfiguration vmHostAgentConfig,
@@ -38,57 +38,54 @@ namespace Eryph.VmManagement.Storage
         {
             //currently this will not be configurable, but keep it here at least as constant
             const int controllerNumber = 0;
-            
+
             //later, when adding controller config support, we will have to add a logic to 
             //set location relative to the free slots for each controller   
             var controllerLocation = index;
 
-            //if it is not a vhd, we only need controller settings
-            if (driveConfig.Type.HasValue && 
-                driveConfig.Type != CatletDriveType.VHD && driveConfig.Type != CatletDriveType.SharedVHD &&
-                driveConfig.Type != CatletDriveType.VHDSet)
+            return Optional(driveConfig.Type).IfNone(CatletDriveType.VHD) switch
             {
-                VMDriveStorageSettings result;
-                if (driveConfig.Type == CatletDriveType.DVD)
-                    result = new VMDvDStorageSettings
-                    {
-                        ControllerNumber = controllerNumber,
-                        ControllerLocation = controllerLocation,
-                        Type = CatletDriveType.DVD,
-                        Path = driveConfig.Source,
-                    };
-                else
-                    result = new VMDriveStorageSettings
-                    {
-                        ControllerNumber = controllerNumber,
-                        ControllerLocation = controllerLocation,
-                        Type = driveConfig.Type.GetValueOrDefault(CatletDriveType.PHD)
-                    };
+                CatletDriveType.DVD => new VMDvDStorageSettings
+                {
+                    ControllerNumber = controllerNumber,
+                    ControllerLocation = controllerLocation,
+                    Type = CatletDriveType.DVD,
+                    Path = driveConfig.Source,
+                },
+                CatletDriveType.VHD or CatletDriveType.SharedVHD or CatletDriveType.VHDSet =>
+                    FromVhdDriveConfig(vmHostAgentConfig, storageSettings, driveConfig,
+                        getVhdInfo, controllerNumber, controllerLocation),
+                _ => LeftAsync<Error, VMDriveStorageSettings>(Error.New(
+                    $"The drive type {driveConfig.Type} is not supported")),
+            };
+        }
 
-                return RightAsync<Error, VMDriveStorageSettings>(result);
-            }
+        private static EitherAsync<Error, VMDriveStorageSettings> FromVhdDriveConfig(
+            VmHostAgentConfiguration vmHostAgentConfig,
+            VMStorageSettings storageSettings,
+            CatletDriveConfig driveConfig,
+            Func<string, EitherAsync<Error, Option<VhdInfo>>> getVhdInfo,
+            int controllerNumber,
+            int controllerLocation)
+        {
+            var driveStorageNames = new StorageNames
+            {
+                ProjectName = storageSettings.StorageNames.ProjectName,
+                EnvironmentName = storageSettings.StorageNames.EnvironmentName,
+                DataStoreName = Optional(driveConfig.Store).Filter(notEmpty).IfNone("default"),
+            };
 
-            //so far for the simple part, now the complicated case - a vhd disk...
-
-            var projectName = storageSettings.StorageNames.ProjectName;
-            var environmentName = storageSettings.StorageNames.EnvironmentName;
-            var dataStoreName = Optional(driveConfig.Store).Filter(notEmpty).IfNone("default");
             var storageIdentifier = Optional(driveConfig.Location).Filter(notEmpty).Match(
                 Some: s => s,
                 None: storageSettings.StorageIdentifier);
 
-            var names = new StorageNames
-            {
-                ProjectName = projectName,
-                EnvironmentName = environmentName,
-                DataStoreName = dataStoreName
-            };
-
             return
-                from resolvedPath in names.ResolveVolumeStorageBasePath(vmHostAgentConfig)
+                from resolvedPath in driveStorageNames.ResolveVolumeStorageBasePath(vmHostAgentConfig)
                 from identifier in storageIdentifier.ToEitherAsync(
                     Error.New($"Unexpected missing storage identifier for disk '{driveConfig.Name}'."))
-                let fileName = driveConfig.Type == CatletDriveType.VHDSet ? $"{driveConfig.Name}.vhds" : $"{driveConfig.Name}.vhdx"
+                let fileName = driveConfig.Type == CatletDriveType.VHDSet
+                    ? $"{driveConfig.Name}.vhds"
+                    : $"{driveConfig.Name}.vhdx"
                 let attachPath = Path.Combine(resolvedPath, identifier, fileName)
                 let configuredSize = Optional(driveConfig.Size).Filter(notDefault).Map(s => s * 1024L * 1024 * 1024)
                 from vhdInfo in getVhdInfo(attachPath)
@@ -96,7 +93,7 @@ namespace Eryph.VmManagement.Storage
                 let vhdSize = vhdInfo.Map(i => i.Size)
                 from parentOptions in match(
                     Optional(driveConfig.Source).Filter(notEmpty),
-                    Some: src => 
+                    Some: src =>
                         from dss in DiskStorageSettings.FromSourceString(vmHostAgentConfig, src)
                             .ToEitherAsync(Error.New("The catlet drive source is invalid"))
                         select Some(dss),
@@ -122,13 +119,14 @@ namespace Eryph.VmManagement.Storage
                     AttachPath = attachPath,
                     DiskSettings = new DiskStorageSettings
                     {
-                        StorageNames = names,
+                        StorageNames = driveStorageNames,
                         StorageIdentifier = storageIdentifier,
                         ParentSettings = parentOptions,
                         Path = Path.Combine(resolvedPath, identifier),
                         FileName = fileName,
                         Name = driveConfig.Name,
-                        SizeBytesCreate = (configuredSize | parentVhdInfo.Map(i => i.Size)).IfNone(1 * 1024L * 1024 * 1024),
+                        SizeBytesCreate = (configuredSize | parentVhdInfo.Map(i => i.Size))
+                            .IfNone(1 * 1024L * 1024 * 1024),
                         SizeBytes = configuredSize.IsSome ? configuredSize.ValueUnsafe() : null,
                     },
                     ControllerNumber = controllerNumber,

--- a/src/core/src/Eryph.VmManagement/Storage/VMDriveStorageSettings.cs
+++ b/src/core/src/Eryph.VmManagement/Storage/VMDriveStorageSettings.cs
@@ -86,7 +86,7 @@ namespace Eryph.VmManagement.Storage
                 from resolvedPath in names.ResolveVolumeStorageBasePath(vmHostAgentConfig)
                 from identifier in storageIdentifier.ToEitherAsync(
                     Error.New($"Unexpected missing storage identifier for disk '{driveConfig.Name}'."))
-                let fileName = $"{driveConfig.Name}.vhdx"
+                let fileName = driveConfig.Type == CatletDriveType.SharedVHD ? $"{driveConfig.Name}.vhds" : $"{driveConfig.Name}.vhdx"
                 let attachPath = Path.Combine(resolvedPath, identifier, fileName)
                 let configuredSize = Optional(driveConfig.Size).Filter(notDefault).Map(s => s * 1024L * 1024 * 1024)
                 from vhdInfo in getVhdInfo(attachPath)

--- a/src/core/src/Eryph.VmManagement/Storage/VMDriveStorageSettings.cs
+++ b/src/core/src/Eryph.VmManagement/Storage/VMDriveStorageSettings.cs
@@ -44,7 +44,7 @@ namespace Eryph.VmManagement.Storage
             var controllerLocation = index;
 
             //if it is not a vhd, we only need controller settings
-            if (driveConfig.Type.HasValue && driveConfig.Type != CatletDriveType.VHD)
+            if (driveConfig.Type.HasValue && driveConfig.Type != CatletDriveType.VHD && driveConfig.Type != CatletDriveType.SharedVHD)
             {
                 VMDriveStorageSettings result;
                 if (driveConfig.Type == CatletDriveType.DVD)
@@ -116,7 +116,7 @@ namespace Eryph.VmManagement.Storage
                     Error.New("Disk size is below minimum size of the virtual disk"))
                 let planned = new HardDiskDriveStorageSettings
                 {
-                    Type = CatletDriveType.VHD,
+                    Type = driveConfig.Type.GetValueOrDefault(),
                     AttachPath = attachPath,
                     DiskSettings = new DiskStorageSettings
                     {

--- a/src/core/src/Eryph.VmManagement/TypedPsObjectMapping.cs
+++ b/src/core/src/Eryph.VmManagement/TypedPsObjectMapping.cs
@@ -101,6 +101,7 @@ public class TypedPsObjectMapping : ITypedPsObjectMapping
                         c.AddHyperVMapping<VMFirmwareInfo>(hyperVAssembly, "VMFirmware");
 
                         c.AddHyperVMapping<VMSwitchExtension>(hyperVAssembly, "VMSwitchExtension");
+                        c.AddHyperVMapping<VhdInfo>(hyperVAssembly, "VirtualHardDisk");
                         c.AddHyperVMapping<VMSystemSwitchExtension>(hyperVAssembly, "VMSystemSwitchExtension");
                     }
 

--- a/src/core/test/Eryph.VmManagement.Test/ConvergeDriveTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/ConvergeDriveTests.cs
@@ -487,7 +487,7 @@ namespace Eryph.VmManagement.Test
                 attachCommand?.ShouldBeCommand("Add-VMHardDiskDrive")
                     .ShouldBeParam("VM", vmData.PsObject)
                     .ShouldBeParam("Path", $@"x:\disks\abc\{diskName}")
-                    .ShouldBeFlag("ShareVirtualDisk");
+                    .ShouldBeFlag("SupportPersistentReservations");
             }
             else
             {

--- a/src/core/test/Eryph.VmManagement.Test/ConvergeDriveTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/ConvergeDriveTests.cs
@@ -23,8 +23,6 @@ namespace Eryph.VmManagement.Test
         [InlineData(0, 40, 40)]
         [InlineData(40,30, 40)]
         [InlineData(50, 30, 50)]
-        [InlineData(20, 30, 20)]
-
         public async Task Converges_existing_disk(int? configSize, int currentSize, int newSize)
         {
             _fixture.Config.Drives = new[] { new CatletDriveConfig { Name = "sda" , Size = configSize} };
@@ -32,7 +30,7 @@ namespace Eryph.VmManagement.Test
             {
                 DefaultVhdPath = @"x:\disks\abc",
                 StorageIdentifier = "abc",
-                StorageNames = StorageNames.FromVmPath(@"x:\data\eryph\abc", _fixture.VmHostAgentConfiguration).Names
+                StorageNames = StorageNames.FromVmPath(@"x:\data\abc", _fixture.VmHostAgentConfiguration).Names
             };
 
 
@@ -97,10 +95,6 @@ namespace Eryph.VmManagement.Test
             vhdCommand?.ShouldBeCommand("Resize-VHD")
                 .ShouldBeParam("Path", "x:\\disks\\abc\\sda.vhdx")
                 .ShouldBeParam("SizeBytes", newSize*1024L*1024*1024);
-
-            //vhdCommand?.ShouldBeScript("New-VHD -Path \"x:\\disks\\abc\\sdb.vhdx\" -Dynamic -SizeBytes 1073741824");
-
-
         }
 
         [Fact]
@@ -111,7 +105,7 @@ namespace Eryph.VmManagement.Test
             {
                 DefaultVhdPath = @"x:\disks\abc",
                 StorageIdentifier = "abc",
-                StorageNames = StorageNames.FromVmPath(@"x:\data\eryph\abc", _fixture.VmHostAgentConfiguration).Names
+                StorageNames = StorageNames.FromVmPath(@"x:\data\abc", _fixture.VmHostAgentConfiguration).Names
             };
 
 
@@ -183,12 +177,103 @@ namespace Eryph.VmManagement.Test
             _ = (await convergeTask.Converge(vmData)).IfLeft(l=>l.Throw());
 
             vhdCommand.Should().NotBeNull();
-            vhdCommand?.ShouldBeScript("New-VHD -Path \"x:\\disks\\abc\\sdb.vhdx\" -Dynamic -SizeBytes 1073741824");
+            vhdCommand?.ShouldBeCommand("New-VHD")
+                .ShouldBeParam("Path", @"x:\disks\abc\sdb.vhdx")
+                .ShouldBeFlag("Dynamic")
+                .ShouldBeParam("SizeBytes", 1073741824);
 
             attachCommand.Should().NotBeNull();
             attachCommand?.ShouldBeCommand("Add-VMHardDiskDrive")
-                .ShouldBeParam("VM", vmData.PsObject).ShouldBeParam("Path", "x:\\disks\\abc\\sdb.vhdx");
+                .ShouldBeParam("VM", vmData.PsObject)
+                .ShouldBeParam("Path", @"x:\disks\abc\sdb.vhdx");
         }
 
+        [Fact]
+        public async Task Converges_new_disk_with_genepool_parent()
+        {
+            _fixture.Config.Drives = new[]
+            {
+                new CatletDriveConfig { Name = "sda", Source = "gene:testorg/testset/testtag:sda" }
+            };
+            _fixture.StorageSettings = _fixture.StorageSettings with
+            {
+                DefaultVhdPath = @"x:\disks\abc",
+                StorageIdentifier = "abc",
+                StorageNames = StorageNames.FromVmPath(@"x:\data\abc", _fixture.VmHostAgentConfiguration).Names
+            };
+
+            var vmData = _fixture.Engine.ToPsObject(new Data.Full.VirtualMachineInfo
+            {
+                Id = new Guid(),
+            });
+
+            AssertCommand? vhdCommand = null;
+            AssertCommand? attachCommand = null;
+
+            _fixture.Engine.RunCallback = command =>
+            {
+                if (command.ToString().Contains("CheckpointType"))
+                {
+                    command.ShouldBeCommand("Set-VM")
+                        .ShouldBeParam("VM", vmData.PsObject)
+                        .ShouldBeParam("CheckpointType");
+                }
+
+                if (command.ToString().Contains("New-VHD")) vhdCommand = command;
+
+                return Unit.Default;
+            };
+
+            _fixture.Engine.GetObjectCallback = (type, command) =>
+            {
+                var commandString = command.ToString();
+                if (commandString.Contains("Get-VM"))
+                    return new[] { _fixture.Engine.ToPsObject<object>(vmData.Value) }.ToSeq();
+
+                if (commandString.Contains(@"Test-Path [x:\disks\abc\sda.vhdx]"))
+                    return new[] { _fixture.Engine.ToPsObject<object>(false) }.ToSeq();
+
+
+                if (commandString.Contains("Get-VHD"))
+                    return new[] { _fixture.Engine.ToPsObject<object>(new VhdInfo
+                    {
+                        Path =  @"x:\disks\abc\sda.vhdx",
+                        Size = 1073741824
+                    }) }.ToSeq();
+
+                if (command.ToString().Contains("Add-VMHardDiskDrive"))
+                {
+                    attachCommand = command;
+                    var res = new HardDiskDriveInfo
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        ControllerLocation = 0,
+                        ControllerNumber = 0,
+                        ControllerType = ControllerType.SCSI,
+                        Path = @"x:\disks\abc\sda.vhdx"
+                    };
+
+                    return new[] { _fixture.Engine.ToPsObject<object>(res) }.ToSeq();
+                }
+
+
+                return new PowershellFailure { Message = $"unknown command: {commandString}" };
+            };
+
+            var convergeTask = new ConvergeDrives(_fixture.Context);
+            _ = (await convergeTask.Converge(vmData)).IfLeft(l => l.Throw());
+
+            vhdCommand.Should().NotBeNull();
+            vhdCommand!.ShouldBeCommand("New-VHD")
+                .ShouldBeParam("Path", @"x:\disks\abc\sda.vhdx")
+                .ShouldBeParam("ParentPath", @"x:\disks\genepool\testorg\testset\testtag\volumes\sda.vhdx")
+                .ShouldBeFlag("Differencing")
+                .ShouldBeParam("SizeBytes", 1073741824);
+
+            attachCommand.Should().NotBeNull();
+            attachCommand?.ShouldBeCommand("Add-VMHardDiskDrive")
+                .ShouldBeParam("VM", vmData.PsObject)
+                .ShouldBeParam("Path", @"x:\disks\abc\sda.vhdx");
+        }
     }
 }

--- a/src/core/test/Eryph.VmManagement.Test/Storage/VMDriveStorageSettingsTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/Storage/VMDriveStorageSettingsTests.cs
@@ -43,7 +43,7 @@ public class VMDriveStorageSettingsTests
     };
 
     [Fact]
-    public void PlanDriveStorageSettings_MultipleDrives_DrivesHaveCorrectControllerLocations()
+    public async Task PlanDriveStorageSettings_MultipleDrives_DrivesHaveCorrectControllerLocations()
     {
         var config = new CatletConfig
         {
@@ -75,7 +75,7 @@ public class VMDriveStorageSettingsTests
         _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
             .Returns(RightAsync<Error, Option<VhdInfo>>(None));
 
-        var result = VMDriveStorageSettings.PlanDriveStorageSettings(
+        var result = await VMDriveStorageSettings.PlanDriveStorageSettings(
             _vmHostAgentConfiguration, config, _storageSettings, _getVhdInfoMock.Object);
 
 

--- a/src/core/test/Eryph.VmManagement.Test/Storage/VMDriveStorageSettingsTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/Storage/VMDriveStorageSettingsTests.cs
@@ -1,0 +1,384 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Eryph.ConfigModel.Catlets;
+using Eryph.Core.VmAgent;
+using Eryph.VmManagement.Data.Core;
+using Eryph.VmManagement.Storage;
+using FluentAssertions;
+using FluentAssertions.LanguageExt;
+using LanguageExt;
+using LanguageExt.Common;
+using Moq;
+using Xunit;
+
+using static LanguageExt.Prelude;
+
+namespace Eryph.VmManagement.Test.Storage;
+
+public class VMDriveStorageSettingsTests
+{
+    private readonly Mock<Func<string, EitherAsync<Error, Option<VhdInfo>>>> _getVhdInfoMock = new();
+
+    private readonly VmHostAgentConfiguration _vmHostAgentConfiguration = new()
+    {
+        Defaults = new()
+        {
+            Vms = @"x:\data",
+            Volumes = @"x:\disks",
+        }
+    };
+
+    private readonly VMStorageSettings _storageSettings = new()
+    {
+        StorageIdentifier = Some("storage-id-vm"),
+        StorageNames = new()
+        {
+            DataStoreName = Some("default"),
+            EnvironmentName = Some("default"),
+            ProjectName = Some("default"),
+        },
+    };
+
+    [Fact]
+    public void PlanDriveStorageSettings_MultipleDrives_DrivesHaveCorrectControllerLocations()
+    {
+        var config = new CatletConfig
+        {
+            Drives = new[]
+            {
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.VHD,
+                    Name = "sda",
+                },
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.DVD,
+                    Source = @"x:\dvds\disk1.iso",
+                },
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.VHD,
+                    Name = "sdb",
+                },
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.DVD,
+                    Source = @"x:\dvds\disk2.iso",
+                },
+            }
+        };
+
+        _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(None));
+
+        var result = VMDriveStorageSettings.PlanDriveStorageSettings(
+            _vmHostAgentConfiguration, config, _storageSettings, _getVhdInfoMock.Object);
+
+
+        result.Should().BeRight().Which.Should().SatisfyRespectively(
+            dss =>
+            {
+                dss.ControllerNumber.Should().Be(0);
+                dss.ControllerLocation.Should().Be(0);
+                dss.Should().BeOfType<HardDiskDriveStorageSettings>()
+                    .Which.DiskSettings.FileName.Should().Be("sda.vhdx");
+            },
+            dss =>
+            {
+                dss.ControllerNumber.Should().Be(0);
+                dss.ControllerLocation.Should().Be(1);
+                dss.Should().BeOfType<VMDvDStorageSettings>()
+                    .Which.Path.Should().Be(@"x:\dvds\disk1.iso");
+            },
+            dss =>
+            {
+                dss.ControllerNumber.Should().Be(0);
+                dss.ControllerLocation.Should().Be(2);
+                dss.Should().BeOfType<HardDiskDriveStorageSettings>()
+                    .Which.DiskSettings.FileName.Should().Be("sdb.vhdx");
+            },
+            dss =>
+            {
+                dss.ControllerNumber.Should().Be(0);
+                dss.ControllerLocation.Should().Be(3);
+                dss.Should().BeOfType<VMDvDStorageSettings>()
+                    .Which.Path.Should().Be(@"x:\dvds\disk2.iso");
+            });
+    }
+
+    [Fact]
+    public async Task PlanDriveStorageSettings_NewDiskWithoutConfiguredSizeAndWithParent_UsesParentSize()
+    {
+        var config = new CatletConfig
+        {
+            Drives = new[]
+            {
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.VHD,
+                    Name = "sda",
+                    Source = "gene:testorg/testset/testtag:sda",
+                },
+            }
+        };
+
+        _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(None));
+
+        _getVhdInfoMock.Setup(m => m(@"x:\disks\genepool\testorg\testset\testtag\volumes\sda.vhdx"))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(new VhdInfo()
+            {
+                Size = 42,
+            }));
+
+        var result = await VMDriveStorageSettings.PlanDriveStorageSettings(
+                       _vmHostAgentConfiguration, config, _storageSettings, _getVhdInfoMock.Object);
+
+        result.Should().BeRight().Which.Should().SatisfyRespectively(
+            dss =>
+            {
+                dss.Type.Should().Be(CatletDriveType.VHD);
+                dss.ControllerNumber.Should().Be(0);
+                dss.ControllerLocation.Should().Be(0);
+                
+                var settings = dss.Should().BeOfType<HardDiskDriveStorageSettings>().Subject;
+                settings.AttachPath.Should().Be(@"x:\disks\storage-id-vm\sda.vhdx");
+                settings.DiskSettings.SizeBytes.Should().BeNull();
+                settings.DiskSettings.SizeBytesCreate.Should().Be(42);
+
+                AssertParent(settings.DiskSettings.ParentSettings);
+            });
+    }
+
+    [Fact]
+    public async Task PlanDriveStorageSettings_NewDiskWithoutConfiguredSizeAndWithoutParent_UsesDefaultSize()
+    {
+        var config = new CatletConfig
+        {
+            Drives = new[]
+            {
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.VHD,
+                    Name = "sda",
+                },
+            }
+        };
+
+        _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(None));
+
+        var result = await VMDriveStorageSettings.PlanDriveStorageSettings(
+            _vmHostAgentConfiguration, config, _storageSettings, _getVhdInfoMock.Object);
+
+        result.Should().BeRight().Which.Should().SatisfyRespectively(
+            dss =>
+            {
+                dss.Type.Should().Be(CatletDriveType.VHD);
+                dss.ControllerNumber.Should().Be(0);
+                dss.ControllerLocation.Should().Be(0);
+
+                var settings = dss.Should().BeOfType<HardDiskDriveStorageSettings>().Subject;
+                settings.AttachPath.Should().Be(@"x:\disks\storage-id-vm\sda.vhdx");
+                settings.DiskSettings.SizeBytes.Should().BeNull();
+                settings.DiskSettings.SizeBytesCreate.Should().Be(1*1024L*1024*1024);
+
+                settings.DiskSettings.ParentSettings.Should().BeNone();
+            });
+    }
+
+    [Fact]
+    public async Task PlanDriveStorageSettings_NewDiskWithConfiguredSizeAndWithoutParent_UsesConfiguredSize()
+    {
+        var config = new CatletConfig
+        {
+            Drives = new[]
+            {
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.VHD,
+                    Name = "sda",
+                    Size = 42,
+                },
+            }
+        };
+
+        _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(None));
+
+        var result = await VMDriveStorageSettings.PlanDriveStorageSettings(
+            _vmHostAgentConfiguration, config, _storageSettings, _getVhdInfoMock.Object);
+
+        result.Should().BeRight().Which.Should().SatisfyRespectively(
+            dss =>
+            {
+                dss.Type.Should().Be(CatletDriveType.VHD);
+                dss.ControllerNumber.Should().Be(0);
+                dss.ControllerLocation.Should().Be(0);
+
+                var settings = dss.Should().BeOfType<HardDiskDriveStorageSettings>().Subject;
+                settings.AttachPath.Should().Be(@"x:\disks\storage-id-vm\sda.vhdx");
+                settings.DiskSettings.SizeBytes.Should().Be(42 * 1024L * 1024 * 1024);
+                settings.DiskSettings.SizeBytesCreate.Should().Be(42 * 1024L * 1024 * 1024);
+
+                settings.DiskSettings.ParentSettings.Should().BeNone();
+            });
+    }
+
+    [Fact]
+    public async Task PlanDriveStorageSettings_NewDiskWithConfiguredSizeAndWithSmallerParent_UsesConfiguredSize()
+    {
+        var config = new CatletConfig
+        {
+            Drives = new[]
+            {
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.VHD,
+                    Name = "sda",
+                    Source = "gene:testorg/testset/testtag:sda",
+                    Size = 42,
+                },
+            }
+        };
+
+        _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(None));
+
+        _getVhdInfoMock.Setup(m => m(@"x:\disks\genepool\testorg\testset\testtag\volumes\sda.vhdx"))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(new VhdInfo()
+            {
+                Size = 40 * 1024L * 1024 * 1024,
+            }));
+
+        var result = await VMDriveStorageSettings.PlanDriveStorageSettings(
+            _vmHostAgentConfiguration, config, _storageSettings, _getVhdInfoMock.Object);
+
+        result.Should().BeRight().Which.Should().SatisfyRespectively(
+            dss =>
+            {
+                dss.Type.Should().Be(CatletDriveType.VHD);
+                dss.ControllerNumber.Should().Be(0);
+                dss.ControllerLocation.Should().Be(0);
+
+                var settings = dss.Should().BeOfType<HardDiskDriveStorageSettings>().Subject;
+                settings.AttachPath.Should().Be(@"x:\disks\storage-id-vm\sda.vhdx");
+                settings.DiskSettings.SizeBytes.Should().Be(42 * 1024L * 1024 * 1024);
+                settings.DiskSettings.SizeBytesCreate.Should().Be(42 * 1024L * 1024 * 1024);
+
+                AssertParent(settings.DiskSettings.ParentSettings);
+            });
+    }
+
+    [Fact]
+    public async Task PlanDriveStorageSettings_NewDiskWithConfiguredSizeAndWithLargerParent_Fails()
+    {
+        var config = new CatletConfig
+        {
+            Drives = new[]
+            {
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.VHD,
+                    Name = "sda",
+                    Source = "gene:testorg/testset/testtag:sda",
+                    Size = 42,
+                },
+            }
+        };
+
+        _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(None));
+
+        _getVhdInfoMock.Setup(m => m(@"x:\disks\genepool\testorg\testset\testtag\volumes\sda.vhdx"))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(new VhdInfo()
+            {
+                Size = 50 * 1024L * 1024 * 1024,
+            }));
+
+        var result = await VMDriveStorageSettings.PlanDriveStorageSettings(
+            _vmHostAgentConfiguration, config, _storageSettings, _getVhdInfoMock.Object);
+
+        result.Should().BeLeft().Which.Message.Should().Be("Disk size is below minimum size of the virtual disk");
+    }
+
+    [Fact]
+    public async Task PlanDriveStorageSettings_ExistingDiskWithConfiguredSizeTooSmall_Fails()
+    {
+        var config = new CatletConfig
+        {
+            Drives = new[]
+            {
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.VHD,
+                    Name = "sda",
+                    Size = 42,
+                },
+            }
+        };
+
+        _getVhdInfoMock.Setup(m => m(@"x:\disks\storage-id-vm\sda.vhdx"))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(new VhdInfo()
+            {
+                Size = 50 * 1024L * 1024 * 1024,
+            }));
+
+        var result = await VMDriveStorageSettings.PlanDriveStorageSettings(
+            _vmHostAgentConfiguration, config, _storageSettings, _getVhdInfoMock.Object);
+
+        result.Should().BeLeft().Which.Message.Should().Be("Disk size is below minimum size of the virtual disk");
+    }
+
+    [Fact]
+    public async Task PlanDriveStorageSettings_ExistingDiskWithConfiguredSizeLarger_UsesConfiguredSize()
+    {
+        var config = new CatletConfig
+        {
+            Drives = new[]
+            {
+                new CatletDriveConfig
+                {
+                    Type = CatletDriveType.VHD,
+                    Name = "sda",
+                    Size = 42,
+                },
+            }
+        };
+
+        _getVhdInfoMock.Setup(m => m(@"x:\disks\storage-id-vm\sda.vhdx"))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(new VhdInfo()
+            {
+                Size = 40 * 1024L * 1024 * 1024,
+            }));
+
+        var result = await VMDriveStorageSettings.PlanDriveStorageSettings(
+            _vmHostAgentConfiguration, config, _storageSettings, _getVhdInfoMock.Object);
+
+        result.Should().BeRight().Which.Should().SatisfyRespectively(
+            dss =>
+            {
+                dss.Type.Should().Be(CatletDriveType.VHD);
+                dss.ControllerNumber.Should().Be(0);
+                dss.ControllerLocation.Should().Be(0);
+
+                var settings = dss.Should().BeOfType<HardDiskDriveStorageSettings>().Subject;
+                settings.AttachPath.Should().Be(@"x:\disks\storage-id-vm\sda.vhdx");
+                settings.DiskSettings.SizeBytes.Should().Be(42 * 1024L * 1024 * 1024);
+                settings.DiskSettings.SizeBytesCreate.Should().Be(42 * 1024L * 1024 * 1024);
+
+                settings.DiskSettings.ParentSettings.Should().BeNone();
+            });
+    }
+
+    private void AssertParent(Option<DiskStorageSettings> parentSettings)
+    {
+        var settings = parentSettings.Should().BeSome().Subject;
+        settings.Path.Should().Be(@"x:\disks\genepool\testorg\testset\testtag\volumes");
+        settings.Name.Should().Be("sda");
+    }
+}

--- a/src/core/test/Eryph.VmManagement.Test/Storage/VMDriveStorageSettingsTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/Storage/VMDriveStorageSettingsTests.cs
@@ -69,7 +69,7 @@ public class VMDriveStorageSettingsTests
                     Type = CatletDriveType.DVD,
                     Source = @"x:\dvds\disk2.iso",
                 },
-            }
+            },
         };
 
         _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
@@ -110,6 +110,45 @@ public class VMDriveStorageSettingsTests
             });
     }
 
+    [Theory]
+    [InlineData(CatletDriveType.VHD, ".vhdx")]
+    [InlineData(CatletDriveType.SharedVHD, ".vhdx")]
+    [InlineData(CatletDriveType.VHDSet, ".vhds")]
+    public async Task PlanDriveStorageSettings_UsesCorrectExtensionForVhdType(
+        CatletDriveType driveType,
+        string expectedExtension)
+    {
+        var config = new CatletConfig
+        {
+            Drives = new[]
+            {
+                new CatletDriveConfig
+                {
+                    Type = driveType,
+                    Name = "sda",
+                },
+            },
+        };
+
+        _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
+            .Returns(RightAsync<Error, Option<VhdInfo>>(None));
+
+        var result = await VMDriveStorageSettings.PlanDriveStorageSettings(
+            _vmHostAgentConfiguration, config, _storageSettings, _getVhdInfoMock.Object);
+
+        result.Should().BeRight().Which.Should().SatisfyRespectively(
+            dss =>
+            {
+                dss.ControllerNumber.Should().Be(0);
+                dss.ControllerLocation.Should().Be(0);
+
+                var hdss = dss.Should().BeOfType<HardDiskDriveStorageSettings>().Subject;
+                hdss.AttachPath.Should().Be($@"x:\disks\storage-id-vm\sda{expectedExtension}");
+                hdss.DiskSettings.FileName.Should().Be($"sda{expectedExtension}");
+                hdss.DiskSettings.Path.Should().Be(@"x:\disks\storage-id-vm");
+            });
+    }
+
     [Fact]
     public async Task PlanDriveStorageSettings_NewDiskWithoutConfiguredSizeAndWithParent_UsesParentSize()
     {
@@ -123,7 +162,7 @@ public class VMDriveStorageSettingsTests
                     Name = "sda",
                     Source = "gene:testorg/testset/testtag:sda",
                 },
-            }
+            },
         };
 
         _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
@@ -166,7 +205,7 @@ public class VMDriveStorageSettingsTests
                     Type = CatletDriveType.VHD,
                     Name = "sda",
                 },
-            }
+            },
         };
 
         _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
@@ -204,7 +243,7 @@ public class VMDriveStorageSettingsTests
                     Name = "sda",
                     Size = 42,
                 },
-            }
+            },
         };
 
         _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
@@ -243,7 +282,7 @@ public class VMDriveStorageSettingsTests
                     Source = "gene:testorg/testset/testtag:sda",
                     Size = 42,
                 },
-            }
+            },
         };
 
         _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
@@ -288,7 +327,7 @@ public class VMDriveStorageSettingsTests
                     Source = "gene:testorg/testset/testtag:sda",
                     Size = 42,
                 },
-            }
+            },
         };
 
         _getVhdInfoMock.Setup(m => m(It.IsAny<string>()))
@@ -319,7 +358,7 @@ public class VMDriveStorageSettingsTests
                     Name = "sda",
                     Size = 42,
                 },
-            }
+            },
         };
 
         _getVhdInfoMock.Setup(m => m(@"x:\disks\storage-id-vm\sda.vhdx"))
@@ -347,7 +386,7 @@ public class VMDriveStorageSettingsTests
                     Name = "sda",
                     Size = 42,
                 },
-            }
+            },
         };
 
         _getVhdInfoMock.Setup(m => m(@"x:\disks\storage-id-vm\sda.vhdx"))

--- a/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
@@ -15,7 +15,7 @@
 
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
 
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.2.1-ci.1" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.0" />
 
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
@@ -15,7 +15,7 @@
 
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
 
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.2.0" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.2.1-ci.1" />
 
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Improve the creation of virtual disks:
- Set the correct disk size when creating differential disks
- Add support for shared VHDs and VHD sets
- Improve the validation in the planning step

Prerequisites:
- https://github.com/eryph-org/dotnet-configmodel/pull/47