### PR TITLE
Improve removal of networking during uninstallation

### DIFF
--- a/src/apps/src/Eryph-zero/DriverCommands.cs
+++ b/src/apps/src/Eryph-zero/DriverCommands.cs
@@ -4,13 +4,12 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Eryph.ModuleCore;
 using Eryph.Modules.VmHostAgent.Networks;
 using Eryph.VmManagement;
 using LanguageExt;
 using LanguageExt.Sys;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
+
 using static LanguageExt.Prelude;
 
 namespace Eryph.Runtime.Zero;
@@ -66,16 +65,6 @@ internal static class DriverCommands
     {
         return Run(ensureDriver(
             ovsRunDir, canInstall, canUpgrade),
-            loggerFactory);
-    }
-
-    public static Task<Fin<Unit>> RemoveDriver(
-        ILoggerFactory loggerFactory)
-    {
-        return Run(
-            from _ in uninstallDriver()
-            from __ in removeAllDriverPackages()
-            select unit,
             loggerFactory);
     }
 

--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -39,8 +39,11 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.Win32;
 using Serilog;
+using Serilog.Events;
 using Serilog.Extensions.Logging;
 using Serilog.Sinks.SystemConsole.Themes;
+using Serilog.Templates;
+using Serilog.Templates.Themes;
 using SimpleInjector;
 using SimpleInjector.Lifestyles;
 using Spectre.Console;
@@ -685,16 +688,17 @@ internal static class Program
             outWriter = File.CreateText(outFile.FullName);
             Console.SetOut(outWriter);
             Console.SetError(outWriter);
-
         }
 
         try
         {
-
+            var consoleTemplate = new ExpressionTemplate(
+                "[{@t:yyyy-MM-dd HH:mm:ss.fff} {@l:u3}] {@m}\n{#if @x is not null}{Inspect(@x).Message}\n{#end}");
             Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Information()
                 .Enrich.FromLogContext()
-                .WriteTo.Console(theme: ConsoleTheme.None)
+                .WriteTo.Logger(c =>
+                    c.MinimumLevel.Is(LogEventLevel.Information)
+                    .WriteTo.Console(consoleTemplate))
                 .CreateLogger();
 
             return await AdminGuard.CommandIsElevated(async () =>
@@ -704,7 +708,6 @@ internal static class Program
 
                 var ovsDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
                     "openvswitch");
-
 
                 var loggerFactory = new SerilogLoggerFactory(Log.Logger);
                 var sysEnv = new SystemEnvironment(loggerFactory);
@@ -723,16 +726,14 @@ internal static class Program
                                 var fin = await syncClient.SendSyncCommand("STOP_VSWITCH", cancelSource1.Token)
                                     .Bind(_ => syncClient.SendSyncCommand("STOP_OVSDB", cancelSource1.Token))
                                     .Run();
-                                fin.IfFail(l =>
-                                    Log.Logger.Debug("Failed to send stop chassis commands. Error: {error}", l));
+                                fin.IfFail(l => Log.Logger.Debug(l, "Failed to send stop chassis commands."));
                                 return Unit.Default; // ignore error from stop command - we can also take control of existing processes
                             }).ToAsync()
                             : Unit.Default
 
                         from uStopped in serviceExists
-                            ?
-                            LogProgress("Stopping running service...").Bind(_ =>
-                                serviceManager.EnsureServiceStopped(cancelSource1.Token))
+                            ? LogProgress("Stopping running service...")
+                                .Bind(_ => serviceManager.EnsureServiceStopped(cancelSource1.Token))
                             : Unit.Default
                         let cancelSource2 = new CancellationTokenSource(TimeSpan.FromMinutes(5))
                         from uUninstalled in serviceExists
@@ -781,8 +782,7 @@ internal static class Program
                         
                         _ = await ovsCleanup.IfLeft(l =>
                         {
-                            Log.Warning("OVS Cleanup failed with error '{error}'.\nIf necessary, delete OVS network adapters manually.", l);
-
+                            Log.Logger.Warning(l, "The OVS cleanup failed. If necessary, delete the OVS network adapters manually.");
                         });
 
                         // ReSharper restore AccessToDisposedClosure
