### PR TITLE
Use production genepool

### DIFF
--- a/src/apps/src/Eryph-zero/HostVmHostAgentModuleExtensions.cs
+++ b/src/apps/src/Eryph-zero/HostVmHostAgentModuleExtensions.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Dbosoft.Hosuto.Modules.Hosting;
 using Eryph.Modules.VmHostAgent;
+using Eryph.Modules.VmHostAgent.Genetics;
 using Microsoft.Extensions.DependencyInjection;
 using SimpleInjector;
 

--- a/src/apps/src/Eryph-zero/Properties/launchSettings.json
+++ b/src/apps/src/Eryph-zero/Properties/launchSettings.json
@@ -59,7 +59,7 @@
     },
     "login": {
       "commandName": "Project",
-      "commandLineArgs": "login",
+      "commandLineArgs": "genepool login",
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       },
@@ -67,7 +67,7 @@
     },
     "logout": {
       "commandName": "Project",
-      "commandLineArgs": "logout",
+      "commandLineArgs": "genepool logout",
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       },

--- a/src/apps/src/Eryph-zero/Properties/launchSettings.json
+++ b/src/apps/src/Eryph-zero/Properties/launchSettings.json
@@ -4,7 +4,8 @@
       "commandName": "Project",
       "commandLineArgs": "run",
       "environmentVariables": {
-        "DOTNET_ENVIRONMENT": "Development"
+        "DOTNET_ENVIRONMENT": "Development",
+        "ERYPH_GENEPOOL_AUTHORITY": "staging_off"
       },
       "remoteDebugEnabled": true
     },

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenePoolCli.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenePoolCli.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
+﻿using System.Linq;
 using System.Net;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Azure.Core;
 using Eryph.AnsiConsole.Sys;
 using Eryph.ConfigModel;
 using Eryph.Core.Sys;
 using Eryph.GenePool.Client;
 using Eryph.GenePool.Client.Credentials;
+using Eryph.GenePool.Client.Requests;
 using Eryph.GenePool.Model;
+using Eryph.GenePool.Model.Requests.User;
 using Eryph.GenePool.Model.Responses;
 using Eryph.VmManagement.Sys;
 using LanguageExt;
@@ -35,12 +31,12 @@ public static class GenePoolCli<RT> where RT : struct,
     HasFile<RT>,
     HasHardwareId<RT>
 {
-    public static Aff<RT, Unit> login(IGenePoolApiKeyStore apiKeyStore) =>
+    public static Aff<RT, Unit> login(IGenePoolApiKeyStore apiKeyStore, GenepoolSettings genepoolSettings) =>
         from _1 in AnsiConsole<RT>.write(new Rows(
             new Text("We will create a dedicated API key for this machine which grants read-only access to the genepool."),
             new Text("You will need to authenticate with your personal credentials."),
             Text.Empty))
-        from existingApiKey in apiKeyStore.GetApiKey(GenePoolConstants.EryphGenePool.Name)
+        from existingApiKey in apiKeyStore.GetApiKey(genepoolSettings.Name)
             .ToAff(identity)
         from shouldContinue in existingApiKey.Match(
             Some: apiKey =>
@@ -50,38 +46,38 @@ public static class GenePoolCli<RT> where RT : struct,
                 from shouldOverwrite in AnsiConsole<RT>.confirm("Overwrite API key?", false)
                 select shouldOverwrite,
             None: () => SuccessAff<RT, bool>(true))
-        from _2 in shouldContinue ? createApiKey(apiKeyStore) : unitEff
+        from _2 in shouldContinue ? createApiKey(apiKeyStore, genepoolSettings) : unitEff
         select unit;
 
-    public static Aff<RT, Unit> getApiKeyStatus(IGenePoolApiKeyStore genePoolApiStore) =>
+    public static Aff<RT, Unit> getApiKeyStatus(IGenePoolApiKeyStore genePoolApiStore, GenepoolSettings genepoolSettings) =>
         from apiKeys in genePoolApiStore.GetApiKeys().ToAff(identity)
-        let apiKey = apiKeys.Find(GenePoolConstants.EryphGenePool.Name)
+        let apiKey = apiKeys.Find(genepoolSettings.Name)
         from _ in apiKey.Match(
             Some: key =>
                 from _1 in AnsiConsole<RT>.writeLine("The following gene pool API key is configured:")
                 from _2 in AnsiConsole<RT>.write(printApiKey(key))
-                from _3 in validateApiKey(key)
+                from _3 in validateApiKey(key, genepoolSettings)
                 select unit,
             None: () => AnsiConsole<RT>.writeLine("No gene pool API key is configured."))
         select unit;
 
-    public static Aff<RT, Unit> logout(IGenePoolApiKeyStore keyStore) =>
+    public static Aff<RT, Unit> logout(IGenePoolApiKeyStore keyStore, GenepoolSettings genepoolSettings) =>
         from apiKeys in keyStore.GetApiKeys().ToAff(identity)
-        let apiKey = apiKeys.Find(GenePoolConstants.EryphGenePool.Name)
+        let apiKey = apiKeys.Find(genepoolSettings.Name)
         from _ in apiKey.Match(
             Some: key =>
                 from _1 in AnsiConsole<RT>.writeLine("The following gene pool API key is configured:")
                 from _2 in AnsiConsole<RT>.write(printApiKey(key))
                 from shouldRemove in AnsiConsole<RT>.confirm("Remove API key?", false)
                 from _3 in shouldRemove
-                    ? removeApiKey(keyStore, GenePoolConstants.EryphGenePool.Name, key)
+                    ? removeApiKey(keyStore, genepoolSettings, key)
                     : unitEff
                 select unit,
             None: () => AnsiConsole<RT>.writeLine("No gene pool API key is configured."))
         select unit;
 
     private static Aff<RT, Unit> createApiKey(
-        IGenePoolApiKeyStore apiKeyStore) =>
+        IGenePoolApiKeyStore apiKeyStore, GenepoolSettings genepoolSettings) =>
         from orgName in AnsiConsole<RT>.prompt(
             "Enter your organization:",
             OrganizationName.NewValidation)
