### PR TITLE
Fix reverse catlet config generation for drives

### DIFF
--- a/src/data/src/Eryph.StateDb/Specifications/CatletSpecs.cs
+++ b/src/data/src/Eryph.StateDb/Specifications/CatletSpecs.cs
@@ -46,7 +46,8 @@ namespace Eryph.StateDb.Specifications
                 Query.Where(x => x.Id == catletId)
                     .Include(x => x.Project)
                     .Include(x => x.Drives)
-                    .ThenInclude(x => x.AttachedDisk);
+                    .ThenInclude(x => x.AttachedDisk)
+                    .ThenInclude(x => x!.Parent);
             }
         }
     }


### PR DESCRIPTION
This PR fixes the reverse catlet config generation for drives. Drives which are based on gene disks now:
- use the correct names
- do not include the disk size when it does not differ from the parent.

Closes #177.