### PR TITLE
Fix incorrect dependency injection in database integration tests

### DIFF
--- a/src/data/test/Eryph.StateDb.TestBase/StateDbTestBase.cs
+++ b/src/data/test/Eryph.StateDb.TestBase/StateDbTestBase.cs
@@ -130,7 +130,7 @@ public abstract class StateDbTestBase : IAsyncLifetime
             _ => throw new NotSupportedException($"Database type '{_databaseFixture}' is not supported."),
         };
 
-    private void RegisterStateStore(SimpleInjectorAddOptions options)
+    protected void RegisterStateStore(SimpleInjectorAddOptions options)
     {
         switch (_databaseFixture)
         {

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/ApiModuleFactoryExtensions.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/ApiModuleFactoryExtensions.cs
@@ -33,7 +33,8 @@ public static class ApiModuleFactoryExtensions
 {
     public static WebModuleFactory<ComputeApiModule> WithApiHost(
         this WebModuleFactory<ComputeApiModule> factory,
-        Action<Container> configureContainer) =>
+        Action<Container> configureContainer,
+        Action<SimpleInjectorAddOptions> configureModuleContainer) =>
         factory.WithModuleHostBuilder(hostBuilder =>
         {
             Container container = new();
@@ -117,7 +118,8 @@ public static class ApiModuleFactoryExtensions
                 .ToList();
         }
 
-    private class ModuleFilters
+    private class ModuleFilters(
+        Action<SimpleInjectorAddOptions> configureModuleContainer)
         : IAddSimpleInjectorFilter<ComputeApiModule>,
             IConfigureContainerFilter<ComputeApiModule>
     {
@@ -126,7 +128,7 @@ public static class ApiModuleFactoryExtensions
         {
             return (context, options) =>
             {
-                options.RegisterSqliteStateStore();
+                configureModuleContainer(options);
                 next(context, options);
             };
         }

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Genes/CleanupGenesTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Genes/CleanupGenesTests.cs
@@ -24,7 +24,7 @@ public class CleanupGenesTests : InMemoryStateDbTestBase, IClassFixture<WebModul
         WebModuleFactory<ComputeApiModule> factory)
         : base(outputHelper)
     {
-        _factory = factory.WithApiHost(ConfigureDatabase);
+        _factory = factory.WithApiHost(ConfigureDatabase, RegisterStateStore);
     }
 
     protected override async Task SeedAsync(IStateStore stateStore)

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Genes/GetGeneTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Genes/GetGeneTests.cs
@@ -38,7 +38,7 @@ public class GetGeneTests : InMemoryStateDbTestBase, IClassFixture<WebModuleFact
         WebModuleFactory<ComputeApiModule> factory)
         : base(outputHelper)
     {
-        _factory = factory.WithApiHost(ConfigureDatabase);
+        _factory = factory.WithApiHost(ConfigureDatabase, RegisterStateStore);
     }
 
     protected override async Task SeedAsync(IStateStore stateStore)

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Genes/ListGenesTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Genes/ListGenesTests.cs
@@ -34,7 +34,7 @@ public class ListGenesTests : InMemoryStateDbTestBase, IClassFixture<WebModuleFa
         WebModuleFactory<ComputeApiModule> factory)
         : base(outputHelper)
     {
-        _factory = factory.WithApiHost(ConfigureDatabase);
+        _factory = factory.WithApiHost(ConfigureDatabase, RegisterStateStore);
     }
 
     protected override async Task SeedAsync(IStateStore stateStore)

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Genes/RemoveGeneTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Genes/RemoveGeneTests.cs
@@ -27,7 +27,7 @@ public class RemoveGeneTests : InMemoryStateDbTestBase, IClassFixture<WebModuleF
         WebModuleFactory<ComputeApiModule> factory)
         : base(outputHelper)
     {
-        _factory = factory.WithApiHost(ConfigureDatabase);
+        _factory = factory.WithApiHost(ConfigureDatabase, RegisterStateStore);
     }
 
     protected override async Task SeedAsync(IStateStore stateStore)

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Operations/GetOperationTest.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Operations/GetOperationTest.cs
@@ -39,7 +39,7 @@ public class GetOperationTest : InMemoryStateDbTestBase,
         WebModuleFactory<ComputeApiModule> factory)
         : base(outputHelper)
     {
-        _factory = factory.WithApiHost(ConfigureDatabase);
+        _factory = factory.WithApiHost(ConfigureDatabase, RegisterStateStore);
     }
 
     protected override async Task SeedAsync(IStateStore stateStore)

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Projects/AddProjectMemberTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Projects/AddProjectMemberTests.cs
@@ -28,7 +28,7 @@ public class AddProjectMemberTests : InMemoryStateDbTestBase,
         WebModuleFactory<ComputeApiModule> factory)
         : base(outputHelper)
     {
-        _factory = factory.WithApiHost(ConfigureDatabase);
+        _factory = factory.WithApiHost(ConfigureDatabase, RegisterStateStore);
     }
 
     protected override async Task SeedAsync(IStateStore stateStore)

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Projects/CreateProjectTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Projects/CreateProjectTests.cs
@@ -28,7 +28,7 @@ public class CreateProjectTests : InMemoryStateDbTestBase,
         WebModuleFactory<ComputeApiModule> factory)
         : base(outputHelper)
     {
-        _factory = factory.WithApiHost(ConfigureDatabase);
+        _factory = factory.WithApiHost(ConfigureDatabase, RegisterStateStore);
     }
 
     protected override async Task SeedAsync(IStateStore stateStore)

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Projects/GetProjectTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Projects/GetProjectTests.cs
@@ -27,7 +27,7 @@ public class GetProjectTests : InMemoryStateDbTestBase,
         WebModuleFactory<ComputeApiModule> factory)
         : base(outputHelper)
     {
-        _factory = factory.WithApiHost(ConfigureDatabase);
+        _factory = factory.WithApiHost(ConfigureDatabase, RegisterStateStore);
     }
 
     protected override async Task SeedAsync(IStateStore stateStore)

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/VirtualDisks/VirtualDiskTestBase.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/VirtualDisks/VirtualDiskTestBase.cs
@@ -33,7 +33,7 @@ public abstract class VirtualDiskTestBase : InMemoryStateDbTestBase
         : base(outputHelper)
     {
         Factory = new WebModuleFactory<ComputeApiModule>()
-            .WithApiHost(ConfigureDatabase);
+            .WithApiHost(ConfigureDatabase, RegisterStateStore);
     }
 
     protected override async Task SeedAsync(IStateStore stateStore)

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
@@ -50,7 +50,7 @@ public abstract class ChangeTrackingTestBase(
                 services.AddSimpleInjector(container, options =>
                 {
                     options.AddLogging();
-                    options.RegisterSqliteStateStore();
+                    RegisterStateStore(options);
                     options.AddChangeTracking();
                 });
             });


### PR DESCRIPTION
This PR fixes an incorrect dependency injection setup in the database integration tests. The tests were using some of the SQLite
configuration even when running against MySQL/MariaDB.