### PR TITLE
Fix incorrect inventory of parent disks

### DIFF
--- a/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
@@ -232,6 +232,9 @@ namespace Eryph.Modules.Controller.Inventory
                         return;
                     }
 
+                    // The parent disk might be located in a different project. Most commonly,
+                    // this happens for parent disks which are located in the gene pool as the
+                    // gene pool is part of the default project.
                     var parentProject = await FindProject(diskInfo.Parent.ProjectName, diskInfo.Parent.ProjectId)
                         .IfNoneAsync(() => FindRequiredProject(EryphConstants.DefaultProjectName, null))
                         .ConfigureAwait(false);

--- a/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
@@ -232,7 +232,10 @@ namespace Eryph.Modules.Controller.Inventory
                         return;
                     }
 
-                    await LookupVirtualDisk(diskInfo.Parent, project, addedDisks)
+                    var parentProject = await FindProject(diskInfo.Parent.ProjectName, diskInfo.Parent.ProjectId)
+                        .IfNoneAsync(() => FindRequiredProject(EryphConstants.DefaultProjectName, null))
+                        .ConfigureAwait(false);
+                    await LookupVirtualDisk(diskInfo.Parent, parentProject, addedDisks)
                         .IfSomeAsync(parentDisk =>
                         {
                             currentDisk.Parent = parentDisk;


### PR DESCRIPTION
This PR fixes the inventory of parent disks. In some cases, a parent disk, which is part of the gene pool, was not properly assigned as a parent due to an incorrect database lookup.