### PR TITLE
Increase minimum catlet uptime before cloudinit cleanup

### DIFF
--- a/src/modules/src/Eryph.Modules.Controller/Inventory/CatletUpTimeChangedEventHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/CatletUpTimeChangedEventHandler.cs
@@ -39,7 +39,7 @@ internal class CatletUpTimeChangedEventHandler(
                 if (!anySensitive)
                     return;
 
-                if (vm.UpTime.GetValueOrDefault().TotalMinutes >= 5)
+                if (vm.UpTime.GetValueOrDefault().TotalMinutes >= 15)
                 {
                     metaData.SecureDataHidden = true;
                     await metadataService.SaveMetadata(metaData);


### PR DESCRIPTION
This PR increases the minimum uptime for a catlet before its cloudinit config is cleaned up. This prevents initialization issues when
the cloudinit process takes more time.