### PR TITLE
Fix logging issues

### DIFF
--- a/Eryph.sln.DotSettings
+++ b/Eryph.sln.DotSettings
@@ -14,6 +14,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=TypeParameters/@EntryIndexedValue">&lt;Policy Inspect="False" Prefix="T" Suffix="" Style="AaBb_AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=addr/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=arpa/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catlet/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Catlets/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cidr/@EntryIndexedValue">True</s:Boolean>

--- a/src/apps/src/Eryph-zero/DriverCommands.cs
+++ b/src/apps/src/Eryph-zero/DriverCommands.cs
@@ -40,7 +40,8 @@ internal static class DriverCommands
             $"The following driver packages are installed:",
             (acc, info) =>
                 $"{acc}{Environment.NewLine}\t{info.Driver} - {info.Version} {info.OriginalFileName}"))
-        from ovsRunDir in Eff(() => OVSPackage.UnpackAndProvide())
+        from ovsPackageLogger in default(DriverCommandsRuntime).Logger<OVSPackage>()
+        from ovsRunDir in Eff(() => OVSPackage.UnpackAndProvide(ovsPackageLogger))
         let packageInfFile = Path.Combine(ovsRunDir, "driver", "dbo_ovse.inf")
         from packageDriverVersion in getDriverVersionFromInfFile(
             packageInfFile)

--- a/src/apps/src/Eryph-zero/ZeroLogging.cs
+++ b/src/apps/src/Eryph-zero/ZeroLogging.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Filters;
+using Serilog.Templates;
+using Serilog.Templates.Themes;
+
+namespace Eryph.Runtime.Zero;
+
+internal static class ZeroLogging
+{
+    public static Logger CreateLogger(IConfiguration configuration)
+    {
+        var logFolder = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+            "eryph", "zero", "logs");
+
+        var consoleTemplate = new ExpressionTemplate(
+            "[{@t:yyyy-MM-dd HH:mm:ss.fff} {@l:u3}] {#if ovsLogLevel is not null}[OVS:{controlFile}:{ovsSender}:{ovsLogLevel}] {#end}{@m}\n{@x}",
+            theme: TemplateTheme.Literate);
+        var fileTemplate = new ExpressionTemplate(
+            "[{@t:yyyy-MM-dd HH:mm:ss.fff zzz} {@l:u3}] [{SourceContext}] {#if ovsLogLevel is not null}[OVS:{controlFile}:{ovsSender}:{ovsLogLevel}] {#end}{@m}\n{@x}");
+
+        var loggerConfiguration = new LoggerConfiguration()
+            .ReadFrom.Configuration(configuration)
+            .Enrich.FromLogContext()
+            .WriteTo.Logger(c => c
+                .MinimumLevel.Debug()
+                .WriteTo.Console(consoleTemplate))
+            .WriteTo.Logger(c => c
+                .MinimumLevel.Error()
+                .WriteTo.EventLog(source: "eryph-zero", logName: "Application"))
+            .WriteTo.Logger(c => c
+                .WriteTo.File(
+                    fileTemplate,
+                    Path.Combine(logFolder, "eryph-zero-.log"),
+                    rollingInterval: RollingInterval.Day,
+                    retainedFileCountLimit: 10,
+                    retainedFileTimeLimit: TimeSpan.FromDays(30)));
+
+        return loggerConfiguration.CreateLogger();
+    }
+}

--- a/src/apps/src/Eryph-zero/ZeroStartupConfig.cs
+++ b/src/apps/src/Eryph-zero/ZeroStartupConfig.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Eryph.Runtime.Zero.HttpSys;
+using Eryph.Security.Cryptography;
+using Microsoft.Extensions.Configuration;
+
+namespace Eryph.Runtime.Zero;
+
+internal class ZeroStartupConfig
+{
+    public required IConfiguration Configuration { get; init; }
+
+    public required string? BasePath { get; init; }
+
+    public required ISSLEndpointManager SslEndpointManager { get; init; }
+
+    public required ICryptoIOServices CryptoIO { get; init; }
+
+    public required ICertificateGenerator CertificateGenerator { get; init; }
+
+    public required string? OvsPackageDir { get; init; }
+}

