### PR TITLE
Improve memory configuration

### DIFF
--- a/src/core/src/Eryph.Core/CatletCapabilities.cs
+++ b/src/core/src/Eryph.Core/CatletCapabilities.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Eryph.ConfigModel.Catlets;
+using LanguageExt;
+
+namespace Eryph.Core;
+
+public static class CatletCapabilities
+{
+    public static bool IsDynamicMemoryEnabled(
+        Seq<CatletCapabilityConfig> configs) =>
+        configs.Find(c => string.Equals(
+                c.Name, EryphConstants.Capabilities.DynamicMemory, StringComparison.OrdinalIgnoreCase))
+            .Map(c => !c.Details.ToSeq().Exists(d => string.Equals(
+                d, EryphConstants.CapabilityDetails.Disabled, StringComparison.OrdinalIgnoreCase)))
+            .IfNone(true);
+}

--- a/src/core/src/Eryph.Core/EryphConstants.cs
+++ b/src/core/src/Eryph.Core/EryphConstants.cs
@@ -22,6 +22,8 @@ namespace Eryph.Core
         public static readonly string SystemClientId = "system-client";
         public static readonly Guid SuperAdminRole = Guid.Parse("{E5E83176-7543-4D01-BAEA-08A00EA064A6}");
 
+        public static readonly int DefaultCatletMemoryMb = 1024;
+
         public static class BuildInRoles
         {
             public static readonly Guid Owner = Guid.Parse("{918D2C23-8E9A-41AE-8F0E-ADACA3BECBC4}");

--- a/src/core/src/Eryph.Core/EryphConstants.cs
+++ b/src/core/src/Eryph.Core/EryphConstants.cs
@@ -36,6 +36,7 @@ namespace Eryph.Core
         {
             public static readonly string SecureBoot = "secure_boot";
             public static readonly string NestedVirtualization = "nested_virtualization";
+            public static readonly string DynamicMemory = "dynamic_memory";
         }
 
         public static class CapabilityDetails

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeMemory.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeMemory.cs
@@ -65,12 +65,13 @@ public class ConvergeMemory(ConvergeContext context) : ConvergeTaskBase(context)
         let command5 = changedMaxMemory.Match(
             Some: b => command4.AddParameter("MaximumBytes", b),
             None: () => command4)
-        let message = "Updating VM memory settings: "
-            + string.Join("; ",
-                changedStartupMemory.Map(b => $"Startup memory {ToMiB(b)} MiB").IfNone(""),
-                changedUseDynamicMemory.Map(d => $"Dynamic memory {(d ? "enabled" : "disabled")}").IfNone(""),
-                changedMinMemory.Map(b => $"Minimum memory {ToMiB(b)} MiB").IfNone(""),
-                changedMaxMemory.Map(b => $"Maximum memory {ToMiB(b)} MiB").IfNone(""))
+        let message = "Updating catlet memory settings: "
+            + string.Join("; ", Seq(
+                    changedStartupMemory.Map(b => $"Startup memory {ToMiB(b)} MiB"),
+                    changedUseDynamicMemory.Map(d => $"Dynamic memory {(d ? "enabled" : "disabled")}"),
+                    changedMinMemory.Map(b => $"Minimum memory {ToMiB(b)} MiB"),
+                    changedMaxMemory.Map(b => $"Maximum memory {ToMiB(b)} MiB"))
+                .Somes())
             + "."
         from result in changedUseDynamicMemory.IsSome
                        || changedStartupMemory.IsSome

--- a/src/core/src/Eryph.VmManagement/VirtualMachine.cs
+++ b/src/core/src/Eryph.VmManagement/VirtualMachine.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Eryph.ConfigModel;
 using Eryph.ConfigModel.Catlets;
 using Eryph.ConfigModel.Json;
+using Eryph.Core;
 using Eryph.Core.VmAgent;
 using Eryph.GenePool.Model;
 using Eryph.Resources.Disks;
@@ -33,7 +34,7 @@ namespace Eryph.VmManagement
             string vmPath,
             int? startupMemory)
         {
-            var memoryStartupBytes = startupMemory.GetValueOrDefault(1024) * 1024L * 1024;
+            var memoryStartupBytes = startupMemory.GetValueOrDefault(EryphConstants.DefaultCatletMemoryMb) * 1024L * 1024;
 
             return engine.GetObjectsAsync<VirtualMachineInfo>(PsCommandBuilder.Create()
                     .AddCommand("New-VM")

--- a/src/core/test/Eryph.VmManagement.Test/AssertCommand.cs
+++ b/src/core/test/Eryph.VmManagement.Test/AssertCommand.cs
@@ -89,6 +89,12 @@ public class AssertCommand
         return new AssertCommand(_position + 1, _chain);
     }
 
+    public void ShouldBeComplete()
+    {
+        _chain.Should().HaveCount(_position,
+            "the chain should have ended with the previous parameter or command");
+    }
+
     public override string ToString()
     {
         var sb = new StringBuilder();

--- a/src/core/test/Eryph.VmManagement.Test/ConvergeMemoryTests.cs
+++ b/src/core/test/Eryph.VmManagement.Test/ConvergeMemoryTests.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Eryph.ConfigModel.Catlets;
+using Eryph.Core;
+using Eryph.VmManagement.Converging;
+using Eryph.VmManagement.Data.Full;
+using FluentAssertions;
+using Xunit;
+
+using static LanguageExt.Prelude;
+
+namespace Eryph.VmManagement.Test;
+
+public class ConvergeMemoryTests
+{
+    private readonly ConvergeFixture _fixture = new();
+    private AssertCommand? _executedCommand;
+
+    public ConvergeMemoryTests()
+    {
+        _fixture.Engine.RunCallback = cmd =>
+        {
+            _executedCommand = cmd;
+            return unit;
+        };
+    }
+
+    [Fact]
+    public async Task Converge_NoMemoryConfiguration_UsesDefaultMemory()
+    {
+        const int startupMb = 1024;
+        _fixture.Config.Memory = null;
+        var vmInfo = _fixture.Engine.ToPsObject(new VirtualMachineInfo
+        {
+            DynamicMemoryEnabled = true,
+            MemoryStartup = 4096 * 1024L * 1024,
+            MemoryMinimum = 42 * 1024L * 1024,
+            MemoryMaximum = 42 * 1024L * 1024,
+        });
+
+        var convergeTask = new ConvergeMemory(_fixture.Context);
+        await convergeTask.Converge(vmInfo);
+
+        _executedCommand.Should().NotBeNull();
+        _executedCommand!.ShouldBeCommand("Set-VMMemory")
+            .ShouldBeParam("VM", vmInfo.PsObject)
+            .ShouldBeParam("DynamicMemoryEnabled", false)
+            .ShouldBeParam("StartupBytes", EryphConstants.DefaultCatletMemoryMb * 1024L * 1024)
+            .ShouldBeComplete();
+    }
+
+    [Fact]
+    public async Task Converge_OnlyStartupMemoryConfigured_DisablesDynamicMemory()
+    {
+        const int startupMb = 2048;
+        _fixture.Config.Memory = new CatletMemoryConfig
+        {
+            Startup = startupMb,
+        };
+        var vmInfo = _fixture.Engine.ToPsObject(new VirtualMachineInfo
+        {
+            DynamicMemoryEnabled = true,
+            MemoryStartup = 42 * 1024L * 1024,
+            MemoryMinimum = 42 * 1024L * 1024,
+            MemoryMaximum = 42 * 1024L * 1024,
+        });
+
+        var convergeTask = new ConvergeMemory(_fixture.Context);
+        await convergeTask.Converge(vmInfo);
+
+        _executedCommand.Should().NotBeNull();
+        _executedCommand!.ShouldBeCommand("Set-VMMemory")
+            .ShouldBeParam("VM", vmInfo.PsObject)
+            .ShouldBeParam("DynamicMemoryEnabled", false)
+            .ShouldBeParam("StartupBytes", startupMb * 1024L * 1024)
+            .ShouldBeComplete();
+    }
+
+    [Fact]
+    public async Task Converge_NoMinimumMemoryConfigured_UsesStartupMemoryAsMinimum()
+    {
+        const int startupMb = 2048;
+        const int maximumMb = 4096;
+        _fixture.Config.Memory = new CatletMemoryConfig
+        {
+            Startup = startupMb,
+            Maximum = maximumMb,
+        };
+        var vmInfo = _fixture.Engine.ToPsObject(new VirtualMachineInfo
+        {
+            DynamicMemoryEnabled = false,
+            MemoryStartup = 42 * 1024L * 1024,
+            MemoryMinimum = 42 * 1024L * 1024,
+            MemoryMaximum = 42 * 1024L * 1024,
+        });
+
+        var convergeTask = new ConvergeMemory(_fixture.Context);
+        await convergeTask.Converge(vmInfo);
+
+        _executedCommand.Should().NotBeNull();
+        _executedCommand!.ShouldBeCommand("Set-VMMemory")
+            .ShouldBeParam("VM", vmInfo.PsObject)
+            .ShouldBeParam("DynamicMemoryEnabled", true)
+            .ShouldBeParam("StartupBytes", startupMb * 1024L * 1024)
+            .ShouldBeParam("MinimumBytes", startupMb * 1024L * 1024)
+            .ShouldBeParam("MinimumBytes", maximumMb * 1024L * 1024)
+            .ShouldBeComplete();
+    }
+
+    [Fact]
+    public async Task Converge_NoMaximumMemoryConfigured_UsesHyperVDefaultAsMaximum()
+    {
+        const int startupMb = 2048;
+        const int minimumMb = 1024;
+        _fixture.Config.Memory = new CatletMemoryConfig
+        {
+            Startup = startupMb,
+            Minimum = minimumMb,
+        };
+        var vmInfo = _fixture.Engine.ToPsObject(new VirtualMachineInfo
+        {
+            DynamicMemoryEnabled = false,
+            MemoryStartup = 42 * 1024L * 1024,
+            MemoryMinimum = 42 * 1024L * 1024,
+            MemoryMaximum = 42 * 1024L * 1024,
+        });
+
+        var convergeTask = new ConvergeMemory(_fixture.Context);
+        await convergeTask.Converge(vmInfo);
+
+        _executedCommand.Should().NotBeNull();
+        _executedCommand!.ShouldBeCommand("Set-VMMemory")
+            .ShouldBeParam("VM", vmInfo.PsObject)
+            .ShouldBeParam("DynamicMemoryEnabled", true)
+            .ShouldBeParam("StartupBytes", startupMb * 1024L * 1024)
+            .ShouldBeParam("MinimumBytes", minimumMb * 1024L * 1024)
+            // The Hyper-V default is 1 TiB
+            .ShouldBeParam("MinimumBytes", 1 * 1024L * 1024 * 1024 * 1024)
+            .ShouldBeComplete();
+    }
+
+    [Fact]
+    public async Task Converge_NoChanges_CommandIsNotExecuted()
+    {
+        _fixture.Config.Memory = new CatletMemoryConfig
+        {
+            Startup = 2048,
+            Minimum = 1024,
+            Maximum = 4096
+        };
+        var vmInfo = _fixture.Engine.ToPsObject(new VirtualMachineInfo
+        {
+            DynamicMemoryEnabled = true,
+            MemoryStartup = 2048 * 1024L * 1024,
+            MemoryMinimum = 1024 * 1024L * 1024,
+            MemoryMaximum = 4096 * 1024L * 1024,
+        });
+
+        var convergeTask = new ConvergeMemory(_fixture.Context);
+        await convergeTask.Converge(vmInfo);
+
+        _executedCommand.Should().BeNull();
+    }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
@@ -320,6 +320,22 @@ namespace Eryph.Modules.ComputeApi.Handlers
                 capabilities.Add(secureBootCap);
             }
 
+            if (catlet.Features.Any(x => 
+                    x == CatletFeature.DynamicMemory
+                    || parentCaps.Any(c => c.Name == EryphConstants.Capabilities.DynamicMemory)))
+            {
+                var featureOff = catlet.Features.All(x => x != CatletFeature.DynamicMemory);
+
+                var dynamicMemoryCap = new CatletCapabilityConfig
+                {
+                    Name = EryphConstants.Capabilities.DynamicMemory,
+                    Details = featureOff
+                        ? [EryphConstants.CapabilityDetails.Disabled]
+                        : null
+                };
+                capabilities.Add(dynamicMemoryCap);
+            }
+
             // reduce capabilities to only those that are not set same on parent
             foreach (var capabilityConfig in capabilities.ToArray())
             {

--- a/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
@@ -365,11 +365,12 @@ namespace Eryph.Modules.Controller.Inventory
         {
             var features = new System.Collections.Generic.HashSet<CatletFeature>();
             
-            if(vmInfo.Firmware?.SecureBoot ?? false)
+            if (vmInfo.Firmware?.SecureBoot ?? false)
                 features.Add(CatletFeature.SecureBoot);
             if (vmInfo.Cpu?.ExposeVirtualizationExtensions ?? false)
                 features.Add(CatletFeature.NestedVirtualization);
-
+            if (vmInfo.Memory?.DynamicMemoryEnabled ?? false)
+                features.Add(CatletFeature.DynamicMemory);
 
             return features;
         }


### PR DESCRIPTION
This PR introduces the new capability `dynamic_memory` which controls the use of dynamic memory in Hyper-V. Furthermore, it improves the configuration of the different memory limits (startup, minimum, maximum) in Hyper-V.

Closes #179.