### PR TITLE
fix install.ps1 - HyperV check

### DIFF
--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -484,7 +484,7 @@ if((Test-CommandExist "Get-WindowsFeature")){
 } else{
     $HyperVFeature = Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V-All -Online
     # Check if Hyper-V is enabled
-    if($hyperv.State -ne "Enabled") {
+    if($HyperVFeature.State -ne "Enabled") {
         Write-Warning "Hyper-V is not installed. Installing feature..."
         Enable-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V-All -Online
 


### PR DESCRIPTION
Invalid variable name in hyperv check cause check to fail always on workstations.