### PR TITLE
Support for scope hierarchy in token validation

### DIFF
--- a/src/modules/src/Eryph.ModuleCore/Authorization/ScopeHierarchy.cs
+++ b/src/modules/src/Eryph.ModuleCore/Authorization/ScopeHierarchy.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Eryph.Core;
+
+namespace Eryph.ModuleCore.Authorization;
+
+public static class ScopeHierarchy
+{
+    private static readonly Dictionary<string, HashSet<string>> ScopeHierarchyList = new()
+    {
+        // Compute API hierarchies
+        [EryphConstants.Authorization.Scopes.ComputeWrite] =
+        [
+            EryphConstants.Authorization.Scopes.ComputeRead,
+            EryphConstants.Authorization.Scopes.CatletsWrite,
+            EryphConstants.Authorization.Scopes.CatletsRead,
+            EryphConstants.Authorization.Scopes.CatletsControl,
+            EryphConstants.Authorization.Scopes.GenesWrite,
+            EryphConstants.Authorization.Scopes.GenesRead,
+            EryphConstants.Authorization.Scopes.ProjectsWrite,
+            EryphConstants.Authorization.Scopes.ProjectsRead
+        ],
+        [EryphConstants.Authorization.Scopes.ComputeRead] =
+        [
+            EryphConstants.Authorization.Scopes.CatletsRead,
+            EryphConstants.Authorization.Scopes.GenesRead,
+            EryphConstants.Authorization.Scopes.ProjectsRead
+        ],
+        [EryphConstants.Authorization.Scopes.CatletsWrite] =
+        [
+            EryphConstants.Authorization.Scopes.CatletsRead,
+            EryphConstants.Authorization.Scopes.CatletsControl
+        ],
+        [EryphConstants.Authorization.Scopes.GenesWrite] =
+        [
+            EryphConstants.Authorization.Scopes.GenesRead
+        ],
+        [EryphConstants.Authorization.Scopes.ProjectsWrite] =
+        [
+            EryphConstants.Authorization.Scopes.ProjectsRead
+        ],
+
+        // Identity API hierarchies
+        [EryphConstants.Authorization.Scopes.IdentityWrite] =
+        [
+            EryphConstants.Authorization.Scopes.IdentityRead,
+            EryphConstants.Authorization.Scopes.IdentityClientsWrite,
+            EryphConstants.Authorization.Scopes.IdentityClientsRead
+        ],
+        [EryphConstants.Authorization.Scopes.IdentityRead] =
+        [
+            EryphConstants.Authorization.Scopes.IdentityClientsRead
+        ],
+        [EryphConstants.Authorization.Scopes.IdentityClientsWrite] =
+        [
+            EryphConstants.Authorization.Scopes.IdentityClientsRead
+        ],
+    };
+
+    /// <summary>
+    /// Gets all scopes that are implied by the given scope, including the scope itself.
+    /// </summary>
+    /// <param name="scope">The scope to expand</param>
+    /// <returns>A collection of all implied scopes</returns>
+    public static IEnumerable<string> GetImpliedScopes(string? scope)
+    {
+        if (string.IsNullOrEmpty(scope))
+            yield break;
+
+        // Always include the scope itself
+        yield return scope;
+
+        // Add any implied scopes
+        if (!ScopeHierarchyList.TryGetValue(scope, out var impliedScopes)) yield break;
+
+
+        foreach (var impliedScope in impliedScopes)
+        {
+            yield return impliedScope;
+        }
+    }
+
+    /// <summary>
+    /// Expands a collection of scopes to include all implied scopes.
+    /// </summary>
+    /// <param name="scopes">The scopes to expand</param>
+    /// <returns>A distinct collection of all scopes including implied ones</returns>
+    public static IEnumerable<string> ExpandScopes(IEnumerable<string>? scopes)
+    {
+        if (scopes == null)
+            return [];
+
+        return scopes
+            .SelectMany(GetImpliedScopes)
+            .Distinct(StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Checks if a requested scope is allowed given the granted scopes, considering scope hierarchy.
+    /// </summary>
+    /// <param name="requestedScope">The scope being requested</param>
+    /// <param name="grantedScopes">The scopes that have been granted to the client</param>
+    /// <returns>True if the requested scope is allowed, false otherwise</returns>
+    public static bool IsScopeAllowed(string? requestedScope, IEnumerable<string>? grantedScopes)
+    {
+        if (string.IsNullOrEmpty(requestedScope))
+            return false;
+
+        // Expand all granted scopes to include their implied scopes
+        var expandedGrantedScopes = ExpandScopes(grantedScopes);
+
+        // Check if the requested scope is in the expanded granted scopes
+        return expandedGrantedScopes.Contains(requestedScope, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Validates that all requested scopes are allowed given the granted scopes.
+    /// </summary>
+    /// <param name="requestedScopes">The scopes being requested</param>
+    /// <param name="grantedScopes">The scopes that have been granted to the client</param>
+    /// <returns>True if all requested scopes are allowed, false otherwise</returns>
+    public static bool AreAllScopesAllowed(IEnumerable<string>? requestedScopes, IEnumerable<string>? grantedScopes)
+    {
+        if (requestedScopes == null)
+            return true;
+
+        return grantedScopes != null && requestedScopes.All(scope => IsScopeAllowed(scope, grantedScopes));
+    }
+
+    /// <summary>
+    /// Gets all scopes that should be granted when a specific scope is assigned to a client.
+    /// This includes the scope itself and all scopes it implies.
+    /// </summary>
+    /// <param name="assignedScopes">The scopes assigned to the client</param>
+    /// <returns>All scopes that should be available, including implied ones</returns>
+    public static IEnumerable<string> GetAvailableScopes(IEnumerable<string> assignedScopes)
+    {
+        return ExpandScopes(assignedScopes);
+    }
+}

--- a/src/modules/src/Eryph.Modules.Identity/Events/Validations/ValidateScopePermissionsHandler.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Events/Validations/ValidateScopePermissionsHandler.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Eryph.ModuleCore.Authorization;
+using Microsoft.Extensions.Logging;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using static OpenIddict.Server.OpenIddictServerEvents;
+using static OpenIddict.Server.OpenIddictServerHandlers;
+
+namespace Eryph.Modules.Identity.Events.Validations;
+
+/// <summary>
+/// Custom handler that replaces OpenIddict's built-in scope validation with hierarchy-aware validation.
+/// This handler validates both scope existence and client permissions using hierarchical scope logic.
+/// </summary>
+public sealed class ValidateScopePermissionsHandler : IOpenIddictServerHandler<ValidateTokenRequestContext>
+{
+    private readonly IOpenIddictApplicationManager _applicationManager;
+    private readonly IOpenIddictScopeManager _scopeManager;
+    private readonly ILogger<ValidateScopePermissionsHandler> _logger;
+
+    public ValidateScopePermissionsHandler() => 
+        throw new InvalidOperationException("This handler requires dependency injection.");
+
+    public ValidateScopePermissionsHandler(
+        IOpenIddictApplicationManager applicationManager,
+        IOpenIddictScopeManager scopeManager,
+        ILogger<ValidateScopePermissionsHandler> logger)
+    {
+        _applicationManager = applicationManager ?? throw new ArgumentNullException(nameof(applicationManager));
+        _scopeManager = scopeManager ?? throw new ArgumentNullException(nameof(scopeManager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public static OpenIddictServerHandlerDescriptor Descriptor { get; }
+        = OpenIddictServerHandlerDescriptor.CreateBuilder<ValidateTokenRequestContext>()
+            .UseScopedHandler<ValidateScopePermissionsHandler>()
+            .SetOrder(Exchange.ValidateScopePermissions.Descriptor.Order)
+            .SetType(OpenIddictServerHandlerType.BuiltIn)
+            .Build();
+
+    public async ValueTask HandleAsync(ValidateTokenRequestContext context)
+    {
+        if (context is null)
+            throw new ArgumentNullException(nameof(context));
+
+        // Skip validation if no scopes were requested
+        var requestedScopes = context.Request.GetScopes();
+        if (!requestedScopes.Any())
+        {
+            return;
+        }
+
+        // First, validate that all requested scopes exist in the scope store
+        foreach (var scope in requestedScopes)
+        {
+            var scopeEntity = await _scopeManager.FindByNameAsync(scope, context.CancellationToken);
+            if (scopeEntity == null)
+            {
+                _logger.LogWarning("The scope '{Scope}' is not registered in the scope store", scope);
+                context.Reject(
+                    error: OpenIddictConstants.Errors.InvalidScope,
+                    description: "The specified scope is not supported.");
+                return;
+            }
+        }
+
+        // Get the client application
+        var application = await _applicationManager.FindByClientIdAsync(context.ClientId!, context.CancellationToken);
+        if (application == null)
+        {
+            context.Logger.LogError("The client application associated with '{ClientId}' cannot be found.", context.ClientId);
+            context.Reject(
+                error: OpenIddictConstants.Errors.InvalidClient,
+                description: "The client application cannot be found.");
+            return;
+        }
+
+        // Get the permissions associated with the application
+        var applicationPermissions = await _applicationManager.GetPermissionsAsync(application, context.CancellationToken);
+        var applicationScopes = applicationPermissions
+            .Where(permission => permission.StartsWith(OpenIddictConstants.Permissions.Prefixes.Scope, StringComparison.Ordinal))
+            .Select(permission => permission[OpenIddictConstants.Permissions.Prefixes.Scope.Length..])
+            .ToImmutableArray();
+
+        _logger.LogDebug("Client '{ClientId}' has the following assigned scopes: {AssignedScopes}", 
+            context.ClientId, string.Join(", ", applicationScopes));
+
+        _logger.LogDebug("Client '{ClientId}' is requesting the following scopes: {RequestedScopes}", 
+            context.ClientId, string.Join(", ", requestedScopes));
+
+        // Validate each requested scope using hierarchical scope logic
+        var invalidScopes = requestedScopes
+            .Where(scope => !IsRequestedScopeAllowed(scope, applicationScopes))
+            .ToArray();
+
+        if (invalidScopes.Any())
+        {
+            _logger.LogWarning("Client '{ClientId}' requested invalid scopes: {InvalidScopes}. " +
+                "Available scopes: {AvailableScopes}", 
+                context.ClientId, 
+                string.Join(", ", invalidScopes),
+                string.Join(", ", ScopeHierarchy.GetAvailableScopes(applicationScopes)));
+
+            context.Reject(
+                error: OpenIddictConstants.Errors.InvalidScope,
+                description: "The specified scope is not supported.");
+            return;
+        }
+
+        _logger.LogDebug("All requested scopes are valid for client '{ClientId}'", context.ClientId);
+    }
+
+    private static bool IsRequestedScopeAllowed(string requestedScope, ImmutableArray<string> applicationScopes)
+    {
+        // Handle built-in OpenIddict scopes that are typically auto-approved
+        if (requestedScope == OpenIddictConstants.Scopes.OpenId || 
+            requestedScope == OpenIddictConstants.Scopes.OfflineAccess)
+        {
+            return true;
+        }
+
+        // Use hierarchical scope validation for application-specific scopes
+        return ScopeHierarchy.IsScopeAllowed(requestedScope, applicationScopes);
+    }
+}

--- a/src/modules/test/Eryph.ModuleCore.Tests/Authorization/ScopeHierarchyTests.cs
+++ b/src/modules/test/Eryph.ModuleCore.Tests/Authorization/ScopeHierarchyTests.cs
@@ -1,0 +1,350 @@
+using Eryph.Core;
+using Eryph.ModuleCore.Authorization;
+using FluentAssertions;
+
+namespace Eryph.ModuleCore.Tests.Authorization;
+
+public class ScopeHierarchyTests
+{
+    [Fact]
+    public void GetImpliedScopes_WithNullScope_ReturnsEmpty()
+    {
+        // Act
+        var result = ScopeHierarchy.GetImpliedScopes(null);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetImpliedScopes_WithEmptyScope_ReturnsEmpty()
+    {
+        // Act
+        var result = ScopeHierarchy.GetImpliedScopes("");
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetImpliedScopes_WithBasicScope_ReturnsOnlyItself()
+    {
+        // Act
+        var result = ScopeHierarchy.GetImpliedScopes(EryphConstants.Authorization.Scopes.CatletsRead);
+
+        // Assert
+        result.Should().ContainSingle()
+            .Which.Should().Be(EryphConstants.Authorization.Scopes.CatletsRead);
+    }
+
+    [Fact]
+    public void GetImpliedScopes_WithWriteScope_ReturnsImpliedScopes()
+    {
+        // Act
+        var result = ScopeHierarchy.GetImpliedScopes(EryphConstants.Authorization.Scopes.CatletsWrite);
+
+        // Assert
+        result.Should().Contain([
+            EryphConstants.Authorization.Scopes.CatletsWrite,
+            EryphConstants.Authorization.Scopes.CatletsRead,
+            EryphConstants.Authorization.Scopes.CatletsControl
+        ]);
+    }
+
+    [Fact]
+    public void GetImpliedScopes_WithComputeWrite_ReturnsAllComputeScopes()
+    {
+        // Act
+        var result = ScopeHierarchy.GetImpliedScopes(EryphConstants.Authorization.Scopes.ComputeWrite).ToArray();
+
+        // Assert
+        result.Should().Contain(EryphConstants.Authorization.Scopes.ComputeWrite);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.ComputeRead);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.CatletsWrite);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.CatletsRead);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.CatletsControl);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.GenesWrite);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.GenesRead);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.ProjectsWrite);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.ProjectsRead);
+    }
+
+    [Fact]
+    public void GetImpliedScopes_WithIdentityWrite_ReturnsAllIdentityScopes()
+    {
+        // Act
+        var result = ScopeHierarchy.GetImpliedScopes(EryphConstants.Authorization.Scopes.IdentityWrite).ToArray();
+
+        // Assert
+        result.Should().Contain(EryphConstants.Authorization.Scopes.IdentityWrite);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.IdentityRead);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.IdentityClientsWrite);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.IdentityClientsRead);
+    }
+
+    [Fact]
+    public void ExpandScopes_WithNullScopes_ReturnsEmpty()
+    {
+        // Act
+        var result = ScopeHierarchy.ExpandScopes(null);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ExpandScopes_WithMultipleScopes_ReturnsDistinctExpandedScopes()
+    {
+        // Arrange
+        var scopes = new[]
+        {
+            EryphConstants.Authorization.Scopes.CatletsWrite,
+            EryphConstants.Authorization.Scopes.GenesRead
+        };
+
+        // Act
+        var result = ScopeHierarchy.ExpandScopes(scopes).ToArray();
+
+        // Assert
+        result.Should().Contain(EryphConstants.Authorization.Scopes.CatletsWrite);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.CatletsRead);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.CatletsControl);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.GenesRead);
+        result.Should().HaveCountGreaterOrEqualTo(4);
+        result.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void IsScopeAllowed_WithNullRequestedScope_ReturnsFalse()
+    {
+        // Arrange
+        var grantedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsWrite };
+
+        // Act
+        var result = ScopeHierarchy.IsScopeAllowed(null, grantedScopes);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsScopeAllowed_WithEmptyRequestedScope_ReturnsFalse()
+    {
+        // Arrange
+        var grantedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsWrite };
+
+        // Act
+        var result = ScopeHierarchy.IsScopeAllowed("", grantedScopes);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsScopeAllowed_WithNullGrantedScopes_ReturnsFalse()
+    {
+        // Act
+        var result = ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.CatletsRead, null);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsScopeAllowed_WithExactMatch_ReturnsTrue()
+    {
+        // Arrange
+        var grantedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsRead };
+
+        // Act
+        var result = ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.CatletsRead, grantedScopes);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsScopeAllowed_WithHierarchicalMatch_ReturnsTrue()
+    {
+        // Arrange - User has catlet:write scope
+        var grantedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsWrite };
+
+        // Act - Request catlet:read scope
+        var result = ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.CatletsRead, grantedScopes);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsScopeAllowed_WithComputeWrite_AllowsAllComputeScopes()
+    {
+        var grantedScopes = new[] { EryphConstants.Authorization.Scopes.ComputeWrite };
+
+        // Act & Assert - Should allow all compute-related scopes
+        ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.ComputeRead, grantedScopes)
+            .Should().BeTrue();
+        ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.CatletsRead, grantedScopes)
+            .Should().BeTrue();
+        ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.CatletsWrite, grantedScopes)
+            .Should().BeTrue();
+        ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.CatletsControl, grantedScopes)
+            .Should().BeTrue();
+        ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.GenesRead, grantedScopes)
+            .Should().BeTrue();
+        ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.GenesWrite, grantedScopes)
+            .Should().BeTrue();
+        ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.ProjectsRead, grantedScopes)
+            .Should().BeTrue();
+        ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.ProjectsWrite, grantedScopes)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsScopeAllowed_WithoutPermission_ReturnsFalse()
+    {
+        // Arrange - User has only genes:read scope
+        var grantedScopes = new[] { EryphConstants.Authorization.Scopes.GenesRead };
+
+        // Act - Request catlet:read scope (not related)
+        var result = ScopeHierarchy.IsScopeAllowed(EryphConstants.Authorization.Scopes.CatletsRead, grantedScopes);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AreAllScopesAllowed_WithNullRequestedScopes_ReturnsTrue()
+    {
+        // Arrange
+        var grantedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsWrite };
+
+        // Act
+        var result = ScopeHierarchy.AreAllScopesAllowed(null, grantedScopes);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreAllScopesAllowed_WithNullGrantedScopes_ReturnsFalse()
+    {
+        // Arrange
+        var requestedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsRead };
+
+        // Act
+        var result = ScopeHierarchy.AreAllScopesAllowed(requestedScopes, null);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AreAllScopesAllowed_WithAllValidScopes_ReturnsTrue()
+    {
+        // Arrange
+        var grantedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsWrite };
+        var requestedScopes = new[]
+        {
+            EryphConstants.Authorization.Scopes.CatletsRead,
+            EryphConstants.Authorization.Scopes.CatletsControl
+        };
+
+        // Act
+        var result = ScopeHierarchy.AreAllScopesAllowed(requestedScopes, grantedScopes);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreAllScopesAllowed_WithSomeInvalidScopes_ReturnsFalse()
+    {
+        // Arrange
+        var grantedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsWrite };
+        var requestedScopes = new[]
+        {
+            EryphConstants.Authorization.Scopes.CatletsRead, // Valid - implied by catlets:write
+            EryphConstants.Authorization.Scopes.GenesRead    // Invalid - not implied by catlets:write
+        };
+
+        // Act
+        var result = ScopeHierarchy.AreAllScopesAllowed(requestedScopes, grantedScopes);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetAvailableScopes_WithMultipleGrantedScopes_ReturnsAllImpliedScopes()
+    {
+        // Arrange
+        var assignedScopes = new[]
+        {
+            EryphConstants.Authorization.Scopes.CatletsWrite,
+            EryphConstants.Authorization.Scopes.GenesRead
+        };
+
+        // Act
+        var result = ScopeHierarchy.GetAvailableScopes(assignedScopes).ToArray();
+
+        // Assert
+        result.Should().Contain(EryphConstants.Authorization.Scopes.CatletsWrite);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.CatletsRead);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.CatletsControl);
+        result.Should().Contain(EryphConstants.Authorization.Scopes.GenesRead);
+        result.Should().OnlyHaveUniqueItems();
+    }
+
+    [Theory]
+    [InlineData("compute:catlets:write", "compute:catlets:read")]
+    [InlineData("compute:genes:write", "compute:genes:read")]
+    [InlineData("compute:projects:write", "compute:projects:read")]
+    [InlineData("identity:clients:write", "identity:clients:read")]
+    public void WriteScope_ShouldImply_ReadScope(string writeScope, string readScope)
+    {
+        // Arrange
+        var grantedScopes = new[] { writeScope };
+
+        // Act
+        var result = ScopeHierarchy.IsScopeAllowed(readScope, grantedScopes);
+
+        // Assert
+        result.Should().BeTrue($"{writeScope} should imply {readScope}");
+    }
+
+    [Fact]
+    public void ScopeHierarchy_ShouldBeConsistent_WithEryphConstants()
+    {
+        // This test ensures our hierarchy is consistent with the defined scopes in EryphConstants
+        
+        // Test that all compute scopes are properly defined
+        var computeScopes = new[]
+        {
+            EryphConstants.Authorization.Scopes.ComputeRead,
+            EryphConstants.Authorization.Scopes.ComputeWrite,
+            EryphConstants.Authorization.Scopes.CatletsRead,
+            EryphConstants.Authorization.Scopes.CatletsWrite,
+            EryphConstants.Authorization.Scopes.CatletsControl,
+            EryphConstants.Authorization.Scopes.GenesRead,
+            EryphConstants.Authorization.Scopes.GenesWrite,
+            EryphConstants.Authorization.Scopes.ProjectsRead,
+            EryphConstants.Authorization.Scopes.ProjectsWrite
+        };
+
+        // Test that all identity scopes are properly defined
+        var identityScopes = new[]
+        {
+            EryphConstants.Authorization.Scopes.IdentityRead,
+            EryphConstants.Authorization.Scopes.IdentityWrite,
+            EryphConstants.Authorization.Scopes.IdentityClientsRead,
+            EryphConstants.Authorization.Scopes.IdentityClientsWrite
+        };
+
+        // Act & Assert - All scopes should be defined
+        foreach (var scope in computeScopes.Concat(identityScopes))
+        {
+            scope.Should().NotBeNullOrWhiteSpace($"Scope {scope} should be defined");
+        }
+    }
+}

