### PR TITLE
Support native YAML for fodder content

### DIFF
--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -4,11 +4,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.6.2-PullRequest0096.33" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.33" />
-    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.6.2-PullRequest0096.33" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.33" />
-    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.6.2-PullRequest0096.34" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -4,18 +4,18 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.6.1" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.1" />
-    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.6.1" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.1" />
-    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.6.1" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.6.2-PullRequest0096.33" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="LanguageExt.Core" Version="4.4.9" />
     <PackageReference Include="IPNetwork2" Version="3.0.667" />
-    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageReference Include="LanguageExt.Sys" Version="4.4.9" />
     <PackageReference Include="LanguageExt.Transformers" Version="4.4.8" />
     <PackageReference Include="SimpleInjector" Version="5.4.4" />

--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -4,11 +4,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.7.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -4,11 +4,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.6.2-PullRequest0096.36" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -4,11 +4,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Core" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.6.2-PullRequest0096.38" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.Core/Genetics/CatletBreeding.cs
+++ b/src/core/src/Eryph.Core/Genetics/CatletBreeding.cs
@@ -204,7 +204,7 @@ public static class CatletBreeding
         Source = child.Source,
 
         Content = child.Content ?? parent.Content,
-        FileName = child.FileName ?? parent.FileName,
+        Filename = child.Filename ?? parent.Filename,
         Remove = child.Remove ?? parent.Remove,
         Secret = child.Secret ?? parent.Secret,
         Type = child.Type ?? parent.Type,

--- a/src/core/src/Eryph.VmConfig.Primitives/Eryph.Primitives.csproj
+++ b/src/core/src/Eryph.VmConfig.Primitives/Eryph.Primitives.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Eryph.Primitives</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Eryph.GenePool.Model" Version="0.2.1-ci.48" />
+    <PackageReference Include="Eryph.GenePool.Model" Version="0.3.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.VmManagement/CatletFeeding.cs
+++ b/src/core/src/Eryph.VmManagement/CatletFeeding.cs
@@ -120,12 +120,8 @@ public static class CatletFeeding
             .ToEither(Error.New($"The gene '{geneId}' has not been correctly resolved. This should not happen."))
             .ToAsync()
         from geneContent in genepoolReader.ReadGeneContent(uniqueGeneId)
-        from geneFodderConfig in Try(() =>
-        {
-            var configDictionary = ConfigModelJsonSerializer.DeserializeToDictionary(geneContent);
-            return FodderGeneConfigDictionaryConverter.Convert(configDictionary);
-
-        }).ToEither(Error.New).ToAsync()
+        from geneFodderConfig in Try(() => FodderGeneConfigJsonSerializer.Deserialize(geneContent))
+            .ToEither(Error.New).ToAsync()
         from geneFodderWithName in geneFodderConfig.Fodder.ToSeq()
             .Map(f => from n in FodderName.NewEither(f.Name)
                       select (Name: n, Config: f))

--- a/src/core/src/Eryph.VmManagement/Converging/ConvergeCloudInitDisk.cs
+++ b/src/core/src/Eryph.VmManagement/Converging/ConvergeCloudInitDisk.cs
@@ -131,7 +131,7 @@ namespace Eryph.VmManagement.Converging
 
                             var userData = new UserData(contentType, 
                                 (cloudInitConfig.Content ?? "").TrimEnd('\0'),
-                                cloudInitConfig.FileName!,
+                                cloudInitConfig.Filename!,
                                 Encoding.UTF8);
                             configDrive.AddUserData(userData);
                         }

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -6,8 +6,8 @@
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.NoCloud" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.WindowsImaging" Version="1.0.0-rc.12" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.36" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -6,8 +6,8 @@
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.NoCloud" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.WindowsImaging" Version="1.0.0-rc.12" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.38" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -6,8 +6,8 @@
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.NoCloud" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.WindowsImaging" Version="1.0.0-rc.12" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.1" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.6.1" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.33" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -6,8 +6,8 @@
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.NoCloud" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.WindowsImaging" Version="1.0.0-rc.12" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.33" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.34" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -6,8 +6,8 @@
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.NoCloud" Version="1.0.0-rc.12" />
     <PackageReference Include="Dbosoft.CloudInit.ConfigDrive.WindowsImaging" Version="1.0.0-rc.12" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.7.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/test/Eryph.Core.Tests/Genetics/CatletBreedingTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/CatletBreedingTests.cs
