### PR TITLE
update rebus extensions to 0.5.3

### DIFF
--- a/src/modules/src/Eryph.ModuleCore/Eryph.ModuleCore.csproj
+++ b/src/modules/src/Eryph.ModuleCore/Eryph.ModuleCore.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dbosoft.Hosuto" Version="1.1.0" />
-    <PackageReference Include="Dbosoft.Rebus.Operations.SimpleInjector" Version="0.5.2" />
+    <PackageReference Include="Dbosoft.Rebus.Operations.SimpleInjector" Version="0.5.3" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
fixes issue dbosoft/rebus-extensions#8 - Subtasks failure is not always processed in parent tasks 