### PR TITLE
Improve lookup of cryptographic OIDs

### DIFF
--- a/src/apps/src/Eryph-zero/Configuration/Clients/SystemClientGenerator.cs
+++ b/src/apps/src/Eryph-zero/Configuration/Clients/SystemClientGenerator.cs
@@ -59,7 +59,7 @@ namespace Eryph.Runtime.Zero.Configuration.Clients
                 [
                     new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, true),
                     new X509EnhancedKeyUsageExtension(
-                        [Oid.FromFriendlyName("Client Authentication", OidGroup.EnhancedKeyUsage)],
+                        [Oid.FromOidValue(Oids.EnhancedKeyUsage.ClientAuthentication, OidGroup.EnhancedKeyUsage)],
                         true),
                 ]);
 

--- a/src/apps/src/Eryph-zero/HttpSys/SSLEndpointManager.cs
+++ b/src/apps/src/Eryph-zero/HttpSys/SSLEndpointManager.cs
@@ -57,7 +57,7 @@ public class SslEndpointManager(
                     X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
                     true),
                 new X509EnhancedKeyUsageExtension(
-                    [Oid.FromFriendlyName("Server Authentication", OidGroup.EnhancedKeyUsage)],
+                    [Oid.FromOidValue(Oids.EnhancedKeyUsage.ServerAuthentication, OidGroup.EnhancedKeyUsage)],
                     true),
                 subjectAlternativeNameBuilder.Build(),
             ]);

--- a/src/core/src/Eryph.Security.Cryptography/Oids.cs
+++ b/src/core/src/Eryph.Security.Cryptography/Oids.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Eryph.Security.Cryptography;
+
+public static class Oids
+{
+    public static class EnhancedKeyUsage
+    {
+        public static readonly string ClientAuthentication = "1.3.6.1.5.5.7.3.2";
+        public static readonly string ServerAuthentication = "1.3.6.1.5.5.7.3.1";
+    }
+}

--- a/src/modules/src/Eryph.Modules.Identity/Models/ClientApiModelExtensions.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Models/ClientApiModelExtensions.cs
@@ -41,7 +41,7 @@ namespace Eryph.Modules.Identity.Models
                 [
                     new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, true),
                     new X509EnhancedKeyUsageExtension(
-                        [Oid.FromFriendlyName("Client Authentication", OidGroup.EnhancedKeyUsage)],
+                        [Oid.FromOidValue(Oids.EnhancedKeyUsage.ClientAuthentication, OidGroup.EnhancedKeyUsage)],
                         true),
                 ]);
 


### PR DESCRIPTION
This PR improves the lookup of OIDs which are used when generating certificates. We now use hardcoded constants.

Closes #245.