@@ -516,7 +516,7 @@ public class CatletBreedingTests
                     Name = "cfg",
                     Type = "type1",
                     Content = "contenta",
-                    FileName = "filenamea"
+                    Filename = "filenamea"
                 }
             ]
         };
@@ -532,7 +532,7 @@ public class CatletBreedingTests
                     Name = "cfg",
                     Type = "type2",
                     Content = "contentb",
-                    FileName = "filenameb"
+                    Filename = "filenameb"
                 }
             ]
         };
@@ -545,7 +545,7 @@ public class CatletBreedingTests
             {
                 fodder.Type.Should().Be("type2");
                 fodder.Content.Should().Be("contentb");
-                fodder.FileName.Should().Be("filenameb");
+                fodder.Filename.Should().Be("filenameb");
             });
     }
 
@@ -562,7 +562,7 @@ public class CatletBreedingTests
                     Name = "cfg",
                     Type = "type1",
                     Content = "contenta",
-                    FileName = "filenamea"
+                    Filename = "filenamea"
                 }
             ]
         };

--- a/src/core/test/Eryph.VmManagement.TestBase/LocalGenepoolReaderMockExtensions.cs
+++ b/src/core/test/Eryph.VmManagement.TestBase/LocalGenepoolReaderMockExtensions.cs
@@ -33,7 +33,7 @@ public static class LocalGenepoolReaderMockExtensions
     {
         var validGeneSetId = GeneSetIdentifier.New(geneSetIdentifier);
         var validGeneId = new GeneIdentifier(validGeneSetId, GeneName.New("catlet"));
-        var json = ConfigModelJsonSerializer.Serialize(catletConfig);
+        var json = CatletConfigJsonSerializer.Serialize(catletConfig);
 
         mock.Setup(m => m.ReadGeneContent(new UniqueGeneIdentifier(
                 GeneType.Catlet, validGeneId, Architecture.New("any"))))
@@ -47,7 +47,7 @@ public static class LocalGenepoolReaderMockExtensions
         FodderGeneConfig fodderGene)
     {
         var validGeneId = GeneIdentifier.New(geneIdentifier);
-        var json = ConfigModelJsonSerializer.Serialize(fodderGene);
+        var json = FodderGeneConfigJsonSerializer.Serialize(fodderGene);
 
         mock.Setup(m => m.ReadGeneContent(new UniqueGeneIdentifier(
                 GeneType.Fodder, validGeneId, Architecture.New(architecture))))

--- a/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
 
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.33" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.34" />
 
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
 
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.7.0" />
 
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
@@ -12,7 +12,8 @@
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
 
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.6.1" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.33" />
 
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
 
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.36" />
 
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
 
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.38" />
 
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Create.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Create.cs
@@ -31,8 +31,7 @@ public class Create(
 {
     protected override object CreateOperationMessage(NewCatletRequest request)
     {
-        var configDictionary = ConfigModelJsonSerializer.DeserializeToDictionary(request.Configuration);
-        var config = CatletConfigDictionaryConverter.Convert(configDictionary);
+        var config = CatletConfigJsonSerializer.Deserialize(request.Configuration);
 
         return new CreateCatletCommand
         { 

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Update.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Update.cs
@@ -25,10 +25,7 @@ public class Update(
 {
     protected override object CreateOperationMessage(Catlet model, UpdateCatletRequest request )
     {
-        var jsonString = request.Body.Configuration.GetRawText();
-
-        var configDictionary = ConfigModelJsonSerializer.DeserializeToDictionary(jsonString);
-        var config = CatletConfigDictionaryConverter.Convert(configDictionary);
+        var config = CatletConfigJsonSerializer.Deserialize(request.Body.Configuration);
 
         return new UpdateCatletCommand
         {

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/VirtualNetworks/Update.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/VirtualNetworks/Update.cs
@@ -32,10 +32,7 @@ public class Update(
         if (!Guid.TryParse(request.ProjectId, out var projectId))
             throw new ArgumentException("The project ID is invalid.", nameof(request));
 
-        var configDictionary = ConfigModelJsonSerializer.DeserializeToDictionary(request.Body.Configuration)
-            ?? throw new ArgumentException("The configuration is missing", nameof(request));
-
-        var config = ProjectNetworksConfigDictionaryConverter.Convert(configDictionary);
+        var config = ProjectNetworksConfigJsonSerializer.Deserialize(request.Body.Configuration);
 
         return new CreateNetworksCommand
         { 

--- a/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
@@ -8,7 +8,7 @@
     </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.36" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
@@ -8,7 +8,7 @@
     </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.1" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.33" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
@@ -8,7 +8,7 @@
     </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.34" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
@@ -8,7 +8,7 @@
     </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.38" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
@@ -8,7 +8,7 @@
     </DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.7.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
@@ -368,12 +368,9 @@ internal class GetCatletConfigurationHandler(
                                                             && config.Memory?.Minimum.GetValueOrDefault() == 0)
             config.Memory = null;
 
-
-        var configString = ConfigModelJsonSerializer.Serialize(config);
-
         var result = new CatletConfiguration
         {
-            Configuration = JsonSerializer.Deserialize<JsonElement>(configString)
+            Configuration = CatletConfigJsonSerializer.SerializeToElement(config),
         };
 
         return result;

--- a/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetVirtualNetworksConfigurationHandler.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetVirtualNetworksConfigurationHandler.cs
@@ -41,11 +41,9 @@ internal class GetVirtualNetworksConfigurationHandler(
 
         var projectConfig = networks.ToNetworksConfig(project.Name);
 
-        var configString = ConfigModelJsonSerializer.Serialize(projectConfig);
-
         var result = new VirtualNetworkConfiguration()
         {
-            Configuration = JsonSerializer.Deserialize<JsonElement>(configString)
+            Configuration = ProjectNetworksConfigJsonSerializer.SerializeToElement(projectConfig),
         };
 
         return result;

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualNetworks/VirtualNetworkChangeHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualNetworks/VirtualNetworkChangeHandler.cs
@@ -65,7 +65,7 @@ internal class VirtualNetworkChangeHandler : IChangeHandler<VirtualNetworkChange
     private string PrepareNetworksConfig(Project project, List<VirtualNetwork> networks)
     {
         var networkConfig = networks.ToNetworksConfig(project.Name);
-        return ConfigModelJsonSerializer.Serialize(networkConfig);
+        return ProjectNetworksConfigJsonSerializer.Serialize(networkConfig);
     }
 
     private string PreparePortsConfig(List<VirtualNetwork> networks)

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.8" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.33" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.33" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.34" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.8" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.7.0" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.7.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.8" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.36" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.38" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.38" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.8" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.34" />
-    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.36" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -14,8 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Core" Version="1.0.0-rc.8" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.1" />
-    <PackageReference Include="Eryph.ConfigModel.System.Json" Version="0.6.1" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.6.2-PullRequest0096.33" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.Controller/Seeding/VirtualNetworkSeeder.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Seeding/VirtualNetworkSeeder.cs
@@ -40,8 +40,8 @@ internal class VirtualNetworkSeeder : SeederBase
 
     protected override async Task SeedAsync(Guid entityId, string json, CancellationToken cancellationToken = default)
     {
-        var configDictionary = ConfigModelJsonSerializer.DeserializeToDictionary(json);
-        if (configDictionary == null)
+        var config = ProjectNetworksConfigJsonSerializer.Deserialize(json);
+        if (config == null)
             throw new SeederException($"The network configuration for project {entityId} is invalid");
 
         var project = await _stateStore.For<Project>().GetBySpecAsync(
@@ -56,7 +56,6 @@ internal class VirtualNetworkSeeder : SeederBase
         if (existingNetworks.Any())
             return;
 
-        var config = ProjectNetworksConfigDictionaryConverter.Convert(configDictionary);
         var normalizedConfig = _configValidator.NormalizeConfig(config);
 
         var providerConfig = await _networkProviderManager.GetCurrentConfiguration()

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.8" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.34" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.36" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.2.1-ci.48" />
     <PackageReference Include="Eryph.GenePool.Client.Authentication" Version="0.2.1-ci.48" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.8" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.36" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.38" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.2.1-ci.48" />
     <PackageReference Include="Eryph.GenePool.Client.Authentication" Version="0.2.1-ci.48" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.8" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.33" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.34" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.2.1-ci.48" />
     <PackageReference Include="Eryph.GenePool.Client.Authentication" Version="0.2.1-ci.48" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.8" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.38" />
-    <PackageReference Include="Eryph.GenePool.Client" Version="0.2.1-ci.48" />
-    <PackageReference Include="Eryph.GenePool.Client.Authentication" Version="0.2.1-ci.48" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.7.0" />
+    <PackageReference Include="Eryph.GenePool.Client" Version="0.3.0" />
+    <PackageReference Include="Eryph.GenePool.Client.Authentication" Version="0.3.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Eryph.Modules.VmHostAgent.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.OVN.Hosting" Version="1.0.0-rc.8" />
-    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.1" />
+    <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.6.2-PullRequest0096.33" />
     <PackageReference Include="Eryph.GenePool.Client" Version="0.2.1-ci.48" />
     <PackageReference Include="Eryph.GenePool.Client.Authentication" Version="0.2.1-ci.48" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">

--- a/src/modules/src/Eryph.Modules.VmHostAgent/ResolveCatletConfigCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/ResolveCatletConfigCommandHandler.cs
@@ -195,11 +195,9 @@ internal class ResolveCatletConfigCommandHandler(
             new GeneIdentifier(geneSetId, GeneName.New("catlet")),
             Architecture.New(EryphConstants.AnyArchitecture))
         from json in genepoolReader.ReadGeneContent(uniqueId)
-        from config in Try(() =>
-        {
-            var configDictionary = ConfigModelJsonSerializer.DeserializeToDictionary(json);
-            return CatletConfigDictionaryConverter.Convert(configDictionary);
-        }).ToEither(ex => Error.New($"Could not deserialize catlet config '{geneSetId}'.", Error.New(ex))).ToAsync()
+        from config in Try(() => CatletConfigJsonSerializer.Deserialize(json))
+            .ToEither(ex => Error.New($"Could not deserialize catlet config '{geneSetId}'.", Error.New(ex)))
+            .ToAsync()
         select config;
 
     private static Error CreateError(

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/VirtualNetworkChangeTrackingTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/VirtualNetworkChangeTrackingTests.cs
@@ -528,8 +528,7 @@ public abstract class VirtualNetworkChangeTrackingTests(IDatabaseFixture databas
             ChangeTrackingConfig.ProjectNetworksConfigPath,
             $"{ProjectId}.json");
         var json = await MockFileSystem.File.ReadAllTextAsync(path, Encoding.UTF8);
-        var configDictionary = ConfigModelJsonSerializer.DeserializeToDictionary(json);
-        return ProjectNetworksConfigDictionaryConverter.Convert(configDictionary!);
+        return ProjectNetworksConfigJsonSerializer.Deserialize(json);
     }
 
     private async Task<CatletNetworkPortsConfigModel> ReadPortsConfig()


### PR DESCRIPTION
This PR adds support for specifying the fodder content directly as a YAML mapping. Additionally, the JSON serialization for catlet, fodder, and project network configuations now uses snake case.

Closes #187