### PR TITLE
Add support for VLANs

### DIFF
--- a/Eryph.sln.DotSettings
+++ b/Eryph.sln.DotSettings
@@ -29,4 +29,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=realizer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Uninstallation/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Virtualization/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Vlan/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Workflows/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/core/src/Eryph.Core/Network/BridgeHostIpMode.cs
+++ b/src/core/src/Eryph.Core/Network/BridgeHostIpMode.cs
@@ -1,0 +1,7 @@
+﻿namespace Eryph.Core.Network;
+
+public enum BridgeHostIpMode
+{
+    Disabled,
+    Dhcp
+}

--- a/src/core/src/Eryph.Core/Network/BridgeVlanMode.cs
+++ b/src/core/src/Eryph.Core/Network/BridgeVlanMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Eryph.Core.Network;
+
+public enum BridgeVlanMode
+{
+    Invalid,
+    Access,
+    NativeUntagged,
+    NativeTagged
+}

--- a/src/core/src/Eryph.Core/Network/NetworkProvider.cs
+++ b/src/core/src/Eryph.Core/Network/NetworkProvider.cs
@@ -15,7 +15,8 @@ public class NetworkProvider
     public string BridgeName { get; set; }
     public string SwitchName { get; set; }
 
-    public NetworkProviderVLan Vlan { get; set; }
+    [YamlMember(Alias = "provider_vlan")]
+    public int? ProviderVLan { get; set; }
 
     public string[] Adapters { get; set; }
 
@@ -45,9 +46,9 @@ public class NetworkProvider
                from nonInvalidType in provider.Type == NetworkProviderType.Invalid
                    ? Prelude.Fail<Error, NetworkProvider>($"network_provider {provider.Name}: network provider type has to of value overlay, nat_overlay or flat")
                    : Prelude.Success<Error, NetworkProvider>(provider)
-                   let hasTag = provider.Vlan is { Tag: > 0 }
-                   from nonInvalidVlan in provider.Type == NetworkProviderType.NatOverLay && hasTag
-                          ? Prelude.Fail<Error, NetworkProvider>($"network_provider {provider.Name}: vlan tag is not supported for nat_overlay network providers")
+                   let hasProviderTag = provider.ProviderVLan > 0
+                   from nonInvalidProviderVlan in provider.Type == NetworkProviderType.NatOverLay && hasProviderTag
+                          ? Prelude.Fail<Error, NetworkProvider>($"network_provider {provider.Name}: provider vlan tag is not supported for nat_overlay network providers")
                           : Prelude.Success<Error, NetworkProvider>(provider)
                select provider;
 

--- a/src/core/src/Eryph.Core/Network/NetworkProvider.cs
+++ b/src/core/src/Eryph.Core/Network/NetworkProvider.cs
@@ -15,6 +15,8 @@ public class NetworkProvider
     public string BridgeName { get; set; }
     public string SwitchName { get; set; }
 
+    public NetworkProviderVLan Vlan { get; set; }
+
     public string[] Adapters { get; set; }
 
     public NetworkProviderSubnet[] Subnets { get; set; }
@@ -43,7 +45,12 @@ public class NetworkProvider
                from nonInvalidType in provider.Type == NetworkProviderType.Invalid
                    ? Prelude.Fail<Error, NetworkProvider>($"network_provider {provider.Name}: network provider type has to of value overlay, nat_overlay or flat")
                    : Prelude.Success<Error, NetworkProvider>(provider)
+                   let hasTag = provider.Vlan is { Tag: > 0 }
+                   from nonInvalidVlan in provider.Type == NetworkProviderType.NatOverLay && hasTag
+                          ? Prelude.Fail<Error, NetworkProvider>($"network_provider {provider.Name}: vlan tag is not supported for nat_overlay network providers")
+                          : Prelude.Success<Error, NetworkProvider>(provider)
                select provider;
 
     }
+
 }

--- a/src/core/src/Eryph.Core/Network/NetworkProvider.cs
+++ b/src/core/src/Eryph.Core/Network/NetworkProvider.cs
@@ -15,8 +15,9 @@ public class NetworkProvider
     public string BridgeName { get; set; }
     public string SwitchName { get; set; }
 
-    [YamlMember(Alias = "provider_vlan")]
-    public int? ProviderVLan { get; set; }
+    public int? Vlan { get; set; }
+
+    [CanBeNull] public NetworkProviderBridgeOptions BridgeOptions { get; set; }
 
     public string[] Adapters { get; set; }
 
@@ -46,7 +47,7 @@ public class NetworkProvider
                from nonInvalidType in provider.Type == NetworkProviderType.Invalid
                    ? Prelude.Fail<Error, NetworkProvider>($"network_provider {provider.Name}: network provider type has to of value overlay, nat_overlay or flat")
                    : Prelude.Success<Error, NetworkProvider>(provider)