@@ -797,8 +797,7 @@ internal static class Program
                         }
                         catch (Exception ex)
                         {
-                            Log.Logger.Debug(ex, "Failed to delete ovs data files from '{ovsPath}'", ovsDataDir);
-                            Log.Warning("OVS data files cleanup failed with error '{error}'. \nIf necessary, delete OVS data files manually from {ovsPath}", ex.Message, ovsDataDir);
+                            Log.Logger.Warning(ex, "The OVS data files cleanup failed. If necessary, delete the OVS data files manually from '{OvsPath}'.", ovsDataDir);
                         }
                     }
 
@@ -808,26 +807,30 @@ internal static class Program
 
                     if (Directory.Exists(dataDir) && deleteAppData)
                     {
-                        Log.Logger.Information("Removing data files...");
-                        Directory.Delete(dataDir, true);
+                        try
+                        {
+                            Log.Logger.Information("Removing data files...");
+                            Directory.Delete(dataDir, true);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Logger.Warning(ex, "The data files cleanup failed. If necessary, delete data files manually from '{DataDir}'.", dataDir);
+                        }
                     }
 
                     UnregisterUninstaller();
 
-                    Log.Logger.Information("Uninstallation completed");
+                    Log.Logger.Information("Uninstallation completed.");
 
                     return 0;
 
                 }
                 catch (Exception ex)
                 {
-                    Log.Error("Uninstallation failed. Error: {message}", ex.Message);
-                    Log.Debug(ex, "Error Details");
+                    Log.Logger.Error(ex, "Uninstallation failed.");
 
                     return -1;
                 }
-                
-
             });
         }
         finally
@@ -840,9 +843,8 @@ internal static class Program
 
                 if (deleteOutFile)
                 {
-                    Task.Delay(2000).GetAwaiter().GetResult();
+                    await Task.Delay(2000);
                     File.Delete(outFile.FullName);
-
                 }
             }
         }

--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -770,8 +770,10 @@ internal static class Program
                             let controlCancel = new CancellationTokenSource(TimeSpan.FromMinutes(5))
                             from uCleanup in LogProgress("Removing OVS bridges....")
                             from bridges in ovsControl.GetBridges(controlCancel.Token)
-                            from uRemove in bridges.Map(b => ovsControl.RemoveBridge(b.Name, controlCancel.Token))
-                                .TraverseSerial(l => l).Map(_ => Unit.Default)
+                            from uRemove in bridges
+                                .Map(b => ovsControl.RemoveBridge(b.Name, controlCancel.Token)
+                                    .MapLeft(l => Error.New($"Failed to remove OVS bridge {b.Name}.", l)))
+                                .SequenceSerial().Map(_ => Unit.Default)
                             let stopCancel = new CancellationTokenSource(TimeSpan.FromMinutes(5))
 
                             from uStopLog in LogProgress("Stopping temporary chassis services...")

