### PR TITLE
Support for DNS on overlay networks

### DIFF
--- a/Eryph.sln.DotSettings
+++ b/Eryph.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FIP/@EntryIndexedValue">FIP</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=FQDN/@EntryIndexedValue">FQDN</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MTU/@EntryIndexedValue">MTU</s:String>
@@ -11,6 +12,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=VM/@EntryIndexedValue">VM</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Method/@EntryIndexedValue">&lt;Policy Inspect="False" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="False" Prefix="T" Suffix="" Style="AaBb_AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=arpa/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catlet/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catlets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cidr/@EntryIndexedValue">True</s:Boolean>

--- a/Eryph.sln.DotSettings
+++ b/Eryph.sln.DotSettings
@@ -12,6 +12,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=VM/@EntryIndexedValue">VM</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Method/@EntryIndexedValue">&lt;Policy Inspect="False" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="False" Prefix="T" Suffix="" Style="AaBb_AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=addr/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=arpa/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catlet/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catlets/@EntryIndexedValue">True</s:Boolean>
@@ -19,6 +20,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Cmdlets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Configurer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dbosoft/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=dnat/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Eryph/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dhcp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Genepack/@EntryIndexedValue">True</s:Boolean>
@@ -30,6 +32,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Passthru/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Powershell/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=realizer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=snat/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Uninstallation/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Virtualization/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Vlan/@EntryIndexedValue">True</s:Boolean>

--- a/src/core/src/Eryph.Configuration/Configuration/Model/CatletNetworkPortConfigModel.cs
+++ b/src/core/src/Eryph.Configuration/Configuration/Model/CatletNetworkPortConfigModel.cs
@@ -19,5 +19,7 @@ namespace Eryph.Configuration.Model
         public IpAssignmentConfigModel[] IpAssignments { get; set; }
 
         public Guid CatletMetadataId { get; set; }
+
+        public string AddressName { get; set; }
     }
 }

--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -4,10 +4,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.3.1-PullRequest0070.6" />
-    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.3.1-PullRequest0070.6" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.3.1-PullRequest0070.6" />
-    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.4.0" />
+    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.4.0" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.4.0" />
+    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.4.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -4,10 +4,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.3.1-ci.4" />
-    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.3.1-ci.4" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.3.1-ci.4" />
-    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.3.1-ci.4" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.3.1-PullRequest0070.6" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/CatletMetadata.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/CatletMetadata.cs
@@ -19,7 +19,6 @@ namespace Eryph.Resources.Machines
 
         [CanBeNull] public CatletConfig ParentConfig { get; set; }
 
-        public string SocialName { get; set; }
         [CanBeNull] public FodderConfig[] Fodder { get; set; }
         public bool SecureDataHidden { get; set; }
     }

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -6,8 +6,8 @@
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.NoCloud" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.WindowsImaging" Version="1.0.0-rc.12" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.3.1-ci.4" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.1-ci.4" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.1-PullRequest0070.6" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -6,8 +6,8 @@
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.NoCloud" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.WindowsImaging" Version="1.0.0-rc.12" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.3.1-PullRequest0070.6" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.4.0" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/data/src/Eryph.StateDb/Migrations/20240425224456_dns.Designer.cs
+++ b/src/data/src/Eryph.StateDb/Migrations/20240425224456_dns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eryph.StateDb;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Eryph.StateDb.Migrations
 {
     [DbContext(typeof(StateStoreContext))]
-    partial class StateStoreContextModelSnapshot : ModelSnapshot
+    [Migration("20240425224456_dns")]
+    partial class dns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.4");

--- a/src/data/src/Eryph.StateDb/Migrations/20240425224456_dns.cs
+++ b/src/data/src/Eryph.StateDb/Migrations/20240425224456_dns.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eryph.StateDb.Migrations
+{
+    /// <inheritdoc />
+    public partial class dns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DnsDomain",
+                table: "Subnet",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "LastUpdated",
+                table: "OperationTasks",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "TEXT",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AddressName",
+                table: "NetworkPorts",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DnsDomain",
+                table: "Subnet");
+
+            migrationBuilder.DropColumn(
+                name: "AddressName",
+                table: "NetworkPorts");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "LastUpdated",
+                table: "OperationTasks",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "TEXT");
+        }
+    }
+}

--- a/src/data/src/Eryph.StateDb/Model/NetworkPort.cs
+++ b/src/data/src/Eryph.StateDb/Model/NetworkPort.cs
@@ -10,6 +10,8 @@ public abstract class NetworkPort
     public Guid Id { get; set; }
     public string MacAddress { get; set; }
 
