### PR TITLE
handle capabilities secure_boot and nested_virtualization

### DIFF
--- a/src/core/src/Eryph.Core/EryphConstants.cs
+++ b/src/core/src/Eryph.Core/EryphConstants.cs
@@ -21,5 +21,11 @@ namespace Eryph.Core
             public static readonly Guid Reader = Guid.Parse("{47982531-A6D2-41E4-AD6C-D5023DEB7710}");
 
         }
+
+        public static class Capabilities
+        {
+            public static readonly string SecureBoot = "secure_boot";
+            public static readonly string NestedVirtualization = "nested_virtualization";
+        }
     }
 }

--- a/src/core/src/Eryph.Core/EryphConstants.cs
+++ b/src/core/src/Eryph.Core/EryphConstants.cs
@@ -27,5 +27,11 @@ namespace Eryph.Core
             public static readonly string SecureBoot = "secure_boot";
             public static readonly string NestedVirtualization = "nested_virtualization";
         }
+
+        public static class CapabilityDetails
+        {
+            public static readonly string Disabled = "disabled";
+            public static readonly string Enabled = "enabled";
+        }
     }
 }

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeNestedVirtualization.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeNestedVirtualization.cs
@@ -26,7 +26,7 @@ public class ConvergeNestedVirtualization : ConvergeTaskBase
 
         var onOffState = (capability.Details?.Any(x =>
             string.Equals(x, EryphConstants.CapabilityDetails.Disabled, 
-                StringComparison.InvariantCultureIgnoreCase))).GetValueOrDefault() ? OnOffState.Off : OnOffState.On;
+                StringComparison.OrdinalIgnoreCase))).GetValueOrDefault() ? OnOffState.Off : OnOffState.On;
 
         return await (from exposedExtensions in Context.Engine.GetObjectValuesAsync<bool>(new PsCommandBuilder()
                 .AddCommand("Get-VMProcessor")

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeNestedVirtualization.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeNestedVirtualization.cs
@@ -28,8 +28,8 @@ public class ConvergeNestedVirtualization : ConvergeTaskBase
             string.Equals(x, "off", StringComparison.InvariantCultureIgnoreCase))).GetValueOrDefault() ? OnOffState.Off : OnOffState.On;
 
         return await (from exposedExtensions in Context.Engine.GetObjectValuesAsync<bool>(new PsCommandBuilder()
-                .AddCommand("get-VMProcessor")
-                .AddArgument(vmInfo.PsObject)
+                .AddCommand("Get-VMProcessor")
+                .AddParameter("VM",vmInfo.PsObject)
                 .AddCommand("Select-Object")
                 .AddParameter("ExpandProperty", "ExposeVirtualizationExtensions")
             ).ToError().Bind(

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeNestedVirtualization.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeNestedVirtualization.cs
@@ -25,7 +25,8 @@ public class ConvergeNestedVirtualization : ConvergeTaskBase
             return vmInfo;
 
         var onOffState = (capability.Details?.Any(x =>
-            string.Equals(x, "off", StringComparison.InvariantCultureIgnoreCase))).GetValueOrDefault() ? OnOffState.Off : OnOffState.On;
+            string.Equals(x, EryphConstants.CapabilityDetails.Disabled, 
+                StringComparison.InvariantCultureIgnoreCase))).GetValueOrDefault() ? OnOffState.Off : OnOffState.On;
 
         return await (from exposedExtensions in Context.Engine.GetObjectValuesAsync<bool>(new PsCommandBuilder()
                 .AddCommand("Get-VMProcessor")

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeNestedVirtualization.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeNestedVirtualization.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Eryph.Core;
+using Eryph.VmManagement.Data;
+using Eryph.VmManagement.Data.Full;
+using LanguageExt;
+using LanguageExt.Common;
+
+namespace Eryph.VmManagement.Converging;
+
+public class ConvergeNestedVirtualization : ConvergeTaskBase
+{
+    public ConvergeNestedVirtualization(ConvergeContext context) : base(context)
+    {
+    }
+
+    public override async Task<Either<Error, TypedPsObject<VirtualMachineInfo>>> Converge(
+        TypedPsObject<VirtualMachineInfo> vmInfo)
+    {
+        var capability = Context.Config.Capabilities?.FirstOrDefault(x => x.Name ==
+            EryphConstants.Capabilities.NestedVirtualization);
+
+        if (capability == null)
+            return vmInfo;
+
+        var onOffState = (capability.Details?.Any(x =>
+            string.Equals(x, "off", StringComparison.InvariantCultureIgnoreCase))).GetValueOrDefault() ? OnOffState.Off : OnOffState.On;
+
+        return await (from exposedExtensions in Context.Engine.GetObjectValuesAsync<bool>(new PsCommandBuilder()
+                .AddCommand("get-VMProcessor")
+                .AddArgument(vmInfo.PsObject)
+                .AddCommand("Select-Object")
+                .AddParameter("ExpandProperty", "ExposeVirtualizationExtensions")
+            ).ToError().Bind(
+                r => r.HeadOrLeft(Error.New("Failed to read processor details.")).ToAsync())
+            let currentOnOffState = exposedExtensions ? OnOffState.On : OnOffState.Off
+            from uNestedVirtualization in currentOnOffState == onOffState
+                ? Unit.Default
+                : Unit.Default.Apply(async _ =>
+                {
+                    if (vmInfo.Value.State == VirtualMachineState.Running)
+                        return Error.New("Cannot change nested virtualization settings of a running catlet.");
+
+                    if(onOffState == OnOffState.On)
+                        await Context.ReportProgress("Enabling nested virtualization.").ConfigureAwait(false);
+                    else
+                        await Context.ReportProgress("Disabling nested virtualization.").ConfigureAwait(false);
+
+                    return await Context.Engine.RunAsync(PsCommandBuilder.Create()
+                        .AddCommand("Set-VMProcessor")
+                        .AddParameter("VM", vmInfo.PsObject)
+                        .AddParameter("ExposeVirtualizationExtensions", onOffState == OnOffState.On)
+                        ).ToError();
+                }).ToAsync()
+            from newVmInfo in vmInfo.RecreateOrReload(Context.Engine)
+            select newVmInfo).ToEither();
+
+
+    }
+}

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeSecureBoot.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeSecureBoot.cs
@@ -28,7 +28,7 @@ public class ConvergeSecureBoot : ConvergeTaskBase
 
         var templateName =
             secureBootCapability.Details?.FirstOrDefault(x => x.StartsWith("template:", 
-                StringComparison.CurrentCultureIgnoreCase))?.Split(':')[1]
+                StringComparison.OrdinalIgnoreCase))?.Split(':')[1]
             ?? "MicrosoftWindows";
 
         var onOffState = (secureBootCapability.Details?.Any(x =>

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeSecureBoot.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeSecureBoot.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Eryph.ConfigModel;
+using Eryph.Core;
 using Eryph.VmManagement.Data;
 using Eryph.VmManagement.Data.Core;
 using Eryph.VmManagement.Data.Full;
@@ -19,14 +21,14 @@ public class ConvergeSecureBoot : ConvergeTaskBase
         TypedPsObject<VirtualMachineInfo> vmInfo)
     {
         var secureBootCapability = Context.Config.Capabilities?.FirstOrDefault(x => x.Name ==
-            "SecureBoot");
+            EryphConstants.Capabilities.SecureBoot);
 
         if (secureBootCapability == null)
             return vmInfo;
 
         var templateName =
             secureBootCapability.Details?.FirstOrDefault(x => x.StartsWith("Template:"))?.Split(':')[1]
-            ?? "Windows";
+            ?? "MicrosoftWindows";
 
         var onOffState = (secureBootCapability.Details?.Any(x =>
             string.Equals(x, "off", StringComparison.InvariantCultureIgnoreCase))).GetValueOrDefault() ? OnOffState.Off : OnOffState.On;

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeSecureBoot.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeSecureBoot.cs
@@ -27,11 +27,12 @@ public class ConvergeSecureBoot : ConvergeTaskBase
             return vmInfo;
 
         var templateName =
-            secureBootCapability.Details?.FirstOrDefault(x => x.StartsWith("Template:"))?.Split(':')[1]
+            secureBootCapability.Details?.FirstOrDefault(x => x.StartsWith("template:", 
+                StringComparison.CurrentCultureIgnoreCase))?.Split(':')[1]
             ?? "MicrosoftWindows";
 
         var onOffState = (secureBootCapability.Details?.Any(x =>
-            string.Equals(x, "off", StringComparison.InvariantCultureIgnoreCase))).GetValueOrDefault() ? OnOffState.Off : OnOffState.On;
+            string.Equals(x, EryphConstants.CapabilityDetails.Disabled, StringComparison.InvariantCultureIgnoreCase))).GetValueOrDefault() ? OnOffState.Off : OnOffState.On;
 
         return await (from currentFirmware in Context.Engine.GetObjectsAsync<VMFirmwareInfo>(new PsCommandBuilder()
                 .AddCommand("get-VMFirmware")

--- a/src/core/src/Eryph.VmManagement/Data/Core/VMFirmwareInfo.cs
+++ b/src/core/src/Eryph.VmManagement/Data/Core/VMFirmwareInfo.cs
@@ -18,4 +18,5 @@ namespace Eryph.VmManagement.Data.Core
 
         public OnOffState PauseAfterBootFailure { get; private set; }
     }
+
 }