--- a/src/apps/src/Eryph-zero/appsettings.Development.json
+++ b/src/apps/src/Eryph-zero/appsettings.Development.json
@@ -1,20 +1,15 @@
 ﻿{
-  "Logging": {
-    "IncludeScopes": {},
-    "LogLevel": {
-      "Default": "Information",
-      "System": "Information",
-      "Microsoft": "Warning",
-      "Eryph": "Debug",
-      "Dbosoft.OVN": "Debug",
-      "Eryph.Modules.VmHostAgent.Networks": "Debug"
-    },
-    "EventLog": {
-      "SourceName": "eryph-zero",
-      "LogName": "Application"
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Verbose",
+      "Override": {
+        "Dbosoft.OVN": "Information",
+        "Microsoft": "Warning",
+        "Rebus": "Information",
+        "System": "Warning"
+      }
     }
-
   },
-  "basePath":  "https://localhost:8000",
+  "basePath": "https://localhost:8000",
   "ovsPackagePath": "..\\..\\..\\..\\..\\..\\..\\"
 }

--- a/src/apps/src/Eryph-zero/appsettings.json
+++ b/src/apps/src/Eryph-zero/appsettings.json
@@ -1,12 +1,11 @@
 ﻿{
-  
-  "Logging": {
-    "LogLevel": {
-      "Default": "Warning"
-    },
-    "EventLog": {
-      "SourceName": "eryph-zero",
-      "LogName": "Application"
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     }
   }
 }

--- a/src/apps/src/Eryph-zero/eryph-zero.csproj
+++ b/src/apps/src/Eryph-zero/eryph-zero.csproj
@@ -32,11 +32,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.48.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />

--- a/src/infrastructure/src/Eryph.Rebus/Eryph.Rebus.csproj
+++ b/src/infrastructure/src/Eryph.Rebus/Eryph.Rebus.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Rebus" Version="8.4.2" />
     <PackageReference Include="Rebus.Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Rebus.RabbitMq" Version="9.3.0" />
-    <PackageReference Include="Rebus.Serilog" Version="8.0.0" />
     <PackageReference Include="Rebus.TransactionScopes" Version="7.0.1" />
     <PackageReference Include="Rebus.UnitOfWork" Version="7.0.1" />
   </ItemGroup>

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiModule.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiModule.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Rebus.Config;
 using Rebus.Handlers;
 using Rebus.Retry.Simple;
@@ -125,7 +126,8 @@ namespace Eryph.Modules.AspNetCore
                         x.RetryStrategy();
                         x.SetNumberOfWorkers(5);
                     })
-                    .Logging(x => x.Serilog()).Start();
+                    .Logging(x => x.MicrosoftExtensionsLogging(container.GetInstance<ILoggerFactory>()))
+                    .Start();
             });
         }
     }

--- a/src/modules/src/Eryph.Modules.Controller/ControllerModule.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ControllerModule.cs
@@ -23,6 +23,7 @@ using IdGen;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Rebus.Config;
 using Rebus.Handlers;
 using Rebus.Retry.Simple;
@@ -109,7 +110,7 @@ namespace Eryph.Modules.Controller
                     s.EnforceExclusiveAccess();
                 })
                 .Subscriptions(s => serviceProvider.GetService<IRebusConfigurer<ISubscriptionStorage>>()?.Configure(s))
-                .Logging(x => x.Serilog())
+                .Logging(x => x.MicrosoftExtensionsLogging(container.GetInstance<ILoggerFactory>()))
                 .Start());
         }
 

--- a/src/modules/src/Eryph.Modules.VmHostAgent/VmHostAgentModule.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/VmHostAgentModule.cs
@@ -18,6 +18,7 @@ using Eryph.VmManagement.Tracing;
 using JetBrains.Annotations;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
 using Polly.Extensions.Http;
@@ -123,7 +124,8 @@ namespace Eryph.Modules.VmHostAgent
                     x.EnableSynchronousRequestReply();
                 })
                 .Subscriptions(s => serviceProvider.GetService<IRebusConfigurer<ISubscriptionStorage>>()?.Configure(s))
-                .Logging(x => x.Serilog()).Start());
+                .Logging(x => x.MicrosoftExtensionsLogging(container.GetInstance<ILoggerFactory>()))
+                .Start());
         }
 
         private static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()


### PR DESCRIPTION
Fix some logging issues which were caused by not initializing the static `Log.Logger`:
- Internal logging by Rebus was not working: logging for Rebus now uses `Microsoft.Extensions.Logging` with injected Serilog
- Some logs were lost during startup: use loggers from `SerilogLoggerFactory`
- Use Serilog sinks for all logging to have a single point of configuration
- Serilog logging levels can be configured in `appsettings.json`