### PR TITLE
Improve error messages for naming conflicts

### DIFF
--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Create.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Create.cs
@@ -89,7 +89,7 @@ public class Create(
         if (existingCatlet != null)
             return Problem(
                 statusCode: StatusCodes.Status409Conflict,
-                detail: "A catlet with this name already exists");
+                detail: $"A catlet with name '{catletName}' already exists in project '{projectName.Value}'. Catlet names must be unique within a project.");
             
         return await base.HandleAsync(request, cancellationToken);
     }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Create.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/Create.cs
@@ -89,7 +89,7 @@ public class Create(
         if (existingCatlet != null)
             return Problem(
                 statusCode: StatusCodes.Status409Conflict,
-                detail: $"A catlet with name '{catletName}' already exists in project '{projectName.Value}'. Catlet names must be unique within a project.");
+                detail: $"A catlet with the name '{catletName}' already exists in the project '{projectName.Value}'. Catlet names must be unique within a project.");
             
         return await base.HandleAsync(request, cancellationToken);
     }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/ExpandNewCatletConfig.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/ExpandNewCatletConfig.cs
@@ -93,7 +93,7 @@ public class ExpandNewCatletConfig(
         if (existingCatlet != null)
             return Problem(
                 statusCode: StatusCodes.Status409Conflict,
-                detail: "A catlet with this name already exists");
+                detail: $"A catlet with name '{catletName}' already exists in project '{projectName.Value}'. Catlet names must be unique within a project.");
 
         return await base.HandleAsync(request, cancellationToken);
     }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/ExpandNewCatletConfig.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/ExpandNewCatletConfig.cs
@@ -93,7 +93,7 @@ public class ExpandNewCatletConfig(
         if (existingCatlet != null)
             return Problem(
                 statusCode: StatusCodes.Status409Conflict,
-                detail: $"A catlet with name '{catletName}' already exists in project '{projectName.Value}'. Catlet names must be unique within a project.");
+                detail: $"A catlet with the name '{catletName}' already exists in the project '{projectName.Value}'. Catlet names must be unique within a project.");
 
         return await base.HandleAsync(request, cancellationToken);
     }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/PopulateCatletConfigVariables.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/PopulateCatletConfigVariables.cs
@@ -92,7 +92,7 @@ public class PopulateCatletConfigVariables(
         if (existingCatlet != null)
             return Problem(
                 statusCode: StatusCodes.Status409Conflict,
-                detail: "A catlet with this name already exists");
+                detail: $"A catlet with name '{catletName}' already exists in project '{projectName.Value}'. Catlet names must be unique within a project.");
 
         return await base.HandleAsync(request, cancellationToken);
     }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/PopulateCatletConfigVariables.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/PopulateCatletConfigVariables.cs
@@ -92,7 +92,7 @@ public class PopulateCatletConfigVariables(
         if (existingCatlet != null)
             return Problem(
                 statusCode: StatusCodes.Status409Conflict,
-                detail: $"A catlet with name '{catletName}' already exists in project '{projectName.Value}'. Catlet names must be unique within a project.");
+                detail: $"A catlet with the name '{catletName}' already exists in the project '{projectName.Value}'. Catlet names must be unique within a project.");
 
         return await base.HandleAsync(request, cancellationToken);
     }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/VirtualDisks/Create.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/VirtualDisks/Create.cs
@@ -93,7 +93,7 @@ public class Create(
         if (diskExists)
             return Problem(
                 statusCode: StatusCodes.Status409Conflict,
-                detail: "A disk with this name already exists.");
+                detail: $"A disk with the name '{request.Name}' already exists in the specified storage location. Disk names must be unique within a storage location.");
 
         return await base.HandleAsync(request, cancellationToken);
     }


### PR DESCRIPTION
This PR improves the error messages which are returned for naming conflicts of catlets and virtual disks.

Closes #314