### PR TITLE
Improve workflow stability

### DIFF
--- a/src/apps/src/Eryph-zero/ZeroContainerExtensions.cs
+++ b/src/apps/src/Eryph-zero/ZeroContainerExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+﻿using System;
 using Dbosoft.OVN;
 using Dbosoft.Rebus.Configuration;
 using Dbosoft.Rebus.Operations;
@@ -11,7 +11,6 @@ using Eryph.Runtime.Zero.Configuration.Networks;
 using Eryph.Security.Cryptography;
 using Eryph.StateDb;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.Extensions.Hosting.WindowsServices;
 using Rebus.Sagas;
 using Rebus.Subscriptions;
 using Rebus.Timeouts;
@@ -46,6 +45,7 @@ namespace Eryph.Runtime.Zero
                 DispatchMode = WorkflowEventDispatchMode.Publish, 
                 EventDestination = QueueNames.Controllers,
                 OperationsDestination = QueueNames.Controllers,
+                DeferCompletion = TimeSpan.FromMinutes(1)
             });
         }
 

--- a/src/data/src/Eryph.StateDb/Eryph.StateDb.csproj
+++ b/src/data/src/Eryph.StateDb/Eryph.StateDb.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Rebus.Operations.Core" Version="0.6.0" />
+    <PackageReference Include="Dbosoft.Rebus.Operations.Core" Version="0.6.1" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/data/src/Eryph.StateDb/Eryph.StateDb.csproj
+++ b/src/data/src/Eryph.StateDb/Eryph.StateDb.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Rebus.Operations.Core" Version="0.5.2" />
+    <PackageReference Include="Dbosoft.Rebus.Operations.Core" Version="0.6.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/data/src/Eryph.StateDb/Migrations/20240412221301_ImproveOpTasks.Designer.cs
+++ b/src/data/src/Eryph.StateDb/Migrations/20240412221301_ImproveOpTasks.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eryph.StateDb;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Eryph.StateDb.Migrations
 {
     [DbContext(typeof(StateStoreContext))]
-    partial class StateStoreContextModelSnapshot : ModelSnapshot
+    [Migration("20240412221301_ImproveOpTasks")]
+    partial class ImproveOpTasks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.16");

--- a/src/data/src/Eryph.StateDb/Migrations/20240412221301_ImproveOpTasks.cs
+++ b/src/data/src/Eryph.StateDb/Migrations/20240412221301_ImproveOpTasks.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eryph.StateDb.Migrations
+{
+    public partial class ImproveOpTasks : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Progress",
+                table: "OperationTasks");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "LastUpdated",
+                table: "OperationTasks",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "LastUpdated",
+                table: "Operations",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.CreateTable(
+                name: "TaskProgress",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    OperationId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    TaskId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    Timestamp = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    Progress = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TaskProgress", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TaskProgress_OperationTasks_TaskId",
+                        column: x => x.TaskId,
+                        principalTable: "OperationTasks",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TaskProgress_TaskId",
+                table: "TaskProgress",
+                column: "TaskId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TaskProgress");
+
+            migrationBuilder.DropColumn(
+                name: "LastUpdated",
+                table: "OperationTasks");
+
+            migrationBuilder.DropColumn(
+                name: "LastUpdated",
+                table: "Operations");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Progress",
+                table: "OperationTasks",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+        }
+    }
+}

--- a/src/data/src/Eryph.StateDb/Model/OperationModel.cs
+++ b/src/data/src/Eryph.StateDb/Model/OperationModel.cs
@@ -19,6 +19,7 @@ public class OperationModel
     public OperationStatus Status { get; set; }
 
     public string StatusMessage { get; set; }
+    public DateTimeOffset LastUpdated { get; set; }
 
 
 }

--- a/src/data/src/Eryph.StateDb/Model/OperationTaskModel.cs
+++ b/src/data/src/Eryph.StateDb/Model/OperationTaskModel.cs
@@ -18,11 +18,12 @@ namespace Eryph.StateDb.Model
         public string Name { get; set; }
         public string DisplayName { get; set; }
 
-        public int Progress { get; set; }
         
         public TaskReferenceType? ReferenceType { get; set; }
         public string ReferenceId { get; set; }
         public string ReferenceProjectName { get; set; }
 
+        public DateTimeOffset? LastUpdated { get; set; }
+        public virtual List<TaskProgressEntry> Progress { get; set; }
     }
 }

--- a/src/data/src/Eryph.StateDb/Model/OperationTaskModel.cs
+++ b/src/data/src/Eryph.StateDb/Model/OperationTaskModel.cs
@@ -23,7 +23,7 @@ namespace Eryph.StateDb.Model
         public string ReferenceId { get; set; }
         public string ReferenceProjectName { get; set; }
 