+    public string AddressName { get; set; }
+
     public string Name { get; set; }
     public virtual List<IpAssignment> IpAssignments { get; set; }
 

--- a/src/data/src/Eryph.StateDb/Model/Subnet.cs
+++ b/src/data/src/Eryph.StateDb/Model/Subnet.cs
@@ -12,4 +12,6 @@ public class Subnet
     public string IpNetwork { get; set; }
 
     public virtual List<IpPool> IpPools { get; set; }
+    public string DnsDomain { get; set; }
+
 }

--- a/src/modules/src/Eryph.ModuleCore/Networks/VirtualNetworksExtensions.cs
+++ b/src/modules/src/Eryph.ModuleCore/Networks/VirtualNetworksExtensions.cs
@@ -77,10 +77,12 @@ namespace Eryph.ModuleCore.Networks
             string? GetDnsDomain(VirtualNetwork network, Subnet subnet)
             {
                 // set to null in case it matches either the default or environment default
-                return network.Environment is null or "default" ? 
-                    subnet.DnsDomain == "home.arpa" ? null: subnet.DnsDomain
-                    : subnet.DnsDomain == $"{network.Environment??"".ToLowerInvariant()}.home.arpa" 
-                        ? null : subnet.DnsDomain;
+                if (network.Environment is null or "default")
+                    return subnet.DnsDomain == "home.arpa" ? null : subnet.DnsDomain;
+
+                return subnet.DnsDomain == $"{network.Environment ?? "".ToLowerInvariant()}.home.arpa"
+                    ? null
+                    : subnet.DnsDomain;
             }
 
             string[]? GetDnsServers(IPNetwork2 ipNetwork, VirtualNetworkSubnet subnet)

--- a/src/modules/src/Eryph.ModuleCore/Networks/VirtualNetworksExtensions.cs
+++ b/src/modules/src/Eryph.ModuleCore/Networks/VirtualNetworksExtensions.cs
@@ -44,7 +44,12 @@ namespace Eryph.ModuleCore.Networks
                                     ? subnet.DnsServersV4?.Split(",", StringSplitOptions.RemoveEmptyEntries)
                                     : null,
                                 Mtu = subnet.MTU,
