### PR TITLE
Fix Windows version check in Powershell engine

### DIFF
--- a/src/core/src/Eryph.VmManagement/PowershellEngine.cs
+++ b/src/core/src/Eryph.VmManagement/PowershellEngine.cs
@@ -199,7 +199,7 @@ namespace Eryph.VmManagement
         /// (Build 17763) and later. The module works for our use cases, but we need to disable the
         /// Powershell edition check to be able to load it.
         /// </remarks>
-        private static bool SkipEditionCheck => Environment.OSVersion.Version.Build <= 17763;
+        private static bool SkipEditionCheck => Environment.OSVersion.Version.Build < 17763;
     }
 
 


### PR DESCRIPTION
This PR fixes the Windows version check in the Powershell engine. The Powershell edition check is no longer skipped for Windows Server 2019.