-        public DateTimeOffset? LastUpdated { get; set; }
+        public DateTimeOffset LastUpdated { get; set; }
         public virtual List<TaskProgressEntry> Progress { get; set; }
     }
 }

--- a/src/data/src/Eryph.StateDb/Model/TaskProgressEntry.cs
+++ b/src/data/src/Eryph.StateDb/Model/TaskProgressEntry.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Eryph.StateDb.Model;
+
+public class TaskProgressEntry
+{
+    public Guid Id { get; set; }
+    public Guid OperationId { get; set; }
+    public Guid TaskId { get; set; }
+
+    public virtual OperationTaskModel Task { get; set; }
+    public DateTimeOffset Timestamp { get; set; }
+    public int Progress { get; set; }
+}

--- a/src/data/src/Eryph.StateDb/Specifications/OperationSpecs.cs
+++ b/src/data/src/Eryph.StateDb/Specifications/OperationSpecs.cs
@@ -25,7 +25,8 @@ namespace Eryph.StateDb.Specifications
                             .Where(l => l.Timestamp > requestLogTimestamp));
                         break;
                     case "tasks":
-                        query.Include(x => x.Tasks);
+                        query.Include(x => x.Tasks)
+                            .ThenInclude(x=>x.Progress);
                         break;
                     case "resources":
                         query.Include(x => x.Resources);

--- a/src/data/src/Eryph.StateDb/StateStoreContext.cs
+++ b/src/data/src/Eryph.StateDb/StateStoreContext.cs
@@ -18,6 +18,7 @@ namespace Eryph.StateDb
         public DbSet<OperationModel> Operations { get; set; }
         public DbSet<OperationLogEntry> Logs { get; set; }
         public DbSet<OperationTaskModel> OperationTasks { get; set; }
+        public DbSet<TaskProgressEntry> TaskProgress { get; set; }
         public DbSet<OperationResourceModel> OperationResources { get; set; }
 
         public DbSet<Resource> Resources { get; set; }
@@ -66,6 +67,13 @@ namespace Eryph.StateDb
             modelBuilder.Entity<OperationModel>()
                 .Property(x => x.TenantId)
                 .HasDefaultValue(EryphConstants.DefaultTenantId);
+
+            modelBuilder.Entity<OperationModel>()
+                .Property(x => x.LastUpdated).IsConcurrencyToken();
+
+            modelBuilder.Entity<OperationTaskModel>()
+                .Property(x => x.LastUpdated).IsConcurrencyToken();
+
 
             modelBuilder.Entity<Tenant>()
                 .HasKey(x => x.Id);

--- a/src/data/src/Eryph.StateDb/Workflows/OperationTaskManager.cs
+++ b/src/data/src/Eryph.StateDb/Workflows/OperationTaskManager.cs
@@ -6,6 +6,7 @@ using Dbosoft.Rebus.Operations.Workflow;
 using Eryph.Messages;
 using Eryph.StateDb.Model;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using OperationTaskStatus = Dbosoft.Rebus.Operations.OperationTaskStatus;
 using Resource = Eryph.Resources.Resource;
 
@@ -15,10 +16,12 @@ namespace Eryph.StateDb.Workflows;
 public class OperationTaskManager : OperationTaskManagerBase
 {
     private readonly StateStoreContext _db;
+    private readonly ILogger _logger;
 
-    public OperationTaskManager(StateStoreContext db)
+    public OperationTaskManager(StateStoreContext db, ILogger logger)
     {
         _db = db;
+        _logger = logger;
     }
 
 
@@ -28,11 +31,15 @@ public class OperationTaskManager : OperationTaskManagerBase
         return res == null ? null : new OperationTask(res);
     }
 
-    public override async ValueTask<IOperationTask> GetOrCreateAsync(IOperation operation, object command, Guid taskId,
-        Guid parentTaskId)
+    public override async ValueTask<IOperationTask> GetOrCreateAsync(IOperation operation, 
+        object command, DateTimeOffset timestamp,
+        Guid taskId, Guid parentTaskId)
     {
+        _logger.LogTrace("Entering GetOrCreateAsync for operation {operationId} and task {taskId}  with parent {parentTaskId}", 
+            operation.Id, taskId, parentTaskId);
         var res = await _db.OperationTasks.FindAsync(taskId);
-        if (res != null) return new OperationTask(res);
+        if (res != null)
+            return new OperationTask(res);
 
         var (resources, projects) = await OperationsHelper.GetCommandProjectsAndResources(command, _db);
 
@@ -48,8 +55,11 @@ public class OperationTaskManager : OperationTaskManagerBase
             Status = Model.OperationTaskStatus.Queued,
             ParentTaskId = parentTaskId,
             Name = command.GetType().Name,
-            DisplayName = displayName
+            DisplayName = displayName,
+            LastUpdated = timestamp
         };