-                                DnsDomain = subnet.DnsDomain == "home.arpa" ? null: subnet.DnsDomain,
+
+                                // set to null in case it matches either the default or environment default
+                                DnsDomain = network.Environment is null or "default" ? 
+                                    subnet.DnsDomain == "home.arpa" ? null: subnet.DnsDomain
+                                    : subnet.DnsDomain == $"{network.Environment??"".ToLowerInvariant()}.home.arpa" 
+                                        ? null : subnet.DnsDomain,
                                 IpPools = subnet.IpPools.Count > 0 ? subnet.IpPools.Select(ipPool => new IpPoolConfig
                                 {
                                     Name = ipPool.Name,

--- a/src/modules/src/Eryph.ModuleCore/Networks/VirtualNetworksExtensions.cs
+++ b/src/modules/src/Eryph.ModuleCore/Networks/VirtualNetworksExtensions.cs
@@ -44,6 +44,7 @@ namespace Eryph.ModuleCore.Networks
                                     ? subnet.DnsServersV4?.Split(",", StringSplitOptions.RemoveEmptyEntries)
                                     : null,
                                 Mtu = subnet.MTU,
+                                DnsDomain = subnet.DnsDomain == "home.arpa" ? null: subnet.DnsDomain,
                                 IpPools = subnet.IpPools.Count > 0 ? subnet.IpPools.Select(ipPool => new IpPoolConfig
                                 {
                                     Name = ipPool.Name,

--- a/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
 
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.1-ci.4" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.1-PullRequest0070.6" />
 
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
 
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.0" />
 
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
@@ -7,7 +7,7 @@
     </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.3.1-ci.4" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.3.1-PullRequest0070.6" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
@@ -7,7 +7,7 @@
     </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.4.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualNetworks/VirtualNetworkChangeHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualNetworks/VirtualNetworkChangeHandler.cs
@@ -79,6 +79,7 @@ internal class VirtualNetworkChangeHandler : IChangeHandler<VirtualNetworkChange
                 VirtualNetworkName = p.Network.Name,
                 EnvironmentName = p.Network.Environment,
                 CatletMetadataId = p.CatletMetadataId,
+                AddressName = p.AddressName,
                 MacAddress = p.MacAddress,
                 FloatingNetworkPort = p.FloatingPort is null
                     ? null

--- a/src/modules/src/Eryph.Modules.Controller/DataServices/IVirtualMachineMetadataService.cs
+++ b/src/modules/src/Eryph.Modules.Controller/DataServices/IVirtualMachineMetadataService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Eryph.Resources.Machines;
 using LanguageExt;

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.3" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.3.1-ci.4" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.1-ci.4" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.1-PullRequest0070.6" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.3" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.3.1-PullRequest0070.6" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.4.0" />
+    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -16,7 +16,7 @@
     <Folder Include="EventHandlers\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.3" />
+    <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.4" />
     <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.4.0" />
     <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.4.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">

--- a/src/modules/src/Eryph.Modules.Controller/Networks/NetplanBuilderSpecs.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Networks/NetplanBuilderSpecs.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Ardalis.Specification;
 using Eryph.StateDb.Model;
 
@@ -24,8 +25,11 @@ public static class NetplanBuilderSpecs
             Query
                 .Where(x => x.ProjectId == projectId)
                 .Include(x=>x.RouterPort).ThenInclude(x=>x.IpAssignments)
-                .Include(x => x.NetworkPorts).ThenInclude(x => x.IpAssignments)
                 .Include(x => x.NetworkPorts)
+                .ThenInclude(x => x.IpAssignments)
+                .ThenInclude(x=>x.Subnet);
+
+            Query.Include(x => x.NetworkPorts)
                 .ThenInclude(x=>x.FloatingPort).ThenInclude(x=>x.IpAssignments)
                 .Include(x => x.Subnets);
 

--- a/src/modules/src/Eryph.Modules.Controller/Networks/NetworkConfigRealizer.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Networks/NetworkConfigRealizer.cs
@@ -292,8 +292,14 @@ public class NetworkConfigRealizer : INetworkConfigRealizer
                     ? string.Join(',', subnetConfig.DnsServers)
                     : null;
                 savedSubnet.IpNetwork = subnetConfig.Address ?? networkConfig.Address;
-                subnetConfig.IpPools ??= Array.Empty<IpPoolConfig>();
 
+                // default domain is home.arpa
+                // except for environments where the default is [environment].home.arpa
+                // user set domain names are always preferred (even if this could result in duplicate names)
+                savedSubnet.DnsDomain ??= savedNetwork.Environment is null or "default" 
+                            ? subnetConfig.DnsDomain ?? "home.arpa"
+                            : subnetConfig.DnsDomain ?? $"{(savedNetwork.Environment??"").ToLowerInvariant()}.home.arpa";
+                subnetConfig.IpPools ??= Array.Empty<IpPoolConfig>();
 
                 foundNames.Clear();
 

--- a/src/modules/src/Eryph.Modules.Controller/Networks/ProjectNetworkPlanBuilder.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Networks/ProjectNetworkPlanBuilder.cs
@@ -232,7 +232,14 @@ internal class ProjectNetworkPlanBuilder(INetworkProviderManager networkProvider
     private static NetworkPlan AddDnsNames(NetworkPlan networkPlan,
         Seq<CatletDnsInfo> catletDnsInfos ) =>
         catletDnsInfos.Map(info => networkPlan.AddDnsRecords(
-            info.CatletId, info.Addresses)).Apply(s => JoinPlans(s, networkPlan));
+                info.CatletId,
+                info.Addresses,
+                // Mark the DNS records as owned by OVN. OVN will then not forward
+                // DNS requests (A, AAAA, ANY) for these records when it cannot resolve
+                // them itself. This prevents DNS requests from being forwarded when
+                // only IPv4 or IPv6 is configured.
+                Prelude.Map(("ovn-owned", "true"))))
+            .Apply(s => JoinPlans(s, networkPlan));
 
 
     private static NetworkPlan AddFloatingPorts(NetworkPlan networkPlan, Seq<FloatingPortInfo> ports)

--- a/src/modules/src/Eryph.Modules.Controller/Networks/ProjectNetworkPlanBuilder.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Networks/ProjectNetworkPlanBuilder.cs
@@ -23,7 +23,7 @@ internal class ProjectNetworkPlanBuilder(INetworkProviderManager networkProvider
     private sealed record ProviderRouterPortInfo(ProviderRouterPort Port, VirtualNetwork Network, ProviderSubnetInfo Subnet);
     private sealed record ProviderSubnetInfo(ProviderSubnet Subnet, NetworkProviderSubnet Config);
 
-    private sealed record CatletDnsInfo(string CatletId, Map<string, string> Addresses);
+    private sealed record CatletDnsInfo(string CatletMetadataId, Map<string, string> Addresses);
 
     private static ProviderSubnetInfo EmptyProviderSubnetInfo => new(new ProviderSubnet(), new NetworkProviderSubnet());
 
@@ -46,7 +46,7 @@ internal class ProjectNetworkPlanBuilder(INetworkProviderManager networkProvider
             let catletPorts = FindPortsOfType<CatletNetworkPort>(networks)
             from floatingPorts in GetFloatingPorts(catletPorts, providerSubnets)
             let dnsInfo = MapCatletPortsToDnsInfos(catletPorts)
-            let dnsNames = dnsInfo.Select(info => info.CatletId).ToArray()
+            let dnsNames = dnsInfo.Select(info => info.CatletMetadataId).ToArray()
 
             let p1 = AddProjectRouterAndPorts(networkPlan, networks)
             let p2 = AddExternalNetSwitches(p1, providerSubnets, overLayProviders)
@@ -232,7 +232,7 @@ internal class ProjectNetworkPlanBuilder(INetworkProviderManager networkProvider
     private static NetworkPlan AddDnsNames(NetworkPlan networkPlan,
         Seq<CatletDnsInfo> catletDnsInfos ) =>
         catletDnsInfos.Map(info => networkPlan.AddDnsRecords(
-                info.CatletId,
+                info.CatletMetadataId,
                 info.Addresses,
                 // Mark the DNS records as owned by OVN. OVN will then not forward
                 // DNS requests (A, AAAA, ANY) for these records when it cannot resolve

--- a/src/modules/src/Eryph.Modules.Controller/Networks/ProjectNetworkPlanBuilder.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Networks/ProjectNetworkPlanBuilder.cs
@@ -18,12 +18,12 @@ internal class ProjectNetworkPlanBuilder(INetworkProviderManager networkProvider
     : IProjectNetworkPlanBuilder
 {
 
-    private record FloatingPortInfo(FloatingNetworkPort Port);
+    private sealed record FloatingPortInfo(FloatingNetworkPort Port);
 
-    private record ProviderRouterPortInfo(ProviderRouterPort Port, VirtualNetwork Network, ProviderSubnetInfo Subnet);
-    private record ProviderSubnetInfo(ProviderSubnet Subnet, NetworkProviderSubnet Config);
+    private sealed record ProviderRouterPortInfo(ProviderRouterPort Port, VirtualNetwork Network, ProviderSubnetInfo Subnet);
+    private sealed record ProviderSubnetInfo(ProviderSubnet Subnet, NetworkProviderSubnet Config);
 
-    private record CatletDnsInfo(string CatletId, Map<string, string> Addresses);
+    private sealed record CatletDnsInfo(string CatletId, Map<string, string> Addresses);
 
     private static ProviderSubnetInfo EmptyProviderSubnetInfo => new(new ProviderSubnet(), new NetworkProviderSubnet());
 
@@ -79,7 +79,7 @@ internal class ProjectNetworkPlanBuilder(INetworkProviderManager networkProvider
                     $"Network '{info.Network.Name}' configuration error: subnet {info.Port.SubnetName} of network provider {info.Network.NetworkProvider} not found."))
                 .Map(providerSubnet => info with { Subnet = providerSubnet })).SequenceSerial());
 
-    private EitherAsync<Error, Seq<FloatingPortInfo>> GetFloatingPorts(
+    private static EitherAsync<Error, Seq<FloatingPortInfo>> GetFloatingPorts(
         Seq<CatletNetworkPort> catletPorts, Seq<ProviderSubnetInfo> providerSubnets)
     {
         return catletPorts
@@ -192,7 +192,7 @@ internal class ProjectNetworkPlanBuilder(INetworkProviderManager networkProvider
                         ("dns_server", string.IsNullOrWhiteSpace(subnet.DnsServersV4) ? "9.9.9.9" :
                             $"{{{string.Join(',', subnet.DnsServersV4.Split(','))}}}"),
                         ("router", networkIp.IpAddress ),
-                        //("domain_name", $"\"{subnet.DnsDomain}\"")
+                        ("domain_name", $"\\\\\\\"{subnet.DnsDomain}\\\\\\\"")
 
                     }
                 )

--- a/src/modules/src/Eryph.Modules.Controller/Networks/UpdateCatletNetworksCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Networks/UpdateCatletNetworksCommandHandler.cs
@@ -93,7 +93,8 @@ public class UpdateCatletNetworksCommandHandler : IHandleMessages<OperationTask<
         let c1 = new CancellationTokenSource(5000)
 
         from networkPort in GetOrAddAdapterPort(
-            network, command.CatletId, catletMetadataId, networkConfig.AdapterName, c1.Token)
+            network, command.CatletId, catletMetadataId, networkConfig.AdapterName,
+            command.Config.Hostname ?? command.Config.Name, c1.Token)
 
         let c2 = new CancellationTokenSource()
 
@@ -146,7 +147,8 @@ public class UpdateCatletNetworksCommandHandler : IHandleMessages<OperationTask<
         VirtualNetwork network,
         Guid catletId,
         Guid catletMetadataId,
-        string adapterName, 
+        string adapterName,
+        string addressName,
         CancellationToken cancellationToken)
     {
         var portName = $"{catletId}_{adapterName}";
@@ -167,7 +169,11 @@ public class UpdateCatletNetworksCommandHandler : IHandleMessages<OperationTask<
                     return _stateStore.For<VirtualNetworkPort>().AddAsync(port, cancellationToken);
                 }
             ).ConfigureAwait(false))
-            .Map(p => (CatletNetworkPort)p);
+            .Map(p =>
+            {
+                p.AddressName = addressName;
+                return (CatletNetworkPort)p;
+            });
 
     }
 

--- a/src/modules/src/Eryph.Modules.Controller/Seeding/CatletNetworkPortSeeder.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Seeding/CatletNetworkPortSeeder.cs
@@ -91,6 +91,7 @@ internal class CatletNetworkPortSeeder : SeederBase
             FloatingPort = floatingPort,
             Network = network,
             CatletMetadataId = portConfig.CatletMetadataId,
+            AddressName = portConfig.AddressName,
             IpAssignments = assignments.ToList(),
         };
 

--- a/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
+++ b/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\..\..\data\src\Eryph.StateDb\Eryph.StateDb.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.3" />
+    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.4" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.3" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.3.1-ci.4" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.3.1-PullRequest0070.6" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.1.1-ci.3" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -7,7 +7,7 @@
     <None Include="..\..\..\..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.3" />
+    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.4" />
     <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.4.0" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.1.1-ci.3" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.3" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.3.1-PullRequest0070.6" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.4.0" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.1.1-ci.3" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/VirtualNetworkChangeTrackingTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/VirtualNetworkChangeTrackingTests.cs
@@ -128,6 +128,7 @@ public class VirtualNetworkChangeTrackingTests : ChangeTrackingTestBase
         await WithHostScope(async stateStore =>
         {
             var catletPort = await stateStore.For<CatletNetworkPort>().GetByIdAsync(CatletPortId);
+            catletPort!.AddressName = "test";
             catletPort!.MacAddress = "00:00:00:00:00:02";
 
             await stateStore.SaveChangesAsync();
@@ -136,6 +137,7 @@ public class VirtualNetworkChangeTrackingTests : ChangeTrackingTestBase
         var networksConfig = await ReadNetworksConfig();
         networksConfig.Should().BeEquivalentTo(_expectedNetworksConfig);
         var portsConfig = await ReadPortsConfig();
+        _expectedPortsConfig.CatletNetworkPorts[0].AddressName = "test";
         _expectedPortsConfig.CatletNetworkPorts[0].MacAddress = "00:00:00:00:00:02";
         portsConfig.Should().BeEquivalentTo(_expectedPortsConfig);
     }
@@ -419,11 +421,13 @@ public class VirtualNetworkChangeTrackingTests : ChangeTrackingTestBase
         await WithHostScope(async stateStore =>
         {
             var subnet = await stateStore.For<VirtualNetworkSubnet>().GetByIdAsync(VirtualSubnetId);
+            subnet!.DnsDomain = "eryph.invalid";
             subnet!.MTU = 1300;
             await stateStore.SaveChangesAsync();
         });
 
         var networksConfig = await ReadNetworksConfig();
+        _expectedNetworksConfig.Networks![0].Subnets![0].DnsDomain = "eryph.invalid";
         _expectedNetworksConfig.Networks![0].Subnets![0].Mtu = 1300;
         networksConfig.Should().BeEquivalentTo(_expectedNetworksConfig);
         var portsConfig = await ReadPortsConfig();


### PR DESCRIPTION
This PR adds support for DNS with overlay networks.
resolves #191 

**Remarks:** 
This PR adds a DNSDomain field to the Subnet table and an AddressName field to the NetworkPort table, but not to VirtualNetworkSubnet and CatletPortsTable, because the same fields should be used for provider networks to provide similar functionality for provider ports later. 

