### PR TITLE
Support file-based logging for OVN and OVS

### DIFF
--- a/src/apps/src/Eryph-zero/HostControllerModuleExtensions.cs
+++ b/src/apps/src/Eryph-zero/HostControllerModuleExtensions.cs
@@ -51,6 +51,7 @@ namespace Eryph.Runtime.Zero
                     next(context, container);
 
                     container.UseInMemoryBus(context.ModulesHostServices);
+                    container.UseOvn(context.ModulesHostServices);
                 };
             }
         }

--- a/src/apps/src/Eryph-zero/HostNetworkModuleExtensions.cs
+++ b/src/apps/src/Eryph-zero/HostNetworkModuleExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dbosoft.Hosuto.Modules.Hosting;
+using Eryph.Modules.Controller;
+using Eryph.Modules.Network;
+using Microsoft.Extensions.DependencyInjection;
+using SimpleInjector;
+
+namespace Eryph.Runtime.Zero;
+
+public static class HostNetworkModuleExtensions
+{
+    public static IModulesHostBuilder AddNetworkModule(
+        this IModulesHostBuilder builder)
+    {
+        builder.HostModule<NetworkModule>();
+        builder.ConfigureFrameworkServices((_, services) =>
+        {
+            services.AddTransient<IConfigureContainerFilter<NetworkModule>, NetworkModuleFilter>();
+        });
+
+        return builder;
+    }
+
+    private sealed class NetworkModuleFilter : IConfigureContainerFilter<NetworkModule>
+    {
+        public Action<IModuleContext<NetworkModule>, Container> Invoke(
+            Action<IModuleContext<NetworkModule>, Container> next)
+        {
+            return (context, container) =>
+            {
+                next(context, container);
+
+                container.UseOvn(context.ModulesHostServices);
+            };
+        }
+    }
+}

--- a/src/apps/src/Eryph-zero/HostVmHostAgentModuleExtensions.cs
+++ b/src/apps/src/Eryph-zero/HostVmHostAgentModuleExtensions.cs
@@ -32,6 +32,7 @@ public static class HostVmHostAgentModuleExtensions
             return (context, container) =>
             {
                 container.UseInMemoryBus(context.ModulesHostServices);
+                container.UseOvn(context.ModulesHostServices);
                     
                 next(context, container);
             };