+        _logger.LogDebug("Creating task {taskId} for operation {operationId} with parent {parentTaskId}", taskId, operation.Id, parentTaskId);
+        _logger.LogTrace("Created task: {@task}", res);
 
         await _db.AddAsync(res);
 
@@ -73,10 +83,23 @@ public class OperationTaskManager : OperationTaskManagerBase
     }
 
 
-    public override ValueTask<bool> TryChangeStatusAsync(IOperationTask task, OperationTaskStatus newStatus,
-        object? additionalData)
+    public override ValueTask<bool> TryChangeStatusAsync(IOperationTask task, 
+        OperationTaskStatus newStatus,
+        DateTimeOffset timestamp, object? additionalData)
     {
+        _logger.LogTrace(
+            "Entering TryChangeStatusAsync for operation {operationId} and task {taskId}. New status: {newStatus}",
+            task.OperationId, task.Id, newStatus);
+
         if (task is not OperationTask opTask) return new ValueTask<bool>(false);
+
+        if (opTask.Model.LastUpdated > timestamp)
+        {
+            _logger.LogWarning("Operation: {operationId}, Task {taskId}: has been updated already after change timestamp. Skipping status change. Task last changed: {lastChanged}, change timestamp: {timestamp}", 
+                task.OperationId, task.Id, opTask.Model.LastUpdated, timestamp);
+            return new ValueTask<bool>(false);
+
+        }
 
         opTask.Model.Status = newStatus switch
         {
@@ -87,15 +110,18 @@ public class OperationTaskManager : OperationTaskManagerBase
             _ => throw new ArgumentOutOfRangeException(nameof(newStatus), newStatus, null)
         };
 
-        if(opTask.Model.Status == Model.OperationTaskStatus.Completed)
-             opTask.Model.Progress = 100;
-
         if (additionalData is ITaskReference taskReference)
         {
             opTask.Model.ReferenceType = taskReference.ReferenceType;
             opTask.Model.ReferenceId = taskReference.ReferenceId;
             opTask.Model.ReferenceProjectName = taskReference.ProjectName;
         }
+
+        opTask.Model.LastUpdated = timestamp;
+
+        _logger.LogTrace("Operation: {operationId}, Task {taskId}: updated task model : {@taskModel}",
+            task.OperationId, task.Id, opTask.Model);
+
 
         return new ValueTask<bool>(true);
     }

--- a/src/infrastructure/src/Eryph.Rebus/Eryph.Rebus.csproj
+++ b/src/infrastructure/src/Eryph.Rebus/Eryph.Rebus.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Rebus.Configuration.Selectors" Version="0.6.0" />
-    <PackageReference Include="Dbosoft.Rebus.SimpleInjector" Version="0.6.0" />
+    <PackageReference Include="Dbosoft.Rebus.Configuration.Selectors" Version="0.6.1" />
+    <PackageReference Include="Dbosoft.Rebus.SimpleInjector" Version="0.6.1" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/infrastructure/src/Eryph.Rebus/Eryph.Rebus.csproj
+++ b/src/infrastructure/src/Eryph.Rebus/Eryph.Rebus.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dbosoft.Rebus.Configuration.Selectors" Version="0.5.2" />
-    <PackageReference Include="Dbosoft.Rebus.SimpleInjector" Version="0.5.2" />
+    <PackageReference Include="Dbosoft.Rebus.Configuration.Selectors" Version="0.6.0" />
+    <PackageReference Include="Dbosoft.Rebus.SimpleInjector" Version="0.6.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.ModuleCore/Eryph.ModuleCore.csproj
+++ b/src/modules/src/Eryph.ModuleCore/Eryph.ModuleCore.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dbosoft.Hosuto" Version="1.1.0" />
-    <PackageReference Include="Dbosoft.Rebus.Operations.SimpleInjector" Version="0.5.3" />
+    <PackageReference Include="Dbosoft.Rebus.Operations.SimpleInjector" Version="0.6.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.ModuleCore/Eryph.ModuleCore.csproj
+++ b/src/modules/src/Eryph.ModuleCore/Eryph.ModuleCore.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dbosoft.Hosuto" Version="1.1.0" />
-    <PackageReference Include="Dbosoft.Rebus.Operations.SimpleInjector" Version="0.6.0" />
+    <PackageReference Include="Dbosoft.Rebus.Operations.SimpleInjector" Version="0.6.1" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.ModuleCore/OperationDispatcher.cs
+++ b/src/modules/src/Eryph.ModuleCore/OperationDispatcher.cs
@@ -19,7 +19,8 @@ public class OperationDispatcher : DefaultOperationDispatcher
         _operationManager = operationManager;
     }
 
