### PR TITLE
install.ps1: Missing features if some Hyper-V features are installed

### DIFF
--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -722,11 +722,11 @@ if((Test-CommandExist "Get-WindowsFeature")){
 	}
     
 } else{
-    $HyperVFeature = Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V-All -Online
+    $HyperVFeature = Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V -Online
     # Check if Hyper-V is enabled
     if($HyperVFeature.State -ne "Enabled") {
         Write-Warning "Hyper-V is not installed. Installing feature..."
-        Enable-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V-All -Online -NoRestart -OutVariable results | Out-Null 
+        Enable-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V -All -Online -NoRestart -OutVariable results | Out-Null 
 
         if ($results.RestartNeeded -eq $true) {
             # give a better explaination why a reboot is required in non-server os as it is not shown in the output

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -729,13 +729,14 @@ if((Test-CommandExist "Get-WindowsFeature")){
     if($MissingHyperVFeatures) {
         
         $missingHypervisorFeature = $MissingHyperVFeatures | Where-Object { 
-            $_.FeatureName -eq "Microsoft-Hyper-V-Hypervisor" }
+            # check if Hyper-V core feature is missing
+            # this is a special case as it cannot be installed in same command as other Hyper-V features
+            $_.FeatureName -eq "Microsoft-Hyper-V" }
         
         if($missingHypervisorFeature){
 
             Write-Warning "Hyper-V is not installed. Installing feature..."
 
-            # install Hyper-V core feature which cannot be run in same command as other Hyper-V features
             Enable-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V -All -Online `
                 -NoRestart -OutVariable results | Out-Null 
 
@@ -756,11 +757,12 @@ if((Test-CommandExist "Get-WindowsFeature")){
                 | Where-Object { $_.State -ne "Enabled" }
 
         $MissingHyperVFeatures | ForEach-Object { 
-            Write-Warning "Enabling Hyper-V feature: $($_.FeatureName)"
+            Write-Warning "Enabling Hyper-V feature: $($_.DisplayName)"
             Enable-WindowsOptionalFeature -FeatureName $_.FeatureName -All -Online `
             -NoRestart -OutVariable results | Out-Null 
 
             if ($results.RestartNeeded -eq $true) {
+                # this is used, linter issue
                 $needsRestart = $true
             }
         }

--- a/src/apps/src/Eryph-zero/install.ps1
+++ b/src/apps/src/Eryph-zero/install.ps1
@@ -722,23 +722,50 @@ if((Test-CommandExist "Get-WindowsFeature")){
 	}
     
 } else{
-    $HyperVFeature = Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V -Online
-    # Check if Hyper-V is enabled
-    if($HyperVFeature.State -ne "Enabled") {
-        Write-Warning "Hyper-V is not installed. Installing feature..."
-        Enable-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V -All -Online -NoRestart -OutVariable results | Out-Null 
+    $MissingHyperVFeatures = Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V* -Online `
+                | Where-Object { $_.State -ne "Enabled" }
 
-        if ($results.RestartNeeded -eq $true) {
-            # give a better explaination why a reboot is required in non-server os as it is not shown in the output
-            # if installation command
-            $errorMessage = @(
-                'Automatic reboot is disabled during Hyper-V installation to prevent data loss.'
-                'However, a reboot is required before you can continue with the installation.'
-            ) -join [Environment]::NewLine
-            Write-Warning $errorMessage
-            $needsRestart = $true
+    # Check if Hyper-V is enabled
+    if($MissingHyperVFeatures) {
+        
+        $missingHypervisorFeature = $MissingHyperVFeatures | Where-Object { 
+            $_.FeatureName -eq "Microsoft-Hyper-V-Hypervisor" }
+        
+        if($missingHypervisorFeature){
+
+            Write-Warning "Hyper-V is not installed. Installing feature..."
+
+            # install Hyper-V core feature which cannot be run in same command as other Hyper-V features
+            Enable-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V -All -Online `
+                -NoRestart -OutVariable results | Out-Null 
+
+            if ($results.RestartNeeded -eq $true) {
+                # give a better explaination why a reboot is required in non-server os as it is not shown in the output
+                # if installation command
+                $errorMessage = @(
+                    'Automatic reboot is disabled during Hyper-V installation to prevent data loss.'
+                    'However, a reboot is required before you can continue with the installation.'
+                ) -join [Environment]::NewLine
+                Write-Warning $errorMessage
+                $needsRestart = $true
+            }
+        }
+
+        # install all other Hyper-V features
+        $MissingHyperVFeatures = Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V* -Online `
+                | Where-Object { $_.State -ne "Enabled" }
+
+        $MissingHyperVFeatures | ForEach-Object { 
+            Write-Warning "Enabling Hyper-V feature: $($_.FeatureName)"
+            Enable-WindowsOptionalFeature -FeatureName $_.FeatureName -All -Online `
+            -NoRestart -OutVariable results | Out-Null 
+
+            if ($results.RestartNeeded -eq $true) {
+                $needsRestart = $true
+            }
         }
     }
+
 }
 
 if($needsRestart -eq $true){


### PR DESCRIPTION

If Hyper-V features are already partially installed, the install.ps1 script currently doesn't install them because "All" features are already reported as enabled if at least one component is enabled. 

For some reason, the Hyper-V hypervisor and service feature cannot be installed without adding the Hyper-V feature first. The command has been updated to install the Hyper-V feature first and then everything else.