@@ -91,13 +87,12 @@ public static class GenePoolCli<RT> where RT : struct,
             ApiKeyName.NewValidation,
             $"eryph-zero-{hostname.ToLowerInvariant()}")
         from cancelToken in cancelToken<RT>()
-        from client in createGenePoolClient()
+        from client in createInteractiveGenePoolClient(genepoolSettings)
         from stopSpinner in AnsiConsole<RT>.startSpinner("Creating API key...")
         from result in Aff(async () =>
         {
             var response = await client.GetOrganizationClient(orgName)
-                // TODO Remove Org.Read permission when the /me endpoint is available
-                .CreateApiKeyAsync(apiKeyName, ["Geneset.Read", "Org.Read"], cancellationToken: cancelToken);
+                .CreateApiKeyAsync(apiKeyName, ["Geneset.Read"], cancellationToken: cancelToken);
             return Optional(response);
         }) | @catch(e => stopSpinner.Bind(_ => FailAff<RT, Option<ApiKeySecretResponse>>(e)))
         from _1 in stopSpinner
@@ -109,32 +104,32 @@ public static class GenePoolCli<RT> where RT : struct,
             Organization = validResult.Organization,
             Secret = validResult.Secret,
         }
-        from _2 in apiKeyStore.SaveApiKey(GenePoolConstants.EryphGenePool.Name, apiKey).ToAff(identity)
+        from _2 in apiKeyStore.SaveApiKey(genepoolSettings.Name, apiKey).ToAff(identity)
         from _3 in AnsiConsole<RT>.writeLine("The gene pool API key was successfully created.")
         select unit;
 
-    private static Aff<RT, Unit> validateApiKey(GenePoolApiKey apiKey) =>
-        from keyResponse in getApiKeyFromPool(apiKey).Map(Optional)
+    private static Aff<RT, Unit> validateApiKey(GenePoolApiKey apiKey, GenepoolSettings genepoolSettings) =>
+        from userResponse in getApiKeyUser(apiKey, genepoolSettings).Map(Optional)
                             | @catch(ex => ex is ErrorResponseException { Response.StatusCode: HttpStatusCode.Unauthorized },
-                                Option<ApiKeyResponse>.None)
+                                Option<GetMeResponse>.None)
                             | @catch(_ => true, e => Error.New("Could not validate the gene pool API key.", e))