-    protected override async ValueTask<(IOperation, object)> CreateOperation(object command, object? additionalData,
+    protected override async ValueTask<(IOperation, object)> CreateOperation(object command, 
+        DateTimeOffset timestamp, object? additionalData,
         IDictionary<string,string>? additionalHeaders)
     {
         var operationId = Guid.NewGuid();
@@ -30,6 +31,6 @@ public class OperationDispatcher : DefaultOperationDispatcher
                 : correlatedCommand.CorrelationId;
 
 
-        return (await _operationManager.GetOrCreateAsync(operationId, command, additionalData, additionalHeaders), command);
+        return (await _operationManager.GetOrCreateAsync(operationId, command, timestamp, additionalData, additionalHeaders), command);
     }
 }

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/MapperProfile.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/MapperProfile.cs
@@ -1,5 +1,7 @@
-﻿using AutoMapper;
+﻿using System.Linq;
+using AutoMapper;
 using Eryph.Core;
+using Eryph.StateDb.Model;
 
 
 namespace Eryph.Modules.AspNetCore.ApiProvider.Model.V1
@@ -19,6 +21,17 @@ namespace Eryph.Modules.AspNetCore.ApiProvider.Model.V1
             CreateMap<StateDb.Model.Project, Project>();
             CreateMap<StateDb.Model.OperationTaskModel, OperationTask>()
                 .ForMember(x => x.ParentTask, m => m.MapFrom(x => x.ParentTaskId))
+                .ForMember(x=>x.Progress, m =>
+                {
+                    m.MapFrom(x =>
+                        x.Status == OperationTaskStatus.Completed 
+                            ? 100
+                            : x.Progress == null 
+                                ? 0 
+                                : x.Progress.Count > 0 
+                                    ? x.Progress.Max(p => p.Progress) 
+                                    : 0);
+                })
                 .ForMember(x => x.Reference,
                     m =>
                     {

--- a/src/modules/src/Eryph.Modules.Controller/Operations/EryphRebusOperationMessaging.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Operations/EryphRebusOperationMessaging.cs
@@ -34,7 +34,7 @@ public class EryphRebusOperationMessaging : RebusOperationMessaging
         var messageType = command.GetType();
         var outboundMessage = Activator.CreateInstance(
             typeof(OperationTaskSystemMessage<>).MakeGenericType(messageType),
-            command, task.OperationId, task.InitiatingTaskId, task.Id);
+            command, task.OperationId, task.InitiatingTaskId, task.Id, DateTimeOffset.UtcNow);
         var sendCommandAttribute = messageType.GetCustomAttribute<SendMessageToAttribute>();
 
         if (sendCommandAttribute == null)

--- a/src/modules/src/Eryph.Modules.Controller/Operations/EryphTaskDispatcher.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Operations/EryphTaskDispatcher.cs
@@ -16,7 +16,9 @@ public class EryphTaskDispatcher : DefaultOperationTaskDispatcher
     {
     }
 
-    protected override ValueTask<(IOperationTask, object)> CreateTask(Guid operationId, Guid initiatingTaskId, object command, object? additionalData,
+    protected override ValueTask<(IOperationTask, object)> CreateTask(Guid operationId, 
+        Guid initiatingTaskId, object command,
+        DateTimeOffset created, object? additionalData,
         IDictionary<string, string>? additionalHeaders)
     {
         if (additionalData != null)
@@ -41,6 +43,6 @@ public class EryphTaskDispatcher : DefaultOperationTaskDispatcher
             }
         }
 
-        return base.CreateTask(operationId, initiatingTaskId, command, additionalData, additionalHeaders);
+        return base.CreateTask(operationId, initiatingTaskId, command,created, additionalData, additionalHeaders);
     }
 }


### PR DESCRIPTION
This PR addresses several workflow issues. These issues caused operations to get stuck in processing, for example, because events were sent out of sequence or were repeated.

- Update of Rebus.Extensions to 0.6 for fixes included with PR dbosoft/rebus-extensions#11. 
Among other fixes, this PR introduced event timestamps and automatic deferral of status and progress messages if the task is still queued. 
- Enabled operation completion deferral, as in eryph-zero operation saga will not be committed or rolled back with the database. If a message is resent due to a concurrency exception, the message can now still be processed. 
- Added timestamp (LastChanged) to operation and task model that is filled with the initial timestamp of the operation/task event. This allows to check if a event is already outdated as a newer event was already processed. 
- The LastChanged field has been added to the database model as a concurrency token. Parallel changes will now raise a concurrency update exception, and together with the changes from above, the update can be safely repeated. 
- Task progress has been moved to a separate table so that it is no longer necessary to update the task from a progress event, reducing the chance of a concurrency exception occurring. 
- Log entries are now timestamped with the save time, not the event time. If a progress message is deferred, the event timestamp may be behind earlier log entries, so log watchers would not see those entries. 