### PR TITLE
Replaced InvariantCulture with Ordinal

### DIFF
--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -619,7 +619,7 @@ internal static class Program
                     var runDir = Path.Combine(targetDir, "bin");
 
                     if (pathVariableValue == null || 
-                        !pathVariableValue.Contains(runDir, StringComparison.InvariantCultureIgnoreCase))
+                        !pathVariableValue.Contains(runDir, StringComparison.OrdinalIgnoreCase))
                     {
                         Environment.SetEnvironmentVariable(pathVariable,
                             $"{pathVariableValue};{runDir}", EnvironmentVariableTarget.Machine);

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeDrives.cs
@@ -134,7 +134,7 @@ namespace Eryph.VmManagement.Converging
                         {
                             var plannedAttachPath = plannedDiskAtControllerPos.AttachPath.IfNone("");
                             if (hd.Path == null || !hd.Path.Equals(plannedAttachPath,
-                                StringComparison.InvariantCultureIgnoreCase))
+                                StringComparison.OrdinalIgnoreCase))
                                 detach = true;
                         }
 
@@ -237,7 +237,7 @@ namespace Eryph.VmManagement.Converging
                 currentStorageSettings.Find(x =>
                     driveSettings.DiskSettings.Path.Equals(x.DiskSettings.Path, StringComparison.OrdinalIgnoreCase)
                     && driveSettings.DiskSettings.Name.Equals(x.DiskSettings.Name,
-                        StringComparison.InvariantCultureIgnoreCase));
+                        StringComparison.OrdinalIgnoreCase));
 
             var frozenOptional = currentSettings.Map(x => x.Frozen);
 

--- a/src/core/src/Eryph.VmManagement/Inventory/VirtualMachineInventory.cs
+++ b/src/core/src/Eryph.VmManagement/Inventory/VirtualMachineInventory.cs
@@ -139,7 +139,7 @@ namespace Eryph.VmManagement.Inventory
             var metadataIdString = "";
             if (!string.IsNullOrWhiteSpace(notes))
             {
-                var metadataIndex = notes.IndexOf("Eryph metadata id: ", StringComparison.InvariantCultureIgnoreCase);
+                var metadataIndex = notes.IndexOf("Eryph metadata id: ", StringComparison.OrdinalIgnoreCase);
                 if (metadataIndex != -1)
                 {
                     var metadataEnd = metadataIndex + "Eryph metadata id: ".Length + 36;

--- a/src/core/src/Eryph.VmManagement/Storage/VMStorageSettings.cs
+++ b/src/core/src/Eryph.VmManagement/Storage/VMStorageSettings.cs
@@ -115,7 +115,7 @@ namespace Eryph.VmManagement.Storage
                 {
                     var fullPath = Path.Combine(firstPath, id);
 
-                    if (!secondPath.Equals(fullPath, StringComparison.InvariantCultureIgnoreCase))
+                    if (!secondPath.Equals(fullPath, StringComparison.OrdinalIgnoreCase))
                         return LeftAsync<Error, string>(Error.New(
                                 "Path calculation failure"));
 

--- a/src/core/test/Eryph.VmManagement.Test/ConvergeDriveTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/ConvergeDriveTests.cs
@@ -72,7 +72,7 @@ namespace Eryph.VmManagement.Test
                 if (commandString.Contains("Test-Path [x:\\disks\\abc\\sda.vhdx]"))
                     return new [] { _fixture.Engine.ToPsObject<object>(true) }.ToSeq();
 
-                if (commandString.Contains("Get-VHD [x:\\disks\\abc\\sda.vhdx]", StringComparison.InvariantCultureIgnoreCase))
+                if (commandString.Contains("Get-VHD [x:\\disks\\abc\\sda.vhdx]", StringComparison.OrdinalIgnoreCase))
                     return new[] { _fixture.Engine.ToPsObject<object>(new VhdInfo
                     {
                         Path = @"x:\disks\abc\sda.vhdx",

--- a/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
@@ -61,8 +61,8 @@ namespace Eryph.Modules.Controller.Inventory
             foreach (var diskInfo in diskInfos) SelectAllParentDisks(ref allDisks, diskInfo);
 
             diskInfos = allDisks.Distinct((x, y) =>
-                string.Equals(x.Path, y.Path, StringComparison.InvariantCultureIgnoreCase) &&
-                string.Equals(x.FileName, y.FileName, StringComparison.InvariantCultureIgnoreCase)).ToList();
+                string.Equals(x.Path, y.Path, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(x.FileName, y.FileName, StringComparison.OrdinalIgnoreCase)).ToList();
 
             var addedDisks = new List<VirtualDisk>();
 
@@ -88,8 +88,8 @@ namespace Eryph.Modules.Controller.Inventory
                     disk = disksDataCandidates.FirstOrDefault() ?? Option<VirtualDisk>.None;
                 else
                     disk = disksDataCandidates.FirstOrDefault(x =>
-                        string.Equals(x.Path, diskInfo.Path, StringComparison.InvariantCultureIgnoreCase) &&
-                        string.Equals(x.FileName, diskInfo.FileName, StringComparison.InvariantCultureIgnoreCase))
+                        string.Equals(x.Path, diskInfo.Path, StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(x.FileName, diskInfo.FileName, StringComparison.OrdinalIgnoreCase))
                            ?? Option<VirtualDisk>.None;
 
                 return disk;

--- a/src/modules/src/Eryph.Modules.VmHostAgent/CatletConfigCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/CatletConfigCommandHandler.cs
@@ -106,7 +106,7 @@ namespace Eryph.Modules.VmHostAgent
             var metadataIdString = "";
             if (!string.IsNullOrWhiteSpace(notes))
             {
-                var metadataIndex = notes.IndexOf("eryph metadata id: ", StringComparison.InvariantCultureIgnoreCase);
+                var metadataIndex = notes.IndexOf("eryph metadata id: ", StringComparison.OrdinalIgnoreCase);
                 if (metadataIndex != -1)
                 {
                     var metadataEnd = metadataIndex + "eryph metadata id: ".Length + 36;
@@ -168,7 +168,7 @@ namespace Eryph.Modules.VmHostAgent
         {
             return Prelude.Cond<(string currentName, string newName)>(names =>
                     !string.IsNullOrWhiteSpace(names.newName) &&
-                    !names.newName.Equals(names.currentName, StringComparison.InvariantCulture))((vmInfo.Value.Name,
+                    !names.newName.Equals(names.currentName, StringComparison.Ordinal))((vmInfo.Value.Name,
                     config.Name))
                 .Match(
                     None: () => vmInfo,


### PR DESCRIPTION
Using invariant culture considers some special characters equal that should not be considered equal. 
e.g. german ß will be same as "ss".

Fixed in entire project.