### PR TITLE
Operation should not change final status

### DIFF
--- a/src/data/src/Eryph.StateDb/Workflows/OperationManager.cs
+++ b/src/data/src/Eryph.StateDb/Workflows/OperationManager.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Rebus.Bus;
 using ErrorData = Dbosoft.Rebus.Operations.ErrorData;
 using OperationStatus = Eryph.StateDb.Model.OperationStatus;
+using OperationTaskStatus = Dbosoft.Rebus.Operations.OperationTaskStatus;
 
 namespace Eryph.StateDb.Workflows;
 
@@ -131,6 +132,14 @@ public class OperationManager : OperationManagerBase
         if (op.Model.LastUpdated > timestamp)
         {
             _log.LogWarning("Operation {operationId} has been updated already after change timestamp. Skipping status change.", operation.Id);
+            return false;
+        }
+
+        if (op.Status is Dbosoft.Rebus.Operations.OperationStatus.Completed 
+            or Dbosoft.Rebus.Operations.OperationStatus.Failed)
+        {
+            _log.LogWarning("Operation: {operationId}: has already been completed or failed. Skipping status change. Status: {status}",
+                op.Id, op.Status);
             return false;
         }
 

--- a/src/data/src/Eryph.StateDb/Workflows/OperationTaskManager.cs
+++ b/src/data/src/Eryph.StateDb/Workflows/OperationTaskManager.cs
@@ -101,6 +101,13 @@ public class OperationTaskManager : OperationTaskManagerBase
 
         }
 
+        if (opTask.Status is OperationTaskStatus.Completed or OperationTaskStatus.Failed)
+        {
+            _logger.LogWarning("Operation: {operationId}, Task {taskId}: has already been completed or failed. Skipping status change. Task status: {status}", 
+                               task.OperationId, task.Id, opTask.Status);
+            return new ValueTask<bool>(false);
+        }
+
         opTask.Model.Status = newStatus switch
         {
             OperationTaskStatus.Queued => Model.OperationTaskStatus.Queued,


### PR DESCRIPTION
If a operation or a task is in failed or completed status further events are not allowed to change its status.

fixes #181 