-                   let hasProviderTag = provider.ProviderVLan > 0
+                   let hasProviderTag = provider.Vlan > 0
                    from nonInvalidProviderVlan in provider.Type == NetworkProviderType.NatOverLay && hasProviderTag
                           ? Prelude.Fail<Error, NetworkProvider>($"network_provider {provider.Name}: provider vlan tag is not supported for nat_overlay network providers")
                           : Prelude.Success<Error, NetworkProvider>(provider)

--- a/src/core/src/Eryph.Core/Network/NetworkProviderBridgeOptions.cs
+++ b/src/core/src/Eryph.Core/Network/NetworkProviderBridgeOptions.cs
@@ -1,0 +1,53 @@
+﻿using JetBrains.Annotations;
+using YamlDotNet.Serialization;
+
+namespace Eryph.Core.Network;
+
+public class NetworkProviderBridgeOptions
+{
+    // this is intentionally not named vlan to avoid confusion with the vlan of the provider
+    public int? BridgeVlan { get; set; }
+
+    [YamlMember(Alias = "vlan_mode")]
+    public string VLanModeString { get; set; }
+
+    [YamlIgnore] public BridgeVlanMode VLanMode => ParseVLanMode(VLanModeString);
+
+    public static BridgeVlanMode ParseVLanMode([CanBeNull] string modeString)
+    {
+        if (string.IsNullOrWhiteSpace(modeString))
+            return BridgeVlanMode.Invalid;
+
+        return modeString switch
+        {
+            "access" => BridgeVlanMode.Access,
+            "native_untagged" => BridgeVlanMode.NativeUntagged,
+            "native_tagged" => BridgeVlanMode.NativeTagged,
+            _ => BridgeVlanMode.Invalid
+    };
+    }
+
+    // the ip mode is only used when the bridge is created, therefore it is
+    // named default_ip_mode
+    [YamlMember(Alias = "default_ip_mode")]
+    public string DefaultIpModeString { get; set; }
+
+    [YamlIgnore] public BridgeHostIpMode DefaultIpMode => ParseHostIpMode(DefaultIpModeString);
+
+    public static BridgeHostIpMode ParseHostIpMode([CanBeNull] string modeString)
+    {
+        if (string.IsNullOrWhiteSpace(modeString))
+            return BridgeHostIpMode.Disabled;
+
+        return modeString switch
+        {
+            // for future use
+            //"static" => BridgeHostIpMode.Static,
+            "dhcp" => BridgeHostIpMode.Dhcp,
+            "disabled" => BridgeHostIpMode.Disabled,
+            _ => BridgeHostIpMode.Disabled
+        };
+    }
+
+
+}

--- a/src/core/src/Eryph.Core/Network/NetworkProviderVLan.cs
+++ b/src/core/src/Eryph.Core/Network/NetworkProviderVLan.cs
@@ -1,7 +1,0 @@
-﻿namespace Eryph.Core.Network;
-
-public class NetworkProviderVLan
-{
-    public int Tag { get; set; }
-
-}

--- a/src/core/src/Eryph.Core/Network/NetworkProviderVLan.cs
+++ b/src/core/src/Eryph.Core/Network/NetworkProviderVLan.cs
@@ -1,0 +1,7 @@
+﻿namespace Eryph.Core.Network;
+
+public class NetworkProviderVLan
+{
+    public int Tag { get; set; }
+
+}

--- a/src/core/src/Eryph.Core/Network/NetworkProvidersConfiguration.cs
+++ b/src/core/src/Eryph.Core/Network/NetworkProvidersConfiguration.cs
@@ -4,9 +4,6 @@ public class NetworkProvidersConfiguration
 {
     public NetworkProvider[] NetworkProviders { get; set; }
 
-    public string[] EnabledBridges { get; set; }
-
-
     public const string DefaultConfig = @"
 network_providers:
 - name: default

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-PullRequest0016.2" />
+    <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.2" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.1" />
+    <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-PullRequest0016.2" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.Controller/Networks/ProjectNetworkPlanBuilder.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Networks/ProjectNetworkPlanBuilder.cs
@@ -171,7 +171,7 @@ internal class ProjectNetworkPlanBuilder : IProjectNetworkPlanBuilder
             from provider in overlayProviders.Where(p => providerNames.Contains(p.Name))
             let p1 = networkPlan.AddSwitch($"externalNet-{networkPlan.Id}-{provider.Name}")
             let p2 = p1.AddExternalNetworkPort($"externalNet-{networkPlan.Id}-{provider.Name}",
-                provider.Name)
+                provider.Name, provider.ProviderVLan)
 
             select p2).Apply(s => JoinPlans(s, networkPlan));
     }