--- a/src/modules/test/Eryph.Modules.Identity.Test/Events/Validations/ValidateScopePermissionsHandlerTests.cs
+++ b/src/modules/test/Eryph.Modules.Identity.Test/Events/Validations/ValidateScopePermissionsHandlerTests.cs
@@ -1,0 +1,466 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Eryph.Core;
+using Eryph.Modules.Identity.Events.Validations;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using OpenIddict.Abstractions;
+using OpenIddict.Server;
+using Xunit;
+using static OpenIddict.Server.OpenIddictServerEvents;
+
+namespace Eryph.Modules.Identity.Test.Events.Validations;
+
+public class ValidateScopePermissionsHandlerTests
+{
+    private readonly Mock<IOpenIddictApplicationManager> _mockApplicationManager;
+    private readonly Mock<IOpenIddictScopeManager> _mockScopeManager;
+    private readonly Mock<ILogger<ValidateScopePermissionsHandler>> _mockLogger;
+    private readonly ValidateScopePermissionsHandler _handler;
+
+    public ValidateScopePermissionsHandlerTests()
+    {
+        _mockApplicationManager = new Mock<IOpenIddictApplicationManager>();
+        _mockScopeManager = new Mock<IOpenIddictScopeManager>();
+        _mockLogger = new Mock<ILogger<ValidateScopePermissionsHandler>>();
+        _handler = new ValidateScopePermissionsHandler(_mockApplicationManager.Object, _mockScopeManager.Object, _mockLogger.Object);
+    }
+
+    [Fact]
+    public void Constructor_WithNullApplicationManager_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new ValidateScopePermissionsHandler(null!, _mockScopeManager.Object, _mockLogger.Object));
+    }
+
+    [Fact]
+    public void Constructor_WithNullScopeManager_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new ValidateScopePermissionsHandler(_mockApplicationManager.Object, null!, _mockLogger.Object));
+    }
+
+    [Fact]
+    public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new ValidateScopePermissionsHandler(_mockApplicationManager.Object, _mockScopeManager.Object, null!));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithNullContext_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await _handler.HandleAsync(null!));
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithNoRequestedScopes_DoesNothing()
+    {
+        // Arrange
+        var context = CreateContext("test-client", []);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeFalse();
+        _mockApplicationManager.Verify(x => x.FindByClientIdAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithNonExistentClient_RejectsWithInvalidClient()
+    {
+        // Arrange
+        var context = CreateContext("non-existent-client", [EryphConstants.Authorization.Scopes.CatletsRead]);
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync("non-existent-client", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(null!);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeTrue();
+        context.Error.Should().Be(OpenIddictConstants.Errors.InvalidClient);
+        context.ErrorDescription.Should().Be("The client application cannot be found.");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidExactScopeMatch_Succeeds()
+    {
+        // Arrange
+        var clientId = "test-client";
+        var requestedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsRead };
+        var applicationPermissions = new[] { $"{OpenIddictConstants.Permissions.Prefixes.Scope}{EryphConstants.Authorization.Scopes.CatletsRead}" };
+        
+        var context = CreateContext(clientId, requestedScopes);
+        var mockApplication = new Mock<object>();
+        
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockApplication.Object);
+        
+        _mockApplicationManager
+            .Setup(x => x.GetPermissionsAsync(mockApplication.Object, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([..applicationPermissions]);
+        
+        _mockScopeManager
+            .Setup(x => x.FindByNameAsync(EryphConstants.Authorization.Scopes.CatletsRead, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Mock<object>().Object);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidHierarchicalScopeMatch_Succeeds()
+    {
+        // Arrange
+        var clientId = "test-client";
+        var requestedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsRead }; // Request read scope
+        var applicationPermissions = new[] { $"{OpenIddictConstants.Permissions.Prefixes.Scope}{EryphConstants.Authorization.Scopes.CatletsWrite}" }; 
+
+        var context = CreateContext(clientId, requestedScopes);
+        var mockApplication = new Mock<object>();
+        
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockApplication.Object);
+        
+        _mockApplicationManager
+            .Setup(x => x.GetPermissionsAsync(mockApplication.Object, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([..applicationPermissions]);
+        
+        _mockScopeManager
+            .Setup(x => x.FindByNameAsync(EryphConstants.Authorization.Scopes.CatletsRead, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Mock<object>().Object);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithComputeWriteScope_AllowsAllComputeScopes()
+    {
+        // Arrange
+        var clientId = "test-client";
+        var requestedScopes = new[]
+        {
+            EryphConstants.Authorization.Scopes.CatletsRead,
+            EryphConstants.Authorization.Scopes.GenesRead,
+            EryphConstants.Authorization.Scopes.ProjectsRead,
+            EryphConstants.Authorization.Scopes.ComputeRead
+        };
+        var applicationPermissions = new[] { $"{OpenIddictConstants.Permissions.Prefixes.Scope}{EryphConstants.Authorization.Scopes.ComputeWrite}" };
+        
+        var context = CreateContext(clientId, requestedScopes);
+        var mockApplication = new Mock<object>();
+        
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockApplication.Object);
+        
+        _mockApplicationManager
+            .Setup(x => x.GetPermissionsAsync(mockApplication.Object, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([..applicationPermissions]);
+        
+        // Mock all requested scopes exist
+        foreach (var scope in requestedScopes)
+        {
+            _mockScopeManager
+                .Setup(x => x.FindByNameAsync(scope, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Mock<object>().Object);
+        }
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithInvalidScope_RejectsWithInvalidScope()
+    {
+        // Arrange
+        var clientId = "test-client";
+        var requestedScopes = new[] { EryphConstants.Authorization.Scopes.GenesRead }; // Request genes:read
+        var applicationPermissions = new[] { $"{OpenIddictConstants.Permissions.Prefixes.Scope}{EryphConstants.Authorization.Scopes.CatletsWrite}" }; // Client only has catlets:write
+        
+        var context = CreateContext(clientId, requestedScopes);
+        var mockApplication = new Mock<object>();
+        
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockApplication.Object);
+        
+        _mockApplicationManager
+            .Setup(x => x.GetPermissionsAsync(mockApplication.Object, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([..applicationPermissions]);
+        
+        // Mock scope exists for the invalid scope test (scope exists but permission is missing)
+        _mockScopeManager
+            .Setup(x => x.FindByNameAsync(EryphConstants.Authorization.Scopes.GenesRead, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Mock<object>().Object);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeTrue();
+        context.Error.Should().Be(OpenIddictConstants.Errors.InvalidScope);
+        context.ErrorDescription.Should().Be("The specified scope is not supported.");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithMixedValidAndInvalidScopes_RejectsWithInvalidScope()
+    {
+        // Arrange
+        var clientId = "test-client";
+        var requestedScopes = new[]
+        {
+            EryphConstants.Authorization.Scopes.CatletsRead, // Valid - implied by catlets:write
+            EryphConstants.Authorization.Scopes.GenesRead    // Invalid - not implied by catlets:write
+        };
+        var applicationPermissions = new[] { $"{OpenIddictConstants.Permissions.Prefixes.Scope}{EryphConstants.Authorization.Scopes.CatletsWrite}" };
+        
+        var context = CreateContext(clientId, requestedScopes);
+        var mockApplication = new Mock<object>();
+        
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockApplication.Object);
+        
+        _mockApplicationManager
+            .Setup(x => x.GetPermissionsAsync(mockApplication.Object, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([..applicationPermissions]);
+        
+        // Mock all requested scopes exist
+        foreach (var scope in requestedScopes)
+        {
+            _mockScopeManager
+                .Setup(x => x.FindByNameAsync(scope, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Mock<object>().Object);
+        }
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeTrue();
+        context.Error.Should().Be(OpenIddictConstants.Errors.InvalidScope);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithIdentityWriteScope_AllowsAllIdentityScopes()
+    {
+        // Arrange
+        var clientId = "test-client";
+        var requestedScopes = new[]
+        {
+            EryphConstants.Authorization.Scopes.IdentityRead,
+            EryphConstants.Authorization.Scopes.IdentityClientsRead,
+            EryphConstants.Authorization.Scopes.IdentityClientsWrite
+        };
+        var applicationPermissions = new[] { $"{OpenIddictConstants.Permissions.Prefixes.Scope}{EryphConstants.Authorization.Scopes.IdentityWrite}" };
+        
+        var context = CreateContext(clientId, requestedScopes);
+        var mockApplication = new Mock<object>();
+        
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockApplication.Object);
+        
+        _mockApplicationManager
+            .Setup(x => x.GetPermissionsAsync(mockApplication.Object, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([..applicationPermissions]);
+        
+        // Mock all requested scopes exist
+        foreach (var scope in requestedScopes)
+        {
+            _mockScopeManager
+                .Setup(x => x.FindByNameAsync(scope, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Mock<object>().Object);
+        }
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithNonScopePermissions_IgnoresNonScopePermissions()
+    {
+        // Arrange
+        var clientId = "test-client";
+        var requestedScopes = new[] { EryphConstants.Authorization.Scopes.CatletsRead };
+        var applicationPermissions = new[]
+        {
+            $"{OpenIddictConstants.Permissions.Prefixes.Scope}{EryphConstants.Authorization.Scopes.CatletsWrite}",
+            "some:other:permission", // Non-scope permission should be ignored
+            OpenIddictConstants.Permissions.Endpoints.Token // Non-scope permission should be ignored
+        };
+        
+        var context = CreateContext(clientId, requestedScopes);
+        var mockApplication = new Mock<object>();
+        
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockApplication.Object);
+        
+        _mockApplicationManager
+            .Setup(x => x.GetPermissionsAsync(mockApplication.Object, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([..applicationPermissions]);
+        
+        _mockScopeManager
+            .Setup(x => x.FindByNameAsync(EryphConstants.Authorization.Scopes.CatletsRead, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Mock<object>().Object);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("compute:catlets:write", "compute:catlets:read")]
+    [InlineData("compute:catlets:write", "compute:catlets:control")]
+    [InlineData("compute:genes:write", "compute:genes:read")]
+    [InlineData("compute:projects:write", "compute:projects:read")]
+    [InlineData("identity:write", "identity:read")]
+    [InlineData("identity:clients:write", "identity:clients:read")]
+    public async Task HandleAsync_WriteScope_AllowsCorrespondingReadScope(string grantedScope, string requestedScope)
+    {
+        // Arrange
+        var clientId = "test-client";
+        var requestedScopes = new[] { requestedScope };
+        var applicationPermissions = new[] { $"{OpenIddictConstants.Permissions.Prefixes.Scope}{grantedScope}" };
+        
+        var context = CreateContext(clientId, requestedScopes);
+        var mockApplication = new Mock<object>();
+        
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockApplication.Object);
+        
+        _mockApplicationManager
+            .Setup(x => x.GetPermissionsAsync(mockApplication.Object, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([..applicationPermissions]);
+
+        _mockScopeManager
+            .Setup(x => x.FindByNameAsync(requestedScope, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Mock<object>().Object);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeFalse($"{grantedScope} should allow {requestedScope}");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithBuiltInScopes_AllowsOpenIdAndOfflineAccess()
+    {
+        // Arrange
+        var clientId = "test-client";
+        var requestedScopes = new[] { OpenIddictConstants.Scopes.OpenId, OpenIddictConstants.Scopes.OfflineAccess };
+        var applicationPermissions = new[] { $"{OpenIddictConstants.Permissions.Prefixes.Scope}some:other:scope" }; // Client has different permissions
+        
+        var context = CreateContext(clientId, requestedScopes);
+        var mockApplication = new Mock<object>();
+        
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockApplication.Object);
+        
+        _mockApplicationManager
+            .Setup(x => x.GetPermissionsAsync(mockApplication.Object, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([..applicationPermissions]);
+        
+        // Mock scope existence for built-in scopes
+        _mockScopeManager
+            .Setup(x => x.FindByNameAsync(OpenIddictConstants.Scopes.OpenId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Mock<object>().Object);
+        
+        _mockScopeManager
+            .Setup(x => x.FindByNameAsync(OpenIddictConstants.Scopes.OfflineAccess, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Mock<object>().Object);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeFalse("Built-in OpenID scopes should be automatically allowed");
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithNonExistentScope_RejectsWithInvalidScope()
+    {
+        // Arrange
+        var clientId = "test-client";
+        var requestedScopes = new[] { "non-existent-scope" };
+        var applicationPermissions = new[] { $"{OpenIddictConstants.Permissions.Prefixes.Scope}{EryphConstants.Authorization.Scopes.CatletsWrite}" };
+        
+        var context = CreateContext(clientId, requestedScopes);
+        var mockApplication = new Mock<object>();
+        
+        _mockApplicationManager
+            .Setup(x => x.FindByClientIdAsync(clientId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(mockApplication.Object);
+        
+        _mockApplicationManager
+            .Setup(x => x.GetPermissionsAsync(mockApplication.Object, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([..applicationPermissions]);
+        
+        // Mock that the scope doesn't exist
+        _mockScopeManager
+            .Setup(x => x.FindByNameAsync("non-existent-scope", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((object?)null);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        context.IsRejected.Should().BeTrue();
+        context.Error.Should().Be(OpenIddictConstants.Errors.InvalidScope);
+        context.ErrorDescription.Should().Be("The specified scope is not supported.");
+    }
+
+    private static ValidateTokenRequestContext CreateContext(string clientId, IEnumerable<string> requestedScopes)
+    {
+        // Create a real OpenIddictRequest and populate it with scopes
+        var request = new OpenIddictRequest
+        {
+            Scope = string.Join(" ", requestedScopes)
+        };
+
+        var mockTransaction = new Mock<OpenIddictServerTransaction>();
+        mockTransaction.SetupGet(t => t.Request).Returns(request);
+
+        var context = new ValidateTokenRequestContext(mockTransaction.Object);
+        
+        // Use reflection to set the ClientId since it's read-only
+        var clientIdProperty = typeof(ValidateTokenRequestContext).GetProperty("ClientId");
+        clientIdProperty?.SetValue(context, clientId);
+
+        return context;
+    }
+}
+


### PR DESCRIPTION
currently requesting restricted scopes fails on identity module as scope hierarchy is not considered in token request. 

This fix adds support for requesting scopes like

compute:catlets:read even if client has only compute:write explicit defined.