### PR TITLE
Support different modes for stopping catlets

### DIFF
--- a/src/core/src/Eryph.Messages/Resources/Catlets/Commands/StopCatletCommand.cs
+++ b/src/core/src/Eryph.Messages/Resources/Catlets/Commands/StopCatletCommand.cs
@@ -1,17 +1,20 @@
 ﻿using Eryph.Resources;
 using System;
+using Eryph.Resources.Machines;
 
-namespace Eryph.Messages.Resources.Catlets.Commands
+namespace Eryph.Messages.Resources.Catlets.Commands;
+
+[SendMessageTo(MessageRecipient.Controllers)]
+public class StopCatletCommand : IHasResource, ICommandWithName
 {
-    [SendMessageTo(MessageRecipient.Controllers)]
-    public class StopCatletCommand : IHasResource, ICommandWithName
+    public Guid CatletId { get; set; }
+
+    public Resource Resource => new(ResourceType.Catlet, CatletId);
+
+    public CatletStopMode Mode { get; set; }
+
+    public string GetCommandName()
     {
-        public Guid CatletId { get; set; }
-        public Resource Resource => new(ResourceType.Catlet, CatletId);
-        public bool Graceful { get; set; }
-        public string GetCommandName()
-        {
-            return "Stopping Catlet";
-        }
+        return "Stopping Catlet";
     }
 }

--- a/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/CatletStopMode.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/CatletStopMode.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Eryph.Resources.Machines;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum CatletStopMode
+{
+    /// <summary>
+    /// This mode attempts to gracefully shut down the catlet.
+    /// </summary>
+    Shutdown = 0,
+
+    /// <summary>
+    /// This mode immediately stops the catlet comparable to pulling the power plug.
+    /// </summary>
+    Hard = 1,
+
+    /// <summary>
+    /// This mode is not yet implemented.
+    /// </summary>
+    Kill = 2,
+}

--- a/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/CatletStopMode.cs
+++ b/src/core/src/Eryph.VmConfig.Primitives/Resources/Machines/CatletStopMode.cs
@@ -20,8 +20,7 @@ public enum CatletStopMode
     /// </summary>
     Hard = 1,
 
-    /// <summary>
-    /// This mode is not yet implemented.
-    /// </summary>
-    Kill = 2,
+    // The kill mode will be implemented in the future and will
+    // terminate the underlying process of the Hyper-V VM.
+    // Kill = 2,
 }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Stop.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Stop.cs
@@ -1,24 +1,17 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dbosoft.Functional.Validations;
-using Eryph.Modules.AspNetCore;
 using Eryph.Messages.Resources.Catlets.Commands;
 using Eryph.Modules.AspNetCore.ApiProvider;
 using Eryph.Modules.AspNetCore.ApiProvider.Endpoints;
 using Eryph.Modules.AspNetCore.ApiProvider.Handlers;
 using Eryph.Modules.AspNetCore.ApiProvider.Model;
-using Eryph.Resources.Machines;
 using Eryph.StateDb.Model;
 using JetBrains.Annotations;
-using LanguageExt;
-using LanguageExt.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using Operation = Eryph.Modules.AspNetCore.ApiProvider.Model.V1.Operation;
-
-using static LanguageExt.Prelude;
 
 namespace Eryph.Modules.ComputeApi.Endpoints.V1.Catlets;
 
@@ -51,17 +44,6 @@ public class Stop(
         if (!Guid.TryParse(request.Id, out _))
             return NotFound();
 
-        var validation = ValidateRequest(request.Body);
-        if (validation.IsFail)
-            return ValidationProblem(validation.ToModelStateDictionary());
-
         return await base.HandleAsync(request, cancellationToken);
     }
-
-    private static Validation<ValidationIssue, Unit> ValidateRequest(StopCatletRequestBody requestBody) =>
-        ComplexValidations.ValidateProperty(requestBody, r => r.Mode, mode =>
-            from _ in guard(mode is CatletStopMode.Shutdown or CatletStopMode.Hard,
-                    Error.New($"The stop mode '{mode}' is not yet supported."))
-                .ToValidation()
-            select mode);
 }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Stop.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Stop.cs
@@ -1,17 +1,24 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Dbosoft.Functional.Validations;
+using Eryph.Modules.AspNetCore;
 using Eryph.Messages.Resources.Catlets.Commands;
 using Eryph.Modules.AspNetCore.ApiProvider;
 using Eryph.Modules.AspNetCore.ApiProvider.Endpoints;
 using Eryph.Modules.AspNetCore.ApiProvider.Handlers;
 using Eryph.Modules.AspNetCore.ApiProvider.Model;
+using Eryph.Resources.Machines;
 using Eryph.StateDb.Model;
 using JetBrains.Annotations;
+using LanguageExt;
+using LanguageExt.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 using Operation = Eryph.Modules.AspNetCore.ApiProvider.Model.V1.Operation;
+
+using static LanguageExt.Prelude;
 
 namespace Eryph.Modules.ComputeApi.Endpoints.V1.Catlets;
 
@@ -44,6 +51,17 @@ public class Stop(
         if (!Guid.TryParse(request.Id, out _))
             return NotFound();
 
+        var validation = ValidateRequest(request.Body);
+        if (validation.IsFail)
+            return ValidationProblem(validation.ToModelStateDictionary());
+
         return await base.HandleAsync(request, cancellationToken);
     }
+
+    private static Validation<ValidationIssue, Unit> ValidateRequest(StopCatletRequestBody requestBody) =>
+        ComplexValidations.ValidateProperty(requestBody, r => r.Mode, mode =>
+            from _ in guard(mode is CatletStopMode.Shutdown or CatletStopMode.Hard,
+                    Error.New($"The stop mode '{mode}' is not yet supported."))
+                .ToValidation()
+            select mode);
 }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Stop.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Stop.cs
@@ -25,7 +25,7 @@ public class Stop(
         return new StopCatletCommand
         {
             CatletId = model.Id, 
-            Graceful = request.Body.Graceful.GetValueOrDefault()
+            Mode = request.Body.Mode,
         };
     }
 

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/StopCatletRequest.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/StopCatletRequest.cs
@@ -12,5 +12,5 @@ public class StopCatletRequest : SingleEntityRequest
 
 public class StopCatletRequestBody
 {
-    public CatletStopMode Mode { get; set; }
+    public required CatletStopMode Mode { get; set; }
 }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/StopCatletRequest.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/StopCatletRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Eryph.Modules.AspNetCore.ApiProvider.Model;
+using Eryph.Resources.Machines;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Eryph.Modules.ComputeApi.Endpoints.V1.Catlets;
@@ -9,8 +10,7 @@ public class StopCatletRequest : SingleEntityRequest
     public required StopCatletRequestBody Body { get; set; }
 }
 
-
 public class StopCatletRequestBody
 {
-   public bool? Graceful { get; set; }
+    public CatletStopMode Mode { get; set; }
 }


### PR DESCRIPTION
This PR adds support for different modes when stopping catlets.

See https://github.com/eryph-org/dotnet-computeclient/issues/75.