### PR TITLE
generation suffix for volumes

### DIFF
--- a/src/core/src/Eryph.VmManagement/Storage/DiskStorageSettings.cs
+++ b/src/core/src/Eryph.VmManagement/Storage/DiskStorageSettings.cs
@@ -105,10 +105,9 @@ namespace Eryph.VmManagement.Storage
                 return System.IO.Path.GetFileNameWithoutExtension(path);
 
             var fileName = System.IO.Path.GetFileNameWithoutExtension(path);
-            var extension = System.IO.Path.GetExtension(path);
             var generationSuffix = $"_g{generation}";
             return fileName.EndsWith(generationSuffix)
-                ? fileName[..^generationSuffix.Length] + extension
+                ? fileName[..^generationSuffix.Length]
                 : fileName;
         }
     }

--- a/src/core/src/Eryph.VmManagement/Storage/StorageNames.cs
+++ b/src/core/src/Eryph.VmManagement/Storage/StorageNames.cs
@@ -118,9 +118,9 @@ namespace Eryph.VmManagement.Storage
             where genePathParts.Length == 4
             where string.Equals(genePathParts[3], "volumes", StringComparison.OrdinalIgnoreCase)
             let geneFileName = Path.GetFileNameWithoutExtension(genePath)
-            from geneIdentifer in GeneIdentifier.NewOption(
+            from geneIdentifier in GeneIdentifier.NewOption(
                 $"gene:{genePathParts[0]}/{genePathParts[1]}/{genePathParts[2]}:{geneFileName}")
-            select geneIdentifer;
+            select geneIdentifier;
         
 
         private Either<Error, (string VmPath, string VhdPath)> ResolveStorageBasePaths(

--- a/src/core/test/Eryph.VmManagement.Test/ConvergeDriveTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/ConvergeDriveTests.cs
@@ -250,7 +250,7 @@ namespace Eryph.VmManagement.Test
                 if (commandString.Contains("Get-VM"))
                     return new[] { _fixture.Engine.ToPsObject<object>(vmData.Value) }.ToSeq();
 
-                if (commandString.Contains(@"Test-Path [x:\disks\abc\sda.vhdx]"))
+                if (commandString.Contains(@"Test-Path [x:\disks\abc\sda_g1.vhdx]"))
                     return new[] { _fixture.Engine.ToPsObject<object>(false) }.ToSeq();
 
 
@@ -284,7 +284,7 @@ namespace Eryph.VmManagement.Test
 
             vhdCommand.Should().NotBeNull();
             vhdCommand!.ShouldBeCommand("New-VHD")
-                .ShouldBeParam("Path", @"x:\disks\abc\sda.vhdx")
+                .ShouldBeParam("Path", @"x:\disks\abc\sda_g1.vhdx")
                 .ShouldBeParam("ParentPath", @"x:\disks\genepool\testorg\testset\testtag\volumes\sda.vhdx")
                 .ShouldBeFlag("Differencing")
                 .ShouldBeParam("SizeBytes", 1073741824);
@@ -292,7 +292,7 @@ namespace Eryph.VmManagement.Test
             attachCommand.Should().NotBeNull();
             attachCommand!.ShouldBeCommand("Add-VMHardDiskDrive")
                 .ShouldBeParam("VM", vmData.PsObject)
-                .ShouldBeParam("Path", @"x:\disks\abc\sda.vhdx");
+                .ShouldBeParam("Path", @"x:\disks\abc\sda_g1.vhdx");
         }
 
         [Theory]

--- a/src/core/test/Eryph.VmManagement.Test/Storage/VMDriveStorageSettingsTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/Storage/VMDriveStorageSettingsTests.cs
@@ -185,7 +185,7 @@ public class VMDriveStorageSettingsTests
                 dss.ControllerLocation.Should().Be(0);
                 
                 var settings = dss.Should().BeOfType<HardDiskDriveStorageSettings>().Subject;
-                settings.AttachPath.Should().Be(@"x:\disks\storage-id-vm\sda.vhdx");
+                settings.AttachPath.Should().Be(@"x:\disks\storage-id-vm\sda_g1.vhdx");
                 settings.DiskSettings.SizeBytes.Should().BeNull();
                 settings.DiskSettings.SizeBytesCreate.Should().Be(42);
 
@@ -305,7 +305,7 @@ public class VMDriveStorageSettingsTests
                 dss.ControllerLocation.Should().Be(0);
 
                 var settings = dss.Should().BeOfType<HardDiskDriveStorageSettings>().Subject;
-                settings.AttachPath.Should().Be(@"x:\disks\storage-id-vm\sda.vhdx");
+                settings.AttachPath.Should().Be(@"x:\disks\storage-id-vm\sda_g1.vhdx");
                 settings.DiskSettings.SizeBytes.Should().Be(42 * 1024L * 1024 * 1024);
                 settings.DiskSettings.SizeBytesCreate.Should().Be(42 * 1024L * 1024 * 1024);
 

--- a/src/core/test/Eryph.VmManagement.Test/Storage/VMDriveStorageSettingsTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/Storage/VMDriveStorageSettingsTests.cs
@@ -420,4 +420,69 @@ public class VMDriveStorageSettingsTests
         settings.Path.Should().Be(@"x:\disks\genepool\testorg\testset\testtag\volumes");
         settings.Name.Should().Be("sda");
     }
+
+    [Fact]
+    public async Task FromVhdPath_Resolved_Name_without_generation()
+    {
+        var path = @"x:\disks\genepool\testorg\testset\testtag\volumes\sda_g2.vhdx";
+        var mapping = new FakeTypeMapping();
+        var psEngine = new TestPowershellEngine(mapping);
+        psEngine.GetObjectCallback = (t, command) =>
+        {
+            if(command.ToString().StartsWith("Get-VHD"))
+            {
+                if (command.ToString().Contains("sda_g2"))
+                {
+                    return new[]
+                    {
+                        psEngine.ToPsObject<object>(new VhdInfo
+                        {
+                            ParentPath = @"x:\dummy\sda_g1.vhdx",
+                            Path = path,
+                        })
+                    }.ToSeq();
+                }
+
+                if (command.ToString().Contains("sda_g1"))
+                {
+                    return new[]
+                    {
+                        psEngine.ToPsObject<object>(new VhdInfo
+                        {
+                            ParentPath = @"x:\dummy\sda.vhdx",
+                            Path = @"x:\dummy\sda_g1.vhdx",
+                        })
+                    }.ToSeq();
+                }
+
+                return new[]
+                {
+                    psEngine.ToPsObject<object>(new VhdInfo
+                    {
+                        Path = @"x:\dummy\sda.vhdx",
+                    })
+                }.ToSeq();
+
+            }
+
+            return new PowershellFailure{Message = "Unknown command"};
+        };
+
+        var result = await DiskStorageSettings.FromVhdPath(
+            psEngine, new VmHostAgentConfiguration
+            {
+                Defaults = new VmHostAgentDefaultsConfiguration
+                {
+                    Volumes = @"x:\disks\genepool\testorg\testset\testtag\volumes",
+                }
+            }, Some(path));
+
+
+        result.Should().BeRight().Which.Should().BeSome(
+            dss =>
+            {
+                dss.Name.Should().Be("sda");
+                dss.Generation.Should().Be(2);
+            });
+    }
 }


### PR DESCRIPTION
This PR adds a suffix g[generation] to volumes. This makes the volume name unique even if it has a parent with same name. The generation is increased for each parent. 

Generations are not used for shared vhds and vhd sets, as these will never have a attached parent.

fixes #123 

In contrast to the propsed solution of #123 this also works for multiple parents.