### PR TITLE
Fix minimum and maximum memory in generated catlet config

### DIFF
--- a/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
@@ -170,7 +170,7 @@ internal class GetCatletConfigurationHandler(
 
             Maximum = catlet.MaximumMemory != 0 ? (int)Math.Ceiling(catlet.MaximumMemory / 1024d / 1024)
                 : null,
-            Minimum = catlet.MinimumMemory != 0 ? (int)Math.Ceiling(catlet.MaximumMemory / 1024d / 1024)
+            Minimum = catlet.MinimumMemory != 0 ? (int)Math.Ceiling(catlet.MinimumMemory / 1024d / 1024)
                 : null,
 
         };

--- a/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
@@ -163,7 +163,7 @@ namespace Eryph.Modules.Controller.Inventory
                         existingMachine.CpuCount = newMachine.CpuCount;
                         existingMachine.StartupMemory = newMachine.StartupMemory;
                         existingMachine.MinimumMemory = newMachine.MinimumMemory;
-                        existingMachine.StartupMemory = newMachine.StartupMemory;
+                        existingMachine.MaximumMemory = newMachine.MaximumMemory;
                         existingMachine.Features = newMachine.Features;
                         existingMachine.SecureBootTemplate = newMachine.SecureBootTemplate;
 
@@ -397,7 +397,7 @@ namespace Eryph.Modules.Controller.Inventory
                     CpuCount = vmInfo.Cpu?.Count ?? 0,
                     StartupMemory = vmInfo.Memory?.Startup ?? 0,
                     MinimumMemory = vmInfo.Memory?.Minimum ?? 0,
-                    MaximumMemory = vmInfo.Memory?.Startup ?? 0,
+                    MaximumMemory = vmInfo.Memory?.Maximum ?? 0,
                     Features = MapFeatures(vmInfo),
                     SecureBootTemplate = vmInfo.Firmware?.SecureBootTemplate,
                     NetworkAdapters = vmInfo.NetworkAdapters.Select(a => new CatletNetworkAdapter


### PR DESCRIPTION
This PR fixes the minimum and maximum memory in the generated catlet configuration. The maximum value was also not properly tracked in the inventory.

Closes #287