### PR TITLE
Support removal of VMs and volumes during uninstallation

### DIFF
--- a/src/apps/src/Eryph-zero/DriverCommandsRuntime.cs
+++ b/src/apps/src/Eryph-zero/DriverCommandsRuntime.cs
@@ -19,6 +19,7 @@ namespace Eryph.Runtime.Zero;
 internal readonly struct DriverCommandsRuntime :
     HasAnsiConsole<DriverCommandsRuntime>,
     HasConsole<DriverCommandsRuntime>,
+    HasDirectory<DriverCommandsRuntime>,
     HasDism<DriverCommandsRuntime>,
     HasFile<DriverCommandsRuntime>,
     HasHostNetworkCommands<DriverCommandsRuntime>,
@@ -47,6 +48,8 @@ internal readonly struct DriverCommandsRuntime :
     public CancellationTokenSource CancellationTokenSource => Env.CancellationTokenSource;
 
     public Eff<DriverCommandsRuntime, ConsoleIO> ConsoleEff => SuccessEff(LanguageExt.Sys.Live.ConsoleIO.Default);
+
+    public Eff<DriverCommandsRuntime, DirectoryIO> DirectoryEff => SuccessEff(LanguageExt.Sys.Live.DirectoryIO.Default);
 
     public Eff<DriverCommandsRuntime, DismIO> DismEff => SuccessEff(LiveDismIO.Default);
 

--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -131,7 +131,7 @@ internal static class Program
         uninstallCommand.AddOption(deleteAppData);
         var deleteCatlets = new System.CommandLine.Option<bool>(
             name: "--delete-catlets",
-            description: "Delete all virtual machines and disks");
+            description: "Delete all catlets and disks");
         uninstallCommand.AddOption(deleteCatlets);
         uninstallCommand.SetHandler(SelfUnInstall, outFileOption, deleteOutFile, deleteAppData, deleteCatlets);
         rootCommand.AddCommand(uninstallCommand);

--- a/src/apps/src/Eryph-zero/UninstallCommands.cs
+++ b/src/apps/src/Eryph-zero/UninstallCommands.cs
@@ -175,5 +175,5 @@ internal class UninstallCommands
 
     private static Aff<DriverCommandsRuntime, Unit> RemoveStore(string path) =>
         delete(path, recursive: true) | @catch(e => logWarning<UninstallCommands>(
-            e, "The store {Path} could not be removed. If necessary, remove it manually.", path));
+            e, "The store '{Path}' could not be removed. If necessary, remove it manually.", path));
 }

--- a/src/apps/src/Eryph-zero/UninstallCommands.cs
+++ b/src/apps/src/Eryph-zero/UninstallCommands.cs
@@ -79,10 +79,11 @@ internal class UninstallCommands
         select unit;
 
     public static Aff<DriverCommandsRuntime, Unit> RemoveCatletsAndDisk() =>
-        from _1 in RemoveCatlets()
+        from _1 in logInformation<UninstallCommands>("Removing catlets and disks...")
+        from _2 in RemoveCatlets()
                    | @catch(e => logWarning<UninstallCommands>(
                        e, "The catlets could not be removed. If necessary, remove them manually."))
-        from _2 in RemoveStores()
+        from _3 in RemoveStores()
                    | @catch(e => logWarning<UninstallCommands>(
                        e, "The catlet disks could not be removed. If necessary, remove them manually."))
         select unit;

--- a/src/apps/src/Eryph-zero/UninstallCommands.cs
+++ b/src/apps/src/Eryph-zero/UninstallCommands.cs
@@ -174,6 +174,6 @@ internal class UninstallCommands
         select unit;
 
     private static Aff<DriverCommandsRuntime, Unit> RemoveStore(string path) =>
-        delete(path) | @catch(e => logWarning<UninstallCommands>(
+        delete(path, recursive: true) | @catch(e => logWarning<UninstallCommands>(
             e, "The store {Path} could not be removed. If necessary, remove it manually.", path));
 }

--- a/src/apps/src/eryph-uninstaller/WelcomePage.xaml
+++ b/src/apps/src/eryph-uninstaller/WelcomePage.xaml
@@ -65,7 +65,7 @@
                   Grid.Row="5"
                   Margin="0,5"
                   IsEnabled="{Binding IsChecked, ElementName=RemoveConfigCheckBox}">
-            Remove virtual machines and disks
+            Remove catlets and disks
         </CheckBox>
         <Button x:Name="UninstallButton"
                 Grid.Row="6"

--- a/src/apps/src/eryph-uninstaller/WelcomePage.xaml
+++ b/src/apps/src/eryph-uninstaller/WelcomePage.xaml
@@ -64,8 +64,8 @@
         <CheckBox x:Name="RemoveVirtualMachinesCheckBox"
                   Grid.Row="5"
                   Margin="0,5"
-                  IsEnabled="{Binding IsChecked, ElementName=RemoveConfigCheckBox}" Visibility="Hidden">
-            Remove virtual machines and disk
+                  IsEnabled="{Binding IsChecked, ElementName=RemoveConfigCheckBox}">
+            Remove virtual machines and disks
         </CheckBox>
         <Button x:Name="UninstallButton"
                 Grid.Row="6"


### PR DESCRIPTION
This PR adds another option to the uninstaller which allows the user to remove the VMs and disk which were created by eryph.

Closes #124