### PR TITLE
Add proper permissions to DevOps sync workflow

### DIFF
--- a/.github/workflows/dbosoft-azure-devops-sync.yml
+++ b/.github/workflows/dbosoft-azure-devops-sync.yml
@@ -1,7 +1,5 @@
 name: Sync issue to Azure DevOps
-permissions:
-  contents: read
-  issues: write
+permissions: {}
 on:
   issues:
   issue_comment:

--- a/.github/workflows/dbosoft-azure-devops-sync.yml
+++ b/.github/workflows/dbosoft-azure-devops-sync.yml
@@ -1,4 +1,7 @@
 name: Sync issue to Azure DevOps
+permissions:
+  contents: read
+  issues: write
 on:
   issues:
   issue_comment:


### PR DESCRIPTION
Potential fix for [https://github.com/eryph-org/eryph/security/code-scanning/5](https://github.com/eryph-org/eryph/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's purpose (syncing issues to Azure DevOps), it likely requires `contents: read` to access repository contents and `issues: read` or `issues: write` to interact with GitHub issues. If the workflow does not need to modify issues, we should use `issues: read` to minimize permissions.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