--- a/src/apps/src/Eryph-zero/UninstallCommands.cs
+++ b/src/apps/src/Eryph-zero/UninstallCommands.cs
@@ -19,13 +19,13 @@ internal class UninstallCommands
 {
     public static Aff<DriverCommandsRuntime, Unit> RemoveNetworking() =>
         from _1 in RemoveOverlaySwitch()
-                   | @catch(e => logError<UninstallCommands>(
-                       e, "The eryph overlay switch could not be remove. If necessary, remove it manually."))
+                   | @catch(e => logWarning<UninstallCommands>(
+                       e, "The eryph overlay switch could not be removed. If necessary, remove it manually."))
         from _2 in RemoveNetNats()
-                   | @catch(e => logError<UninstallCommands>(
-                       e, "The NAT configurations could not be remove. If necessary, remove them manually."))
+                   | @catch(e => logWarning<UninstallCommands>(
+                       e, "The NAT configurations could not be removed. If necessary, remove them manually."))
         from _3 in RemoveDrivers()
-                   | @catch(e => logError<UninstallCommands>(
+                   | @catch(e => logWarning<UninstallCommands>(
                        e, "The Hyper-V switch extension could not be removed. If necessary, remove it manually."))
         select unit;
 

--- a/src/apps/src/Eryph-zero/UninstallCommands.cs
+++ b/src/apps/src/Eryph-zero/UninstallCommands.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Eryph.Core;
+using Eryph.Modules.VmHostAgent.Networks;
+using LanguageExt;
+
+using static LanguageExt.Prelude;
+
+namespace Eryph.Runtime.Zero;
+
+using static Logger<DriverCommandsRuntime>;
+using static OvsDriverProvider<DriverCommandsRuntime>;
+
+internal class UninstallCommands
+{
+    public static Aff<DriverCommandsRuntime, Unit> RemoveNetworking() =>
+        from _1 in RemoveOverlaySwitch()
+                   | @catch(e => logError<UninstallCommands>(
+                       e, "The eryph overlay switch could not be remove. If necessary, remove it manually."))
+        from _2 in RemoveNetNats()
+                   | @catch(e => logError<UninstallCommands>(
+                       e, "The NAT configurations could not be remove. If necessary, remove them manually."))
+        from _3 in RemoveDrivers()
+                   | @catch(e => logError<UninstallCommands>(
+                       e, "The Hyper-V switch extension could not be removed. If necessary, remove it manually."))
+        select unit;
+
+    public static Aff<DriverCommandsRuntime, Unit> RemoveOverlaySwitch() =>
+        from _1 in logInformation<UninstallCommands>("Removing eryph overlay switch...")
+        from hostNetworkCommands in default(DriverCommandsRuntime).HostNetworkCommands
+        from allSwitches in hostNetworkCommands.GetSwitches()
+        let allOverlaySwitches = allSwitches.Filter(s => s.Name == EryphConstants.OverlaySwitchName)
+        from allNetworkAdapters in allOverlaySwitches
+            .Map(s => hostNetworkCommands.GetNetAdaptersBySwitch(s.Id))
+            .SequenceSerial()
+            .Map(l => l.Flatten())
+        from _2 in hostNetworkCommands.DisconnectNetworkAdapters(allNetworkAdapters)
+        from _3 in hostNetworkCommands.RemoveOverlaySwitch()
+        select unit;
+
+    public static Aff<DriverCommandsRuntime, Unit> RemoveNetNats() =>
+        from _1 in logInformation<UninstallCommands>("Removing NAT configurations...")
+        from hostNetworkCommands in default(DriverCommandsRuntime).HostNetworkCommands
+        from netNats in hostNetworkCommands.GetNetNat()
+        let eryphNetNats = netNats.Filter(n => n.Name.StartsWith("eryph_"))
+        from _2 in eryphNetNats
+            .Map(n => hostNetworkCommands.RemoveNetNat(n.Name))
+            .SequenceSerial()
+        select unit;
+
+    public static Aff<DriverCommandsRuntime, Unit> RemoveDrivers() =>
+        from _1 in logInformation<UninstallCommands>("Removing Hyper-V switch extension...")
+        from _2 in uninstallDriver()
+        from _3 in removeAllDriverPackages()
+        select unit;
+}

--- a/src/apps/src/Eryph-zero/eryph-zero.csproj
+++ b/src/apps/src/Eryph-zero/eryph-zero.csproj
@@ -31,13 +31,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
+    <PackageReference Include="Serilog" Version="4.0.1" />
+    <PackageReference Include="Serilog.Expressions" Version="5.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageReference Include="Serilog.Sinks.EventLog" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.EventLog" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
     <PackageReference Include="WinHttpUrlAclDotNet" Version="1.0.0" />

--- a/src/core/src/Eryph.VmManagement/PowerShellInvokeExtensions.cs
+++ b/src/core/src/Eryph.VmManagement/PowerShellInvokeExtensions.cs
@@ -121,7 +121,7 @@ internal static class PowerShellInvokeExtensions
         if (error != null)
         {
             var message =
-                $" Command: {error.InvocationInfo?.MyCommand}, Error: {error}, Exception: {error.Exception}";
+                $"Command: {error.InvocationInfo?.MyCommand}, Error: {error}, Exception: {error.Exception}";
 
             log.LogError(error.Exception, message);
 


### PR DESCRIPTION
This PR improves the removal of networking configurations during uninstallation. This includes:
- Disconnecting any existing VMs from the overlay switch
- Removing Switch Embedded Teaming adapters
- Removing NAT configurations

Addtionally, the logging during uninstallation has been improved.

Closes #252 