### PR TITLE
Update language-ext

### DIFF
--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -13,10 +13,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="LanguageExt.Core" Version="4.4.8" />
+    <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
     <PackageReference Include="IPNetwork2" Version="3.0.667" />
     <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
-    <PackageReference Include="LanguageExt.Sys" Version="4.4.8" />
+    <PackageReference Include="LanguageExt.Sys" Version="4.4.9" />
     <PackageReference Include="LanguageExt.Transformers" Version="4.4.8" />
     <PackageReference Include="SimpleInjector" Version="5.4.4" />
     <PackageReference Include="YamlDotNet" Version="12.0.2" />

--- a/src/modules/src/Eryph.AnsiConsole/Eryph.AnsiConsole.csproj
+++ b/src/modules/src/Eryph.AnsiConsole/Eryph.AnsiConsole.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LanguageExt.Core" Version="4.4.8" />
+    <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates language-ext to include a fix for the sequential execution of `EitherAsync`: https://github.com/louthy/language-ext/pull/1334.