### PR TITLE
Fix missing data in the endpoint for virtual disks

### DIFF
--- a/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/MapperProfile.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/MapperProfile.cs
@@ -74,7 +74,8 @@ namespace Eryph.Modules.ComputeApi.Model.V1
                     var isSuperAdmin = authContext.IdentityRoles.Contains(EryphConstants.SuperAdminRole);
                     return isSuperAdmin ? s.Path : null;
                 }))
-                .ForMember(d => d.Location, o => o.MapFrom(s => s.StorageIdentifier));
+                .ForMember(d => d.Location, o => o.MapFrom(s => s.StorageIdentifier))
+                .ForMember(d => d.AttachedCatlets, o => o.MapFrom(s => s.AttachedDrives));
             CreateMap<StateDb.Model.CatletDrive, VirtualDiskAttachedCatlet>();
 
             CreateMap<StateDb.Model.Gene, Gene>()


### PR DESCRIPTION
This PR fixes the data mapping for the endpoint for virtual disks. Due to the incorrect mapping, the information regarding the attached catlets was not populated.