--- a/src/core/src/Eryph.VmManagement/TypedPsObjectMapping.cs
+++ b/src/core/src/Eryph.VmManagement/TypedPsObjectMapping.cs
@@ -140,6 +140,10 @@ public class TypedPsObjectMapping : ITypedPsObjectMapping
 
         try
         {
+            // special case for bool as it is not mapped correctly
+            if(typeof(T) == typeof(bool))
+                return psObject.BaseObject is bool b ? (T)(object)b : default;
+
             // cast is required to map correctly
             // ReSharper disable once RedundantCast
             return _mapper.Map<T>((object) psObject);

--- a/src/core/src/Eryph.VmManagement/VirtualMachine.cs
+++ b/src/core/src/Eryph.VmManagement/VirtualMachine.cs
@@ -286,6 +286,7 @@ namespace Eryph.VmManagement
             {
                 new ConvergeSecureBoot(convergeContext),
                 new ConvergeCPU(convergeContext),
+                new ConvergeNestedVirtualization(convergeContext),
                 new ConvergeMemory(convergeContext),
                 new ConvergeDrives(convergeContext),
                 new ConvergeNetworkAdapters(convergeContext),

--- a/src/core/test/Eryph.VmManagement.Test/ConvergeFixture.cs
+++ b/src/core/test/Eryph.VmManagement.Test/ConvergeFixture.cs
@@ -10,6 +10,11 @@ public class ConvergeFixture
 {
     public ConvergeFixture()
     {
+        Reset();
+    }
+
+    public void Reset()
+    {
         var mapping = new FakeTypeMapping();
         Engine = new TestPowershellEngine(mapping);
         Config = new CatletConfig();
@@ -18,7 +23,7 @@ public class ConvergeFixture
         HostInfo = new VMHostMachineData();
         VmHostAgentConfiguration = new VmHostAgentConfiguration()
         {
-            Defaults = new()
+            Defaults = new VmHostAgentDefaultsConfiguration
             {
                 Vms = "x:\\data",
                 Volumes = "x:\\disks",
@@ -29,14 +34,14 @@ public class ConvergeFixture
     public VMStorageSettings StorageSettings { get; set; }
 
 
-    public TestPowershellEngine Engine { get; }
-    public MachineNetworkSettings[] NetworkSettings { get; set; }
-    public CatletConfig Config { get; set; }
-    public CatletMetadata Metadata { get; set; }
+    public TestPowershellEngine Engine { get; private set; } = null!;
+    public MachineNetworkSettings[] NetworkSettings { get; set; } = null!;
+    public CatletConfig Config { get; set; } = null!;
+    public CatletMetadata Metadata { get; set; } = null!;
 
-    public VMHostMachineData HostInfo { get; set; }
+    public VMHostMachineData HostInfo { get; set; } = null!;
 
-    public VmHostAgentConfiguration VmHostAgentConfiguration { get; set; }
+    public VmHostAgentConfiguration VmHostAgentConfiguration { get; set; } = null!;
 
 
     public ConvergeContext Context =>

--- a/src/core/test/Eryph.VmManagement.Test/ConvergeFixture.cs
+++ b/src/core/test/Eryph.VmManagement.Test/ConvergeFixture.cs
@@ -10,11 +10,6 @@ public class ConvergeFixture
 {
     public ConvergeFixture()
     {
-        Reset();
-    }
-
-    public void Reset()
-    {
         var mapping = new FakeTypeMapping();
         Engine = new TestPowershellEngine(mapping);
         Config = new CatletConfig();
@@ -29,19 +24,21 @@ public class ConvergeFixture
                 Volumes = "x:\\disks",
             },
         };
+        Metadata = new CatletMetadata();
     }
+
 
     public VMStorageSettings StorageSettings { get; set; }
 
 
-    public TestPowershellEngine Engine { get; private set; } = null!;
-    public MachineNetworkSettings[] NetworkSettings { get; set; } = null!;
-    public CatletConfig Config { get; set; } = null!;
-    public CatletMetadata Metadata { get; set; } = null!;
+    public TestPowershellEngine Engine { get;  }
+    public MachineNetworkSettings[] NetworkSettings { get; set; }
+    public CatletConfig Config { get; set; }
+    public CatletMetadata Metadata { get; set; }
 
-    public VMHostMachineData HostInfo { get; set; } = null!;
+    public VMHostMachineData HostInfo { get; set; }
 
-    public VmHostAgentConfiguration VmHostAgentConfiguration { get; set; } = null!;
+    public VmHostAgentConfiguration VmHostAgentConfiguration { get; set; }
 
 
     public ConvergeContext Context =>

--- a/src/core/test/Eryph.VmManagement.Test/ConvergeNestedVirtualizationTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/ConvergeNestedVirtualizationTests.cs
@@ -51,7 +51,7 @@ namespace Eryph.VmManagement.Test
             };
             _fixture.Engine.GetValuesCallback = (_, command) =>
             {
-                if (command.ToString().StartsWith("get-VMProcessor"))
+                if (command.ToString().StartsWith("Get-VMProcessor"))
                 {
                     return new object []{exposed}.ToSeq();
                 }

--- a/src/core/test/Eryph.VmManagement.Test/ConvergeNestedVirtualizationTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/ConvergeNestedVirtualizationTests.cs
@@ -7,14 +7,9 @@ using Xunit;
 
 namespace Eryph.VmManagement.Test
 {
-    public class ConvergeNestedVirtualizationTests : IClassFixture<ConvergeFixture>
+    public class ConvergeNestedVirtualizationTests
     {
-        private readonly ConvergeFixture _fixture;
-
-        public ConvergeNestedVirtualizationTests(ConvergeFixture fixture)
-        {
-            _fixture = fixture;
-        }
+        private readonly ConvergeFixture _fixture = new();
 
         [Theory]
         [InlineData(false, false)]
@@ -26,7 +21,6 @@ namespace Eryph.VmManagement.Test
 
         public async Task Converges_NestedVirtualization_if_necessary(bool exposed, bool? shouldExpose)
         {
-            _fixture.Reset();
             var vmData = _fixture.Engine.ToPsObject(
                 new Data.Full.VirtualMachineInfo());
             var called = false;
@@ -38,7 +32,9 @@ namespace Eryph.VmManagement.Test
                     new CatletCapabilityConfig
                     {
                         Name = EryphConstants.Capabilities.NestedVirtualization,
-                        Details = new []{shouldExpose.GetValueOrDefault() ? "on" : "off"}
+                        Details = new []{shouldExpose.GetValueOrDefault() 
+                            ? EryphConstants.CapabilityDetails.Enabled
+                            : EryphConstants.CapabilityDetails.Disabled}
                     }
                 };
 

--- a/src/core/test/Eryph.VmManagement.Test/ConvergeNestedVirtualizationTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/ConvergeNestedVirtualizationTests.cs
@@ -1,0 +1,82 @@
+﻿using Eryph.ConfigModel.Catlets;
+using Eryph.Core;
+using Eryph.VmManagement.Converging;
+using LanguageExt;
+using LanguageExt.Common;
+using Xunit;
+
+namespace Eryph.VmManagement.Test
+{
+    public class ConvergeNestedVirtualizationTests : IClassFixture<ConvergeFixture>
+    {
+        private readonly ConvergeFixture _fixture;
+
+        public ConvergeNestedVirtualizationTests(ConvergeFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [InlineData(true, null)]
+        [InlineData(false, null)]
+
+        public async Task Converges_NestedVirtualization_if_necessary(bool exposed, bool? shouldExpose)
+        {
+            _fixture.Reset();
+            var vmData = _fixture.Engine.ToPsObject(
+                new Data.Full.VirtualMachineInfo());
+            var called = false;
+
+
+            if(shouldExpose.HasValue)
+                _fixture.Config.Capabilities = new[]
+                {
+                    new CatletCapabilityConfig
+                    {
+                        Name = EryphConstants.Capabilities.NestedVirtualization,
+                        Details = new []{shouldExpose.GetValueOrDefault() ? "on" : "off"}
+                    }
+                };
+
+            AssertCommand? runCommand = null;
+            _fixture.Engine.RunCallback = command =>
+            {
+                called = true;
+                runCommand = command;
+                return Unit.Default;
+            };
+            _fixture.Engine.GetValuesCallback = (_, command) =>
+            {
+                if (command.ToString().StartsWith("get-VMProcessor"))
+                {
+                    return new object []{exposed}.ToSeq();
+                }
+
+                return new PowershellFailure{ Message = $"Unexpected command {command}"};
+            };
+
+
+            var convergeTask = new ConvergeNestedVirtualization(_fixture.Context);
+            await convergeTask.Converge(vmData);
+
+            if (exposed == shouldExpose || shouldExpose == null)
+            {
+                Assert.False(called);
+                return;
+            }
+            
+            Assert.True(called);
+            Assert.NotNull(runCommand);
+            runCommand.ShouldBeCommand("Set-VMProcessor")
+                .ShouldBeParam("VM")
+                .ShouldBeParam("ExposeVirtualizationExtensions", shouldExpose);
+
+
+        }
+
+    }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
@@ -259,7 +259,7 @@ namespace Eryph.Modules.ComputeApi.Handlers
                 {
                     Name = EryphConstants.Capabilities.NestedVirtualization,
                     Details = featureOff
-                                ? new[] { "off" } : null
+                                ? new[] { EryphConstants.CapabilityDetails.Disabled } : null
                 };
                 capabilities.Add(nestedVirtualizationCap);
             }
@@ -272,10 +272,10 @@ namespace Eryph.Modules.ComputeApi.Handlers
                     
                 var details = new List<string>();
                 if(!string.IsNullOrWhiteSpace(catlet.SecureBootTemplate))
-                    details.Add($"Template:{catlet.SecureBootTemplate}");
+                    details.Add($"template:{catlet.SecureBootTemplate}");
 
                 if(featureOff)
-                    details.Add("off");
+                    details.Add(EryphConstants.CapabilityDetails.Disabled);
 
                 var secureBootCap = new CatletCapabilityConfig
                 {

--- a/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
@@ -292,10 +292,9 @@ namespace Eryph.Modules.ComputeApi.Handlers
                 var parentCap = parentCaps
                     .FirstOrDefault(x => x.Name == capabilityConfig.Name);
                 if (parentCap == null) continue;
-                if((parentCap.Details?.Length == 0                       
-                    && capabilityConfig.Details?.Length == 0)
-                       
-                   || parentCap.Details.SequenceEqual(capabilityConfig.Details))
+                var parentDetails = parentCap.Details?.Map(x => x.ToLowerInvariant()).Order().ToArray() ?? Array.Empty<string>();
+                var capDetails = capabilityConfig.Details?.Map(x => x.ToLowerInvariant()).Order().ToArray() ?? Array.Empty<string>();
+                if(parentDetails.SequenceEqual(capDetails))
                     capabilities.Remove(capabilityConfig);
             }
             if(capabilities.Count > 0)

--- a/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
@@ -225,6 +225,7 @@ namespace Eryph.Modules.Controller.Inventory
                         existingMachine.MinimumMemory = newMachine.MinimumMemory;
                         existingMachine.StartupMemory = newMachine.StartupMemory;
                         existingMachine.Features = newMachine.Features;
+                        existingMachine.SecureBootTemplate = newMachine.SecureBootTemplate;
                     });
 
 
@@ -284,6 +285,7 @@ namespace Eryph.Modules.Controller.Inventory
                 MinimumMemory = vmInfo.Memory?.Minimum ?? 0,
                 MaximumMemory = vmInfo.Memory?.Startup ?? 0,
                 Features = MapFeatures(vmInfo),
+                SecureBootTemplate = vmInfo.Firmware?.SecureBootTemplate,
                 NetworkAdapters = vmInfo.NetworkAdapters.Select(a => new CatletNetworkAdapter
                 {
                     Id = a.Id,


### PR DESCRIPTION
Adds support for converging nested virtualization and fixes issues for secure boot capability to be converged correctly. 
This PR also adds output of capabilities in reverse generated config. 

As capabilities are opt-in either by catlet or parent(s) the capabilities will only be converged if enabled or disabled. 

fixes #188  and fixes #189 

Remarks: The current genepool catlets have a bug for secure boot capabilitity - they use "SecureBoot", but this in not correct, it has to be "secure_boot". Therefore until fixed in the parents, the reverse config logic will always generate a capability for secure_boot even if it the same on parent.