### PR TITLE
Fix timing issue in catlet inventory

### DIFF
--- a/src/modules/src/Eryph.Modules.Controller/Inventory/CatletStateChangedEventHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/CatletStateChangedEventHandler.cs
@@ -43,7 +43,7 @@ internal class CatletStateChangedEventHandler(
         }
         else
         {
-            logger.LogDebug("Skipping state update for catlet {CatletId} with timestamp {Timestamp}. Most recent state information is dated {LastSeen}.",
+            logger.LogDebug("Skipping state update for catlet {CatletId} with timestamp {Timestamp:O}. Most recent state information is dated {LastSeen:O}.",
                 catlet.Id, message.Timestamp, catlet.LastSeenState);
         }
 

--- a/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
@@ -131,7 +131,7 @@ namespace Eryph.Modules.Controller.Inventory
                     {
                         if (existingMachine.LastSeen >= timestamp)
                         {
-                            _logger.LogDebug("Skipping inventory update for catlet {CatletId} with timestamp {Timestamp}. Most recent information is dated {LastSeen}.",
+                            _logger.LogDebug("Skipping inventory update for catlet {CatletId} with timestamp {Timestamp:O}. Most recent information is dated {LastSeen:O}.",
                                 existingMachine.Id, timestamp, existingMachine.LastSeen);
                             return;
                         }
@@ -169,7 +169,7 @@ namespace Eryph.Modules.Controller.Inventory
 
                         if (existingMachine.LastSeenState >= timestamp)
                         {
-                            _logger.LogDebug("Skipping state update for catlet {CatletId} with timestamp {Timestamp}. Most recent state information is dated {LastSeen}.",
+                            _logger.LogDebug("Skipping state update for catlet {CatletId} with timestamp {Timestamp:O}. Most recent state information is dated {LastSeen:O}.",
                                 existingMachine.Id, timestamp, existingMachine.LastSeenState);
                             return;
                         }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/CatletConfigCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/CatletConfigCommandHandler.cs
@@ -179,12 +179,10 @@ namespace Eryph.Modules.VmHostAgent
 
         protected static EitherAsync<Error, VirtualMachineData> CreateMachineInventory(
             IPowershellEngine engine, VmHostAgentConfiguration vmHostAgentConfig,
-            TypedPsObject<VirtualMachineInfo> vmInfo, IHostInfoProvider hostInfoProvider)
-        {
-            var inventory = new VirtualMachineInventory(engine, vmHostAgentConfig, hostInfoProvider);
-            return inventory.InventorizeVM(vmInfo);
-        }
-
-
+            TypedPsObject<VirtualMachineInfo> vmInfo, IHostInfoProvider hostInfoProvider) =>
+            from reloadedVmInfo in vmInfo.Reload(engine)
+            let inventory = new VirtualMachineInventory(engine, vmHostAgentConfig, hostInfoProvider)
+            from vmData in inventory.InventorizeVM(vmInfo)
+            select vmData;
     }
 }

--- a/src/modules/src/Eryph.Modules.VmHostAgent/CreateCatletVMCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/CreateCatletVMCommandHandler.cs
@@ -53,13 +53,14 @@ namespace Eryph.Modules.VmHostAgent
             from createdVM in CreateVM(plannedStorageSettings, Engine, command.BredConfig)
             let metadataId = Guid.NewGuid()
             from _ in SetMetadataId(createdVM, metadataId)
+            let timestamp = DateTimeOffset.UtcNow
             from inventory in CreateMachineInventory(Engine, vmHostAgentConfig, createdVM, _hostInfoProvider)
             select new ConvergeCatletResult
             {
                 VmId = createdVM.Value.Id,
                 MetadataId = metadataId,
                 Inventory = inventory,
-                Timestamp = DateTimeOffset.UtcNow,
+                Timestamp = timestamp,
             };
 
         private static EitherAsync<Error, TypedPsObject<VirtualMachineInfo>> CreateVM(

--- a/src/modules/src/Eryph.Modules.VmHostAgent/UpdateCatletVMCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.VmHostAgent/UpdateCatletVMCommandHandler.cs
@@ -56,12 +56,13 @@ internal class UpdateCatletVMCommandHandler(
                 substitutedConfig, command.MachineMetadata, command.MachineNetworkSettings,
                 plannedStorageSettings, command.ResolvedGenes.ToSeq())
             .WriteTrace().ToAsync()
+        let timestamp = DateTimeOffset.UtcNow
         from inventory in CreateMachineInventory(Engine, vmHostAgentConfig, vmInfoConverged, hostInfoProvider).WriteTrace()
         select new ConvergeCatletResult
         {
             VmId = vmInfoConverged.Value.Id,
             MetadataId = command.MachineMetadata.Id,
             Inventory = inventory,
-            Timestamp = DateTimeOffset.UtcNow,
+            Timestamp = timestamp,
         };
 }


### PR DESCRIPTION
This PR fixes a timing issue in the catlet inventory which surfaced in the end-to-end tests. The inventory would sometimes drop
updates due to incorrect timestamps.