### PR TITLE
Add endpoint with API version information

### DIFF
--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/ApiVersion.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/ApiVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace Eryph.Modules.AspNetCore.ApiProvider.Model.V1;
+
+public class ApiVersion
+{
+    public required int Major { get; init; }
+
+    public required int Minor { get; init; }
+}

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/ApiVersion.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/ApiVersion.cs
@@ -1,8 +1,21 @@
 ﻿namespace Eryph.Modules.AspNetCore.ApiProvider.Model.V1;
 
+/// <summary>
+/// Encodes an API version.
+/// </summary>
 public class ApiVersion
 {
+    /// <summary>
+    /// The major version of the API. The major version is incremented when
+    /// breaking changes are introduced to the API. The version part of the
+    /// endpoint URLs will change in this case.
+    /// </summary>
     public required int Major { get; init; }
 
+    /// <summary>
+    /// The minor version of the API. The minor version is incremented when
+    /// backwards-compatible extensions are made to the API. This allows
+    /// the clients to support different features sets.
+    /// </summary>
     public required int Minor { get; init; }
 }

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/ApiVersionResponse.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/ApiVersionResponse.cs
@@ -1,8 +1,14 @@
 ﻿namespace Eryph.Modules.AspNetCore.ApiProvider.Model.V1;
 
+/// <summary>
+/// Contains versioning information for the REST API.
+/// </summary>
 public class ApiVersionResponse
 {
-    public required ApiVersion Version { get; init; } = new()
+    /// <summary>
+    /// The latest version of the API supported by this instance.
+    /// </summary>
+    public required ApiVersion LatestVersion { get; init; } = new()
     {
         Major = 1,
         Minor = 1,

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/ApiVersionResponse.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/ApiVersionResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace Eryph.Modules.AspNetCore.ApiProvider.Model.V1;
+
+public class ApiVersionResponse
+{
+    public required ApiVersion Version { get; init; } = new()
+    {
+        Major = 1,
+        Minor = 1,
+    };
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/ComputeApiVersion.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/ComputeApiVersion.cs
@@ -1,0 +1,8 @@
+﻿namespace Eryph.Modules.ComputeApi;
+
+internal static class ComputeApiVersion
+{
+    public const int Major = 1;
+
+    public const int Minor = 1;
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/GetVersion.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/GetVersion.cs
@@ -17,7 +17,7 @@ public class GetVersion : EndpointBaseAsync
     [SwaggerOperation(
         Summary = "Get the API version",
         Description = "Gets the API version which can be used by clients for compatibility checks. "
-        + "This endpoint has been added with eryph v0.3.",
+        + "This endpoint was added with eryph v0.3.",
         OperationId = "Version_Get",
         Tags = ["Version"])
     ]

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/GetVersion.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/GetVersion.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Ardalis.ApiEndpoints;
+using Eryph.Modules.AspNetCore.ApiProvider.Model.V1;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Eryph.Modules.ComputeApi.Endpoints.V1;
+
+[Route("v{version:apiVersion}")]
+public class GetVersion : EndpointBaseAsync
+    .WithoutRequest
+    .WithActionResult<ApiVersionResponse>
+{
+    [HttpGet("version")]
+    [SwaggerOperation(
+        Summary = "Get the API version",
+        Description = "Gets the API version which can be used by clients for compatibility checks.",
+        OperationId = "Version_Get",
+        Tags = ["Version"])
+    ]
+    [SwaggerResponse(
+        statusCode: StatusCodes.Status200OK,
+        description: "Success",
+        type: typeof(ApiVersionResponse),
+        contentTypes: ["application/json"])
+    ]
+    public override Task<ActionResult<ApiVersionResponse>> HandleAsync(
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(new ActionResult<ApiVersionResponse>(new ApiVersionResponse
+        {
+            Version = new ApiVersion()
+            {
+                Major = 1,
+                Minor = 1,
+            }
+        }));
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/GetVersion.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/GetVersion.cs
@@ -16,7 +16,8 @@ public class GetVersion : EndpointBaseAsync
     [HttpGet("version")]
     [SwaggerOperation(
         Summary = "Get the API version",
-        Description = "Gets the API version which can be used by clients for compatibility checks.",
+        Description = "Gets the API version which can be used by clients for compatibility checks. "
+        + "This endpoint has been added with eryph v0.3.",
         OperationId = "Version_Get",
         Tags = ["Version"])
     ]
@@ -30,10 +31,10 @@ public class GetVersion : EndpointBaseAsync
         CancellationToken cancellationToken = default) =>
         Task.FromResult(new ActionResult<ApiVersionResponse>(new ApiVersionResponse
         {
-            Version = new ApiVersion()
+            LatestVersion = new ApiVersion()
             {
-                Major = 1,
-                Minor = 1,
+                Major = ComputeApiVersion.Major,
+                Minor = ComputeApiVersion.Minor,
             }
         }));
 }


### PR DESCRIPTION
This PR introduces a new endpoint which reports the major and minor version of the compute REST API. This allows clients make
use of new features while maintaining backwards compatibility.