--- a/src/modules/src/Eryph.Modules.Controller/Networks/ProjectNetworkPlanBuilder.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Networks/ProjectNetworkPlanBuilder.cs
@@ -171,7 +171,7 @@ internal class ProjectNetworkPlanBuilder : IProjectNetworkPlanBuilder
             from provider in overlayProviders.Where(p => providerNames.Contains(p.Name))
             let p1 = networkPlan.AddSwitch($"externalNet-{networkPlan.Id}-{provider.Name}")
             let p2 = p1.AddExternalNetworkPort($"externalNet-{networkPlan.Id}-{provider.Name}",
-                provider.Name, provider.ProviderVLan)
+                provider.Name, provider.Vlan)
 
             select p2).Apply(s => JoinPlans(s, networkPlan));
     }

--- a/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
+++ b/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-PullRequest0016.2" />
+    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.2" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
+++ b/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.1" />
+    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-PullRequest0016.2" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-PullRequest0016.2" />
+    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.2" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.1.0-ci.22" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.1" />
+    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-PullRequest0016.2" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.1.0-ci.22" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Networks/HostNetworkCommands.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Networks/HostNetworkCommands.cs
@@ -77,7 +77,7 @@ public class HostNetworkCommands<RT> : IHostNetworkCommands<RT>
                     .AddCommand("Enable-NetAdapter"))
                 .ToAff());
 
-    public Aff<RT, Unit> ConfigureNATAdapter(string adapterName, IPAddress ipAddress, IPNetwork network)
+    public Aff<RT, Unit> ConfigureAdapterIp(string adapterName, IPAddress ipAddress, IPNetwork network)
     {
         var ipCommand = PsCommandBuilder.Create()
             .AddCommand("New-NetIPAddress")

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Networks/IHostNetworkCommands.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Networks/IHostNetworkCommands.cs
@@ -19,7 +19,7 @@ public interface IHostNetworkCommands<RT> where RT : struct, HasCancel<RT>
 
     Aff<RT, Seq<NetNat>> GetNetNat();
     Aff<RT, Unit> EnableBridgeAdapter(string adapterName);
-    Aff<RT, Unit> ConfigureNATAdapter(string adapterName, IPAddress ipAddress, IPNetwork network);
+    Aff<RT, Unit> ConfigureAdapterIp(string adapterName, IPAddress ipAddress, IPNetwork network);
     Aff<RT, Seq<TypedPsObject<VMNetworkAdapter>>> GetNetAdaptersBySwitch(Guid switchId);
     Aff<RT, Unit> DisconnectNetworkAdapters(Seq<TypedPsObject<VMNetworkAdapter>> adapters);
     Aff<RT, Unit> ReconnectNetworkAdapters(Seq<TypedPsObject<VMNetworkAdapter>> adapters, string switchName);

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Networks/NetworkChangeOperationNames.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Networks/NetworkChangeOperationNames.cs
@@ -26,6 +26,7 @@ public class NetworkChangeOperationNames
                 NetworkChangeOperation.RemoveNetNat => "Remove host NAT for provider {0}",
                 NetworkChangeOperation.RemoveAdapterPort => "Remove adapter '{0}' from bridge '{1}'",
                 NetworkChangeOperation.AddAdapterPort => "Add adapter '{0}' to bridge '{1}'",
+                NetworkChangeOperation.UpdateBridgePort => "Configure port options for bridge {0}",
                 NetworkChangeOperation.ConfigureNatIp => "Configure ip settings for NAT bridge '{0}'",
                 NetworkChangeOperation.UpdateBridgeMapping => "Update mapping of bridges to network providers",
                 NetworkChangeOperation.RemoveMissingBridge => "Host adapter '{0}' not found - removing bridge",

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Networks/NewBridge.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Networks/NewBridge.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
+using Eryph.Core.Network;
 
 namespace Eryph.Modules.VmHostAgent.Networks;
 
-public readonly record struct NewBridge(string BridgeName, IPAddress IPAddress, IPNetwork Network);
+public readonly record struct NewBridge(string BridgeName, IPAddress IPAddress, IPNetwork Network, NetworkProviderBridgeOptions? Options);

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Networks/OVS/BridgePort.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Networks/OVS/BridgePort.cs
@@ -9,8 +9,12 @@ public record BridgePort : OVSTableRecord, IOVSEntityWithName
         Columns = new Dictionary<string, OVSFieldMetadata>(OVSTableRecord.Columns)
         {
             { "name", OVSValue<string>.Metadata() },
+            { "tag", OVSValue<int>.Metadata() },
+            { "vlan_mode", OVSValue<string>.Metadata() },
         };
 
     public string Name => GetValue<string>("name");
+    public int? Tag => GetValue<int>("tag");
+    public string? VlanMode => GetValue<string>("vlan_mode");
 
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Networks/OVS/IOVSControl.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Networks/OVS/IOVSControl.cs
@@ -15,4 +15,6 @@ public interface IOVSControl
     EitherAsync<Error, Seq<BridgePort>> GetPorts(CancellationToken cancellationToken);
     EitherAsync<Error, OVSTableRecord> GetOVSTable(CancellationToken cancellationToken);
     EitherAsync<Error, Unit> UpdateBridgeMapping(string bridgeMappings, CancellationToken cancellationToken);
+    EitherAsync<Error, Unit> UpdateBridgePort(string bridgeName, int? tag, string? vlanMode,  CancellationToken cancellationToken);
+
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Networks/OVSBridgeInfo.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Networks/OVSBridgeInfo.cs
@@ -1,7 +1,12 @@
-﻿using LanguageExt;
+﻿using Eryph.Core.Network;
+using LanguageExt;
 
 namespace Eryph.Modules.VmHostAgent.Networks;
 
 public readonly record struct OVSBridgeInfo(
-    Lst<string> Bridges, HashMap<string, string> BridgePorts
+    Lst<string> Bridges, HashMap<string, string> BridgePorts,
+    HashMap<string, OVSBridgePortInfo> Ports
 );
+
+public readonly record struct OVSBridgePortInfo(string BridgeName, 
+    string PortName, int? Tag, string? VlanMode);

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Networks/ProviderNetworkUpdateConstants.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Networks/ProviderNetworkUpdateConstants.cs
@@ -1,0 +1,12 @@
+﻿namespace Eryph.Modules.VmHostAgent.Networks;
+
+internal static class ProviderNetworkUpdateConstants
+{
+    internal static readonly NetworkChangeOperation[] UnsafeChanges = new[]
+    {
+        NetworkChangeOperation.RemoveAdapterPort,
+        NetworkChangeOperation.AddAdapterPort,
+        NetworkChangeOperation.RebuildOverLaySwitch,
+        NetworkChangeOperation.UpdateBridgePort,
+    };
+}

--- a/src/modules/test/Eryph.Modules.VmHostAgent.Test/ProviderNetworkConsoleTests.cs
+++ b/src/modules/test/Eryph.Modules.VmHostAgent.Test/ProviderNetworkConsoleTests.cs
@@ -390,6 +390,12 @@ namespace Eryph.Modules.VmHostAgent.Test
                     It.IsAny<CancellationToken>()))
                 .Returns(Prelude.RightAsync<Error, Unit>(Prelude.unit));
 
