### PR TITLE
Fix lookup in local gene pool

### DIFF
--- a/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/LocalGenePoolSource.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/LocalGenePoolSource.cs
@@ -57,7 +57,7 @@ internal class LocalGenePoolSource(
         CancellationToken cancel) =>
         from parsedHash in ParseGeneHash(geneHash).ToAsync()
         from genesInfo in Try(() => ReadGenesInfo(geneSetInfo)).ToEitherAsync()
-        from geneInfo in genesInfo.MergedGenes.ToSeq().Find(h => h == parsedHash.Hash).Match(
+        from geneInfo in genesInfo.MergedGenes.ToSeq().Find(h => h == geneHash).Match(
             Some: h => new GeneInfo(geneIdentifier, h, parsedHash.HashAlg, null,
                 [], DateTimeOffset.MinValue, null, true),
             None: () =>


### PR DESCRIPTION
This PR fixes the lookup of genes in the local gene pool. The issue had two effects:
- It was not possible to use genes which exist only in the local gene pool
- The gene parts are downloaded a second time as the already merged genes are not detected early enough