### PR TITLE
Support configuration with dedicated environment variables

### DIFF
--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -274,7 +274,7 @@ internal static class Program
                     .UseSimpleInjector(container)
                     .ConfigureAppConfiguration((_, config) =>
                     {
-                        config.AddEnvironmentVariables("ERYPH_ZERO_");
+                        config.AddEnvironmentVariables("ERYPH_");
                         config.AddInMemoryCollection(new Dictionary<string, string>
                         {
                             { "warmupMode", warmupMode.ToString() },
@@ -369,7 +369,7 @@ internal static class Program
                     .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: false);
 
                 config.AddEnvironmentVariables();
-                config.AddEnvironmentVariables("ERYPH_ZERO_");
+                config.AddEnvironmentVariables("ERYPH_");
 
                 if (args is { Length: > 0 })
                 {

--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -274,6 +274,7 @@ internal static class Program
                     .UseSimpleInjector(container)
                     .ConfigureAppConfiguration((_, config) =>
                     {
+                        config.AddEnvironmentVariables("ERYPH_ZERO_");
                         config.AddInMemoryCollection(new Dictionary<string, string>
                         {
                             { "warmupMode", warmupMode.ToString() },
@@ -368,6 +369,7 @@ internal static class Program
                     .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: false);
 
                 config.AddEnvironmentVariables();
+                config.AddEnvironmentVariables("ERYPH_ZERO_");
 
                 if (args is { Length: > 0 })
                 {


### PR DESCRIPTION
This PR adds support for configuring eryph with dedicated environment variables which start with `ERYPH_`. The configuration works the same as the configuration with variables which start with `DOTNET_`. The unique prefix means that the configuration can be performed with machine-wide variables if necessary.