+            ovsControlMock.Setup(x => x.UpdateBridgePort("br-nat",
+                    null,null,
+                    It.IsAny<CancellationToken>()))
+                .Returns(Prelude.RightAsync<Error, Unit>(Prelude.unit));
+
+
             hostCommandsMock.Setup(x => x.WaitForBridgeAdapter(
                     It.IsAny<string>()))
                 .Returns(Prelude.unitAff);
@@ -400,7 +406,7 @@ namespace Eryph.Modules.VmHostAgent.Test
             hostCommandsMock.Setup(x => x.GetAdapterIpV4Address("br-nat"))
                 .Returns(Prelude.SuccessAff(Seq<NetIpAddress>.Empty));
 
-            hostCommandsMock.Setup(x => x.ConfigureNATAdapter("br-nat",
+            hostCommandsMock.Setup(x => x.ConfigureAdapterIp("br-nat",
                     It.IsAny<IPAddress>(), It.IsAny<IPNetwork>()))
                 .Returns(Prelude.unitAff);
 


### PR DESCRIPTION
This PR adds support for VLAN tagging of overlay provider networks. 

### Provider VLANs

New option vlan in network provider configuration:

``` yaml
network_providers:
- name: default
  type: overlay
  vlan: 10
```

Overlay provider network VLAN tags are attached by OVN to all egress traffic from the VMs. This is accomplished by configuring the tag to the logical switch port of the external router port that connects from the project network to the provider network. 

### Bridge VLANs and IP mode

The bridge adapter is not affected by the provider's VLAN setting. The default configuration for an overlay adapter also doesn't enable the bridge adapter for network communications.

For scenarios where we have few (or only one) network adapters, the bridge can now be configured to be enabled for DHCP by default. For this case, we now also have the option to configure a VLAN for the bridge adapter:

``` yaml
network_providers:
- name: default
  type: overlay
  vlan: 10
  bridge_name: br-pif
  bridge_options: 
   default_ip_mode: dhcp
   bridge_vlan: 11
```


See also #144 for static address configuration support.
