### PR TITLE
Operation logs are not requested without timestamp

### DIFF
--- a/src/data/src/Eryph.StateDb/Specifications/OperationSpecs.cs
+++ b/src/data/src/Eryph.StateDb/Specifications/OperationSpecs.cs
@@ -24,7 +24,10 @@ namespace Eryph.StateDb.Specifications
                 switch (expandedField)
                 {
                     case "logs":
-                        query.Include(x => x.LogEntries.Where(l => l.Timestamp > requestLogTimestamp));
+                        if (requestLogTimestamp == null)
+                            query.Include(x => x.LogEntries);
+                        else
+                            query.Include(x => x.LogEntries.Where(l => l.Timestamp > requestLogTimestamp));
                         break;
                     case "tasks":
                         query.Include(x => x.Tasks)


### PR DESCRIPTION
When Operations are expanded with "logs" the current filter requires timestamp to be set. 
This is a bug.