--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -748,8 +748,8 @@ internal static class Program
                     {
                         var ovsEnv = new EryphOVSEnvironment(new EryphOvsPathProvider(ovsPath), loggerFactory);
                         var ovsControl = new OVSControl(ovsEnv);
-                        await using var ovsDbNode = new OVSDbNode(ovsEnv, loggerFactory);
-                        await using var ovsVSwitchNode = new OVSSwitchNode(ovsEnv, loggerFactory);
+                        await using var ovsDbNode = new OVSDbNode(ovsEnv, new LocalOVSWithOVNSettings(), loggerFactory);
+                        await using var ovsVSwitchNode = new OVSSwitchNode(ovsEnv, new LocalOVSWithOVNSettings(), loggerFactory);
                         var cancelSource = new CancellationTokenSource(TimeSpan.FromMinutes(1));
                         // ReSharper disable AccessToDisposedClosure
 

--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -273,7 +273,6 @@ internal static class Program
                     .UseSimpleInjector(container)
                     .ConfigureAppConfiguration((_, config) =>
                     {
-                        config.AddEnvironmentVariables("ERYPH_ZERO_");
                         config.AddInMemoryCollection(new Dictionary<string, string>
                         {
                             { "warmupMode", warmupMode.ToString() },
@@ -368,7 +367,6 @@ internal static class Program
                     .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: false);
 
                 config.AddEnvironmentVariables();
-                config.AddEnvironmentVariables("ERYPH_ZERO_");
 
                 if (args is { Length: > 0 })
                 {

--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -16,7 +16,6 @@ using Dbosoft.OVN.Nodes;
 using Eryph.App;
 using Eryph.AnsiConsole.Sys;
 using Eryph.ModuleCore;
-using Eryph.Modules.Network;
 using Eryph.Modules.VmHostAgent;
 using Eryph.Modules.VmHostAgent.Configuration;
 using Eryph.Modules.VmHostAgent.Genetics;
@@ -274,6 +273,7 @@ internal static class Program
                     .UseSimpleInjector(container)
                     .ConfigureAppConfiguration((_, config) =>
                     {
+                        config.AddEnvironmentVariables("ERYPH_ZERO_");
                         config.AddInMemoryCollection(new Dictionary<string, string>
                         {
                             { "warmupMode", warmupMode.ToString() },
@@ -295,7 +295,7 @@ internal static class Program
                     })
                     .HostModule<ZeroStartupModule>()
                     .AddVmHostAgentModule()
-                    .HostModule<NetworkModule>()
+                    .AddNetworkModule()
                     .AddControllerModule(container)
                     .AddComputeApiModule()
                     .AddIdentityModule(container)
@@ -368,6 +368,7 @@ internal static class Program
                     .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: false);
 
                 config.AddEnvironmentVariables();
+                config.AddEnvironmentVariables("ERYPH_ZERO_");
 
                 if (args is { Length: > 0 })
                 {

--- a/src/modules/src/Eryph.Modules.Controller/ControllerModule.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ControllerModule.cs
@@ -88,8 +88,6 @@ namespace Eryph.Modules.Controller
 
             //use network services from host
             container.RegisterInstance(serviceProvider.GetRequiredService<INetworkProviderManager>());
-            container.RegisterInstance(serviceProvider.GetRequiredService<IOVNSettings>());
-            container.RegisterInstance(serviceProvider.GetRequiredService<ISysEnvironment>());
 
             container.ConfigureRebus(configurer => configurer
                 .Serialization(s => s.UseEryphSettings())

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\..\..\data\src\Eryph.StateDb\Eryph.StateDb.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-PullRequest0030.7" />
+    <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.6" />
     <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.1" />
     <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.6.1" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\..\..\data\src\Eryph.StateDb\Eryph.StateDb.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.5" />
+    <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-PullRequest0030.7" />
     <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.1" />
     <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.6.1" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">

--- a/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
+++ b/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\..\..\data\src\Eryph.StateDb\Eryph.StateDb.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.5" />
+    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-PullRequest0030.7" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
+++ b/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\..\..\data\src\Eryph.StateDb\Eryph.StateDb.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-PullRequest0030.7" />
+    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.6" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.NetworkModule/NetworkModule.cs
+++ b/src/modules/src/Eryph.Modules.NetworkModule/NetworkModule.cs
@@ -7,34 +7,27 @@ using Microsoft.Extensions.DependencyInjection;
 using SimpleInjector;
 using SimpleInjector.Integration.ServiceCollection;
 
-namespace Eryph.Modules.Network
+namespace Eryph.Modules.Network;
+
+[UsedImplicitly]
+public class NetworkModule
 {
     [UsedImplicitly]
-    public class NetworkModule
+    public void ConfigureContainer(IServiceProvider serviceProvider, Container container)
     {
+        container.RegisterSingleton(serviceProvider.GetRequiredService<IAgentControlService>);
+        container.RegisterSingleton<SyncedOVNDatabaseNode>();
+        container.RegisterSingleton<NetworkControllerNode>();
+        container.RegisterSingleton<IOVSService<SyncedOVNDatabaseNode>, OVSNodeService<SyncedOVNDatabaseNode>>();
+        container.RegisterSingleton<IOVSService<NetworkControllerNode>, OVSNodeService<NetworkControllerNode>>();
+    }
 
-        [UsedImplicitly]
-        public void ConfigureServices(IServiceProvider sp, IServiceCollection services)
-        {
-            services.AddSingleton(sp.GetRequiredService<ISysEnvironment>());
-            services.AddSingleton(sp.GetRequiredService<IOVNSettings>());
-            services.AddSingleton(sp.GetRequiredService<IAgentControlService>());
+    [UsedImplicitly]
+    public void AddSimpleInjector(SimpleInjectorAddOptions options)
+    {
+        options.AddHostedService<OwnThreadOVSNodeHostedService<SyncedOVNDatabaseNode>>();
+        options.AddHostedService<OwnThreadOVSNodeHostedService<NetworkControllerNode>>();
 
-            services.AddOvsNode<SyncedOVNDatabaseNode>();
-            services.AddOvsNode<NetworkControllerNode>();
-
-        }
-
-        [UsedImplicitly]
-        public void AddSimpleInjector(SimpleInjectorAddOptions options)
-        {
-
-
-            options.AddHostedService<OwnThreadOVSNodeHostedService<SyncedOVNDatabaseNode>>();
-            options.AddHostedService<OwnThreadOVSNodeHostedService<NetworkControllerNode>>();
-
-            options.AddLogging();
-        }
-
+        options.AddLogging();
     }
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -10,7 +10,7 @@
     <None Include="..\..\..\..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-PullRequest0030.7" />
+    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.6" />
     <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.1" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.2.1-ci.1" />
     <PackageReference Include="Eryph.GenePool.Client.Authentication" Version="0.2.1-ci.1" />

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -10,7 +10,7 @@
     <None Include="..\..\..\..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.5" />
+    <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-PullRequest0030.7" />
     <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.1" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.2.1-ci.1" />
     <PackageReference Include="Eryph.GenePool.Client.Authentication" Version="0.2.1-ci.1" />

--- a/src/modules/src/Eryph.Modules.VmHostAgent/VmHostAgentModule.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/VmHostAgentModule.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.IO.Abstractions;
 using System.Net.Http;
-using System.Web.Services.Description;
-using Dbosoft.Hosuto.HostedServices;
 using Dbosoft.OVN;
 using Dbosoft.OVN.Nodes;
 using Dbosoft.Rebus;
@@ -31,7 +29,6 @@ using Polly.Extensions.Http;
 using Rebus.Config;
 using Rebus.Handlers;
 using Rebus.Retry.Simple;
-using Rebus.Serialization.Json;
 using Rebus.Subscriptions;
 using SimpleInjector;
 using SimpleInjector.Integration.ServiceCollection;

--- a/src/modules/src/Eryph.Modules.VmHostAgent/VmHostAgentModule.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/VmHostAgentModule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO.Abstractions;
 using System.Net.Http;
+using System.Web.Services.Description;
 using Dbosoft.Hosuto.HostedServices;
 using Dbosoft.OVN;
 using Dbosoft.OVN.Nodes;
@@ -64,13 +65,6 @@ namespace Eryph.Modules.VmHostAgent
             })
                 .SetHandlerLifetime(TimeSpan.FromMinutes(5))  //Set lifetime to five minutes
                 .AddPolicyHandler(GetRetryPolicy());
-
-
-            services.AddSingleton(serviceProvider.GetRequiredService<ISysEnvironment>());
-            services.AddSingleton(serviceProvider.GetRequiredService<IOVNSettings>());
-            services.AddOvsNode<OVSDbNode>();
-            services.AddOvsNode<OVSSwitchNode>();
-            services.AddOvsNode<OVNChassisNode>();
         }
 
         [UsedImplicitly]
@@ -91,6 +85,13 @@ namespace Eryph.Modules.VmHostAgent
             container.Register<IHostNetworkCommands<AgentRuntime>, HostNetworkCommands<AgentRuntime>>();
             container.Register<IOVSControl, OVSControl>();
             container.RegisterInstance(serviceProvider.GetRequiredService<INetworkSyncService>());
+
+            container.RegisterSingleton<OVNChassisNode>();
+            container.RegisterSingleton<OVSDbNode>();
+            container.RegisterSingleton<OVSSwitchNode>();
+            container.RegisterSingleton<IOVSService<OVNChassisNode>, OVSNodeService<OVNChassisNode>>();
+            container.RegisterSingleton<IOVSService<OVSDbNode>, OVSNodeService<OVSDbNode>>();
+            container.RegisterSingleton<IOVSService<OVSSwitchNode>, OVSNodeService<OVSSwitchNode>>();
 
             container.RegisterSingleton<IFileSystem, FileSystem>();
             container.RegisterSingleton<IFileSystemService, FileSystemService>();


### PR DESCRIPTION
This PR adds support for file-based logging for OVN and OVS. The logging is disabled by default. It can be enabled by adding the following to the `appsettings.json`:
```
"Ovn": {
  "Logging": {
    "File": {
      "Level": "Debug"
    }
  }
}
```