### PR TITLE
Server 2016 comp.: check capabilities of Set-VM

### DIFF
--- a/src/core/src/Eryph.VmManagement/Data/Full/PowershellCommand.cs
+++ b/src/core/src/Eryph.VmManagement/Data/Full/PowershellCommand.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Management.Automation;
+
+namespace Eryph.VmManagement.Data.Full;
+
+public class PowershellCommand
+{
+
+    /// <summary>Gets the name of the command.</summary>
+    public string Name { get; init; }
+
+    
+    /// <summary>Return the parameters for this command.</summary>
+    public virtual Dictionary<string, ParameterMetadata> Parameters { get; init; }
+
+
+
+}

--- a/src/core/src/Eryph.VmManagement/TypedPsObjectMapping.cs
+++ b/src/core/src/Eryph.VmManagement/TypedPsObjectMapping.cs
@@ -51,6 +51,11 @@ public class TypedPsObjectMapping : ITypedPsObjectMapping
 
             var config = new MapperConfiguration(cfg =>
             {
+                cfg.CreateProfile("Powershell", c =>
+                {
+                    c.CreateMap<CommandInfo, PowershellCommand>();
+                });
+
                 cfg.CreateProfile("HyperV", c =>
                 {
                     var hyperVAssemblies = GetHyperVAssemblies();
@@ -96,7 +101,7 @@ public class TypedPsObjectMapping : ITypedPsObjectMapping
                         c.AddHyperVMapping<VMFirmwareInfo>(hyperVAssembly, "VMFirmware");
 
                         c.AddHyperVMapping<VMSwitchExtension>(hyperVAssembly, "VMSwitchExtension");
-
+                        
                     }
 
                     c.IgnoreUnmapped(_logger);


### PR DESCRIPTION
Not all parameters of Set-VM command are available on winserver 2016. Updated SetDefaults to set only supported parameters.

fixes #136 