-        from _ in keyResponse.Match(
+        from _ in userResponse.Match(
             Some: response =>
                 from _ in AnsiConsole<RT>.write(new Rows(
                     new Markup("The gene pool API key is valid. The following information was returned by the gene pool:"),
                     new Grid()
                         .AddColumn()
                         .AddColumn()
-                        .AddRow(new Text("Key ID:"), new Text(response.KeyId))
-                        .AddRow(new Text("Key Name:"), new Text(response.Name))
-                        .AddRow(new Text("Organisation:"), new Text(response.Organization.Name))))
+                        .AddRow(new Text("Key ID:"), new Text(response.Id))
+                        .AddRow(new Text("Key Name:"), new Text(response.DisplayName ?? ""))
+                        .AddRow(new Text("Organisation:"), new Text(response.GenepoolOrgs?.FirstOrDefault()?.Name ?? ""))))
                 select unit,
             None: () =>
                 from _ in AnsiConsole<RT>.writeLine("The gene pool API key is invalid.")
                 select unit)
         select unit;
 
-    private static Aff<RT, ApiKeyResponse> getApiKeyFromPool(GenePoolApiKey apiKey) =>
+    private static Aff<RT, GetMeResponse> getApiKeyUser(GenePoolApiKey apiKey, GenepoolSettings genepoolSettings) =>
         from cancelToken in cancelToken<RT>()
         from applicationId in ApplicationInfo<RT>.applicationId()
         from hardwareId in HardwareId<RT>.hashedHardwareId()
@@ -142,7 +137,7 @@ public static class GenePoolCli<RT> where RT : struct,
         from response in Aff(async () =>
         {
             var client = new GenePoolClient(
-                GenePoolConstants.EryphGenePool.ApiEndpoint,
+                genepoolSettings.ApiEndpoint,
                 new ApiKeyCredential(apiKey.Secret),
                 new GenePoolClientOptions()
                 {
@@ -152,24 +147,24 @@ public static class GenePoolCli<RT> where RT : struct,
                     },
                     HardwareId = hardwareId,
                 });
-            var response = await client.GetApiKeyClient(apiKey.Organization, apiKey.Id)
-                .GetAsync(cancellationToken: cancelToken);
+            var response = await client.GetUserClient()
+                .GetAsync(new GetUserRequestOptions{Expand = new ExpandFromUser{ GenepoolOrgs = true}}, cancellationToken: cancelToken);
 
             return response;
-        }) | @catch(e => stopSpinner.Bind(_ => FailAff<RT, ApiKeyResponse>(e)))
+        }) | @catch(e => stopSpinner.Bind(_ => FailAff<RT, GetMeResponse>(e)))
         from _ in stopSpinner
         select response;
 
     private static Aff<RT, Unit> removeApiKey(
         IGenePoolApiKeyStore apiKeyStore,
-        string genePoolName,
+        GenepoolSettings genepoolSettings,
         GenePoolApiKey apiKey) =>
         from _1 in AnsiConsole<RT>.writeLine(
             "Do you want to delete the API key from the remote gene pool? "
             + "You will need to authenticate with the gene pool.")
         from shouldDelete in AnsiConsole<RT>.confirm("Delete gene pool API key from gene pool?", false)
         from shouldContinue in shouldDelete
