### PR TITLE
Network change builder - IPAddress not mapped

### DIFF
--- a/src/modules/src/Eryph.Modules.VmHostAgent/Networks/NetworkChangeOperationBuilder.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Networks/NetworkChangeOperationBuilder.cs
@@ -491,13 +491,13 @@ public class NetworkChangeOperationBuilder<RT> where RT : struct,
 
                                           var currentIp = ips[0];
                                           var res = currentIp.PrefixLength == newBridge.Network.Cidr &&
-                                                 currentIp.IpAddress == newBridge.IPAddress.ToString();
+                                                 currentIp.IPAddress == newBridge.IPAddress.ToString();
 
                                           if (!res)
                                           {
                                               _logger.LogDebug("host nat adapter {bridgeName} has invalid ip. Expected: {expectedIp}/{expectedSuffix}, Actual: {actualIp}/{actualSuffix}",
                                                       networkProvider.BridgeName, newBridge.IPAddress, newBridge.Network.Cidr,
-                                                      currentIp.IpAddress, currentIp.PrefixLength);
+                                                      currentIp.IPAddress, currentIp.PrefixLength);
 
                                           }
 

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Networks/Powershell/NetIpAddress.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Networks/Powershell/NetIpAddress.cs
@@ -2,6 +2,6 @@
 
 public class NetIpAddress
 {
-    public string IpAddress { get; private set; }
+    public string? IPAddress { get; private set; }
     public byte PrefixLength { get; private set; }
 }


### PR DESCRIPTION
Due to a typo in Powershell mapped type the Ip address is no longer mapped.