### PR TITLE
Remove certificates during uninstallation

### DIFF
--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -805,6 +805,10 @@ internal static class Program
                         UninstallCommands.RemoveNetworking(),
                         loggerFactory);
 
+                    UninstallCommands.RemoveCertificatesAndKeys().Run()
+                        .IfFail(e => Log.Logger.Warning(e,
+                            "The cleanup of the certificates failed. Please remove any leftover certificates from the Windows certificate store."));
+
                     if (Directory.Exists(dataDir) && deleteAppData)
                     {
                         try

--- a/src/apps/src/Eryph-zero/UninstallCommands.cs
+++ b/src/apps/src/Eryph-zero/UninstallCommands.cs
@@ -76,14 +76,13 @@ internal class UninstallCommands
         from keyPair in Eff(() => Optional(keyStore.GetPersistedRsaKey(keyName)))
         from _2 in keyPair.Match(
             Some: kp =>
-                from _1 in SuccessEff(unit)
                 from publicKey in Eff(() => new PublicKey(kp))
-                from _2 in Eff(() =>
+                from _1 in Eff(() =>
                 {
                     certStore.RemoveFromMyStore(publicKey);
                     return unit;
                 })
-                from _3 in Eff(() =>
+                from _2 in Eff(() =>
                 {
                     certStore.RemoveFromRootStore(publicKey);
                     return unit;

--- a/src/apps/src/Eryph-zero/UninstallCommands.cs
+++ b/src/apps/src/Eryph-zero/UninstallCommands.cs
@@ -85,7 +85,7 @@ internal class UninstallCommands
                 })
                 from _3 in Eff(() =>
                 {
-                    certStore.RemoveFromMyStore(publicKey);
+                    certStore.RemoveFromRootStore(publicKey);
                     return unit;
                 })
                 select unit,


### PR DESCRIPTION
This PR adds code to remove the certificates used by eryph-zero during the uninstallation.

Closes #250