-            ? deleteApiKeyFromPool(apiKey).Map(_ => true)
+            ? deleteApiKeyFromPool(apiKey, genepoolSettings).Map(_ => true)
               | @catch(e =>
                   from _1 in AnsiConsole<RT>.write(new Rows(
                       new Markup("[red]Could not delete the API key from the remote gene pool.[/]"),
@@ -178,13 +173,13 @@ public static class GenePoolCli<RT> where RT : struct,
                   select shouldContinue)
             : SuccessAff<RT, bool>(true)
         from _2 in shouldContinue
-            ? apiKeyStore.RemoveApiKey(genePoolName).ToAff(identity)
+            ? apiKeyStore.RemoveApiKey(genepoolSettings.Name).ToAff(identity)
             : unitEff
         from _5 in AnsiConsole<RT>.writeLine("The gene pool API key was successfully removed.")
         select unit;
 
-    private static Aff<RT, Unit> deleteApiKeyFromPool(GenePoolApiKey apiKey) =>
-        from client in createGenePoolClient()
+    private static Aff<RT, Unit> deleteApiKeyFromPool(GenePoolApiKey apiKey, GenepoolSettings genepoolSettings) =>
+        from client in createInteractiveGenePoolClient(genepoolSettings)
         from cancelToken in cancelToken<RT>()
         from stopSpinner in AnsiConsole<RT>.startSpinner("Deleting API key...")
         from _1 in Aff(async () =>
@@ -196,12 +191,12 @@ public static class GenePoolCli<RT> where RT : struct,
         from _2 in stopSpinner
         select unit;
 
-    private static Aff<RT, GenePoolClient> createGenePoolClient() =>
+    private static Aff<RT, GenePoolClient> createInteractiveGenePoolClient(GenepoolSettings genepoolSettings) =>
         from cancelToken in cancelToken<RT>()
         from applicationId in ApplicationInfo<RT>.applicationId()
         from hardwareId in HardwareId<RT>.hashedHardwareId()
         from stopSpinner in AnsiConsole<RT>.startSpinner("Authenticating with the gene pool. Please check your browser.")
-        let options = new GenePoolClientOptions()
+        let options = new GenePoolClientOptions(GenePoolClientOptions.ServiceVersion.V1, genepoolSettings.ApiEndpoint.ToString(), genepoolSettings.IsStaging)
         {
             Diagnostics =
             {
@@ -213,8 +208,8 @@ public static class GenePoolCli<RT> where RT : struct,
         {
             var credentialOptions = new B2CInteractiveBrowserCredentialOptions
             {
-                ClientId = GenePoolConstants.EryphGenePool.AuthClientId,
-                AuthorityUri = GenePoolConstants.EryphGenePool.AuthEndpoint.AbsoluteUri,
+                ClientId = genepoolSettings.AuthClientId,
+                AuthorityUri = genepoolSettings.AuthEndpoint.AbsoluteUri,
                 BrowserCustomization = new BrowserCustomizationOptions
                 {
                     UseEmbeddedWebView = false,
@@ -224,7 +219,7 @@ public static class GenePoolCli<RT> where RT : struct,
             var credential = new B2CInteractiveBrowserCredential(credentialOptions);
             await credential.AuthenticateAsync(new TokenRequestContext());
             
-            return new GenePoolClient(GenePoolConstants.EryphGenePool.ApiEndpoint, credential, options);
+            return new GenePoolClient(genepoolSettings.ApiEndpoint, credential, options);
         }) | @catch(e => stopSpinner.Bind(_ => FailAff<RT, GenePoolClient>(e)))
         from _ in stopSpinner
         from __ in AnsiConsole<RT>.writeLine("Successfully authenticated with the gene pool.")

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenePoolCli.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenePoolCli.cs
@@ -122,7 +122,8 @@ public static class GenePoolCli<RT> where RT : struct,
                         .AddColumn()
                         .AddRow(new Text("Key ID:"), new Text(response.Id))
                         .AddRow(new Text("Key Name:"), new Text(response.DisplayName ?? ""))
-                        .AddRow(new Text("Organisation:"), new Text(response.GenepoolOrgs?.FirstOrDefault()?.Name ?? ""))))
+                        .AddRow(new Text(response.GenepoolOrgs?.Length != 1 ? "Organizations:": "Organization:"), 
+                            new Text(string.Join(',',(response.GenepoolOrgs ?? []).Select(x=>x.Name))))))
                 select unit,
             None: () =>
                 from _ in AnsiConsole<RT>.writeLine("The gene pool API key is invalid.")
@@ -231,5 +232,5 @@ public static class GenePoolCli<RT> where RT : struct,
             .AddColumn()
             .AddRow(new Text("Key ID:"), new Text(apiKey.Id))
             .AddRow(new Text("Key Name:"), new Text(apiKey.Name))
-            .AddRow(new Text("Organisation:"), new Text(apiKey.Organization));
+            .AddRow(new Text("Organization:"), new Text(apiKey.Organization));
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenePoolConstants.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenePoolConstants.cs
@@ -7,7 +7,7 @@ public static class GenePoolConstants
         public static readonly string Name = "local";
     }
 
-    public static string PartClientName = "gene_part_client";
+    public const string PartClientName = "gene_part_client";
 
     public static GenepoolSettings ProductionGenepool => new (
         "eryph-genepool",

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenePoolConstants.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenePoolConstants.cs
@@ -1,20 +1,25 @@
-﻿using System;
+﻿namespace Eryph.Modules.VmHostAgent.Genetics;
 
-namespace Eryph.Modules.VmHostAgent.Genetics;
-
-internal static class GenePoolConstants
+public static class GenePoolConstants
 {
     internal static class Local
     {
         public static readonly string Name = "local";
     }
 
-    internal static class EryphGenePool
-    {
-        public static readonly string Name = "eryph-genepool";
-        public static readonly Uri ApiEndpoint = new("https://eryphgenepoolapistaging.azurewebsites.net/api/");
-        public static readonly Uri AuthEndpoint = new("https://dbosoftb2cstaging.b2clogin.com/tfp/dbosoftb2cstaging.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN/v2.0");
-        public static readonly string AuthClientId = "56136c3f-d46e-4644-a66c-b88304d09da8";
-        public static readonly Uri CdnEndpoint = new("https://eryph-staging-b2.b-cdn.net");
-    }
+    public static string PartClientName = "gene_part_client";
+
+    public static GenepoolSettings ProductionGenepool => new (
+        "eryph-genepool",
+        new("https://genepool-api.eryph.io/"),
+        new("https://login.dbosoft.eu/tfp/a18f6025-dca7-463e-b38a-84cf9f2ca684/B2C_1A_SIGNUP_SIGNIN/v2.0"),
+        "0cadd98d-1e87-467b-a908-db1e340e9049", false);
+
+    public static GenepoolSettings StagingGenepool => new(
+        "eryph-genepool-staging",
+        new("https://eryphgenepoolapistaging.azurewebsites.net/"),
+        new("https://dbosoftb2cstaging.b2clogin.com/tfp/dbosoftb2cstaging.onmicrosoft.com/B2C_1A_SIGNUP_SIGNIN/v2.0"),
+        "56136c3f-d46e-4644-a66c-b88304d09da8", true);
+
+
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenePoolFactory.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenePoolFactory.cs
@@ -24,14 +24,14 @@ internal class GenePoolFactory(Container container) : IGenePoolFactory
         ActivatorUtilities.CreateInstance<LocalGenePoolSource>(
             container, GenePoolConstants.Local.Name, genePoolPath);
 
-    public void Register<TImplementation>(string name)
+    public void Register<TImplementation>(GenepoolSettings settings)
         where TImplementation : class, IGenePool
     {
         var producer = Lifestyle.Transient
             .CreateProducer<IGenePool>(
-                () => ActivatorUtilities.CreateInstance<TImplementation>(container, name),
+                () => ActivatorUtilities.CreateInstance<TImplementation>(container, settings),
                 container);
 
-        _producers.Add(name, producer);
+        _producers.Add(settings.Name, producer);
     }
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenepoolSettings.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/Genetics/GenepoolSettings.cs
@@ -1,0 +1,5 @@
+﻿using System;
+
+namespace Eryph.Modules.VmHostAgent.Genetics;
+
+public record GenepoolSettings(string Name, Uri ApiEndpoint, Uri AuthEndpoint, string AuthClientId, bool IsStaging);


### PR DESCRIPTION
This PR changes the default genepool to the production genepool.
For testing, the same logic has been added as already used for packer: 

If the environment variable ERYPH_GENEPOOL_AUTHORITY is set to "staging", both the staging authority and the staging genepool will be enabled. If ERYPH_GENEPOOL_API is also set, the alternate genepool endpoint will also be used for local testing. 

Login/logout will also take these variables into account. Genepool settings managed by these commands are separated for staging and production, so both can be configured in the same agent. 

Login/Logout has been moved to the genepool command like info as it is more consistent with the command line interface.

CDN HTTP client configuration was removed, as CDN is selected on server side, client configuration only requires a unique name for client to configure retry settings.

Api Key no longer requires org.read permissions as we are now using user endpoint to check API key.

closes #247 