### PR TITLE
install script: enforce administrator / updates

### DIFF
--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -744,7 +744,7 @@ if(-not $DownloadUrl){
     }
 
     # version check as soon we know selected version
-    if(Test-InstalledOrNotUpdated -eq $true){
+    if((Test-InstalledOrNotUpdated) -eq $true){
         return
     }  
 
@@ -788,7 +788,7 @@ if (Test-Path $DownloadUrl) {
     Request-File -Url $DownloadUrl -File $file -ProxyConfiguration $proxyConfig
 
     # check for forced update if not downloaded
-    if(Test-InstalledOrNotUpdated -eq $true){
+    if((Test-InstalledOrNotUpdated) -eq $true){
         return
     }  
 }

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -744,7 +744,7 @@ if(-not $DownloadUrl){
     }
 
     # version check as soon we know selected version
-    if(Test-InstalledOrNotUpdated){
+    if(Test-InstalledOrNotUpdated -eq $true){
         return
     }  
 
@@ -788,7 +788,7 @@ if (Test-Path $DownloadUrl) {
     Request-File -Url $DownloadUrl -File $file -ProxyConfiguration $proxyConfig
 
     # check for forced update if not downloaded
-    if(Test-InstalledOrNotUpdated){
+    if(Test-InstalledOrNotUpdated -eq $true){
         return
     }  
 }

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -1,3 +1,4 @@
+#Requires -RunAsAdministrator
 <#
     .SYNOPSIS
     Downloads and installs eryph-zero on the local machine.

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -636,9 +636,9 @@ else{
     if($processor.VirtualizationFirmwareEnabled -eq $false -or $processor.VMMonitorModeExtensions -eq $false){
             $errorMessage = @(
         'Virtualization is not enabled for your computer system.'
-        'To continue the installation enable virtualization extensions in the BIOS of your computer.'
+        'To continue the installation, enable virtualization extensions in your computer''s BIOS.'
         ''
-        'A list of requirements of Hyper-V can be found here:'
+        'A list of Hyper-V requirements can be found here:'
         'https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/reference/hyper-v-requirements'
 
     ) -join [Environment]::NewLine

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -440,8 +440,10 @@ function Test-InstalledOrUpdate {
         Write-Warning $message
 
         if(-not $Force -and !$update){
-            exit
+            $True
         }
+
+        $false
     }
 }
 
@@ -684,6 +686,17 @@ catch {
     Write-Warning $errorMessage
 }
 
+
+$vcruntimeVersion = Get-VCRuntimeVersion
+
+if($vcruntimeVersion){
+    Write-Verbose "Found VC runtime version: $vcruntimeVersion" -InformationAction Continue
+}
+
+if($vcruntimeVersion -lt "v14.42.34433.0"){
+    Install-VCRuntime -ProxyConfiguration $proxyConfig
+}
+
 if ($DownloadUrl) {
     if ($Version) {
         Write-Warning "Ignoring -Version parameter ($Version) because -DownloadUrl is set."
@@ -730,7 +743,10 @@ if(-not $DownloadUrl){
         return
     }
 
-    Test-InstalledOrUpdate  # version check as soon we know selected version
+    # version check as soon we know selected version
+    if(-not (Test-InstalledOrUpdate)){
+        return
+    }  
 
     if(-not $productFile.Beta){
         $DownloadUrl = $productFile.url
@@ -771,7 +787,10 @@ if (Test-Path $DownloadUrl) {
     Write-Information "Getting eryph from $DownloadUrl." -InformationAction Continue
     Request-File -Url $DownloadUrl -File $file -ProxyConfiguration $proxyConfig
 
-    Test-InstalledOrUpdate # check for forced update if not downloaded
+    # check for forced update if not downloaded
+    if(-not (Test-InstalledOrUpdate)){
+        return
+    }  
 }
 
 
@@ -811,18 +830,9 @@ if($deleteFile) {
 
 #region Install eryph
 
-$vcruntimeVersion = Get-VCRuntimeVersion
-
-if($vcruntimeVersion){
-    Write-Verbose "Found VC runtime version: $vcruntimeVersion" -InformationAction Continue
-}
-
-if($vcruntimeVersion -lt "v14.42.34433.0"){
-    Install-VCRuntime -ProxyConfiguration $proxyConfig
-}
-
 Write-Information "Starting eryph-zero installation." -InformationAction Continue
 Write-Host
+
 $toolsFolder = Join-Path $tempDir -ChildPath "bin"
 $eryphInstallExe = Join-Path $toolsFolder -ChildPath "eryph-zero.exe"
 

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -441,10 +441,10 @@ function Test-InstalledOrNotUpdated {
 
         if(-not $Force -and !$update){
             $True
-        }
-
-        $false
+        }        
     }
+
+    $false
 }
 
 

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -744,7 +744,8 @@ if(-not $DownloadUrl){
     }
 
     # version check as soon we know selected version
-    if((Test-InstalledOrNotUpdated) -eq $true){
+    $stop = Test-InstalledOrNotUpdated
+    if($stop -eq $true){
         return
     }  
 
@@ -788,7 +789,8 @@ if (Test-Path $DownloadUrl) {
     Request-File -Url $DownloadUrl -File $file -ProxyConfiguration $proxyConfig
 
     # check for forced update if not downloaded
-    if((Test-InstalledOrNotUpdated) -eq $true){
+    $stop = Test-InstalledOrNotUpdated
+    if($stop -eq $true){
         return
     }  
 }

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -684,17 +684,6 @@ catch {
     Write-Warning $errorMessage
 }
 
-
-$vcruntimeVersion = Get-VCRuntimeVersion
-
-if($vcruntimeVersion){
-    Write-Verbose "Found VC runtime version: $vcruntimeVersion" -InformationAction Continue
-}
-
-if($vcruntimeVersion -lt "v14.42.34433.0"){
-    Install-VCRuntime -ProxyConfiguration $proxyConfig
-}
-
 if ($DownloadUrl) {
     if ($Version) {
         Write-Warning "Ignoring -Version parameter ($Version) because -DownloadUrl is set."
@@ -822,9 +811,18 @@ if($deleteFile) {
 
 #region Install eryph
 
+$vcruntimeVersion = Get-VCRuntimeVersion
+
+if($vcruntimeVersion){
+    Write-Verbose "Found VC runtime version: $vcruntimeVersion" -InformationAction Continue
+}
+
+if($vcruntimeVersion -lt "v14.42.34433.0"){
+    Install-VCRuntime -ProxyConfiguration $proxyConfig
+}
+
 Write-Information "Starting eryph-zero installation." -InformationAction Continue
 Write-Host
-
 $toolsFolder = Join-Path $tempDir -ChildPath "bin"
 $eryphInstallExe = Join-Path $toolsFolder -ChildPath "eryph-zero.exe"
 

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -361,7 +361,7 @@ function Test-EryphInstalled {
 }
 
 
-function Test-InstalledOrUpdate {
+function Test-InstalledOrNotUpdated {
     [CmdletBinding()]
     param()
 
@@ -744,7 +744,7 @@ if(-not $DownloadUrl){
     }
 
     # version check as soon we know selected version
-    if(-not (Test-InstalledOrUpdate)){
+    if(Test-InstalledOrNotUpdated){
         return
     }  
 
@@ -788,7 +788,7 @@ if (Test-Path $DownloadUrl) {
     Request-File -Url $DownloadUrl -File $file -ProxyConfiguration $proxyConfig
 
     # check for forced update if not downloaded
-    if(-not (Test-InstalledOrUpdate)){
+    if(Test-InstalledOrNotUpdated){
         return
     }  
 }

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -441,6 +441,7 @@ function Test-InstalledOrNotUpdated {
 
         if(-not $Force -and !$update){
             $True
+            return
         }        
     }
 


### PR DESCRIPTION
Recent changes to eryph-zero install.ps1 further enforce being admin when installing (VC package check). However, this is currently not automatically checked in the script. 

Added check to enforce admin.

In addition this PR also adds the functionality to update eryph-zero and to ensure that virtualization extensions are installed.