### PR TITLE
Detect routing conflicts with NAT overlay IP ranges

### DIFF
--- a/src/apps/src/Eryph-zero/UninstallCommands.cs
+++ b/src/apps/src/Eryph-zero/UninstallCommands.cs
@@ -46,7 +46,7 @@ internal class UninstallCommands
         from allSwitches in hostNetworkCommands.GetSwitches()
         let allOverlaySwitches = allSwitches.Filter(s => s.Name == EryphConstants.OverlaySwitchName)
         from allNetworkAdapters in allOverlaySwitches
-            .Map(s => hostNetworkCommands.GetNetAdaptersBySwitch(s.Id))
+            .Map(s => hostNetworkCommands.GetVmAdaptersBySwitch(s.Id))
             .SequenceSerial()
             .Map(l => l.Flatten())
         from _2 in hostNetworkCommands.DisconnectNetworkAdapters(allNetworkAdapters)

--- a/src/core/src/Eryph.VmManagement.HyperV/Data/Full/HostNetworkAdapter.cs
+++ b/src/core/src/Eryph.VmManagement.HyperV/Data/Full/HostNetworkAdapter.cs
@@ -6,7 +6,7 @@ public class HostNetworkAdapter
 {
     public Guid InterfaceGuid { get; init; }
 
-    public int  InterfaceIndex { get; init; }
+    public int InterfaceIndex { get; init; }
 
     public string Name { get; init; }
 

--- a/src/core/src/Eryph.VmManagement.HyperV/Data/Full/HostNetworkAdapter.cs
+++ b/src/core/src/Eryph.VmManagement.HyperV/Data/Full/HostNetworkAdapter.cs
@@ -6,6 +6,8 @@ public class HostNetworkAdapter
 {
     public Guid InterfaceGuid { get; init; }
 
+    public int  InterfaceIndex { get; init; }
+
     public string Name { get; init; }
 
     public bool Virtual { get; init; }

--- a/src/core/src/Eryph.VmManagement.HyperV/Data/Full/NetRoute.cs
+++ b/src/core/src/Eryph.VmManagement.HyperV/Data/Full/NetRoute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Eryph.VmManagement.Data.Full;
+
+public class NetRoute
+{
+    public string DestinationPrefix { get; init; }
+    
+    public string NextHop { get; init; }
+
+    public string InterfaceAlias { get; init; }
+
+    public int InterfaceIndex { get; set; }
+}

--- a/src/core/src/Eryph.VmManagement.HyperV/Data/Full/NetRoute.cs
+++ b/src/core/src/Eryph.VmManagement.HyperV/Data/Full/NetRoute.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Eryph.VmManagement.Data.Full;
+﻿namespace Eryph.VmManagement.Data.Full;
 
 public class NetRoute
 {

--- a/src/core/src/Eryph.VmManagement.HyperV/Data/Full/VMNetworkAdapter.cs
+++ b/src/core/src/Eryph.VmManagement.HyperV/Data/Full/VMNetworkAdapter.cs
@@ -1,11 +1,18 @@
 ﻿using System;
 using Eryph.ConfigModel;
 using Eryph.VmManagement.Data.Core;
+using JetBrains.Annotations;
 
 namespace Eryph.VmManagement.Data.Full;
 
 public class VMNetworkAdapter : VirtualMachineDeviceInfo
 {
+    /// <summary>
+    /// The <c>InterfaceGuid</c> of the network adapter. Only populated
+    /// when this virtual adapter belongs to the management OS / host.
+    /// </summary>
+    public Guid? DeviceId { get; init; }
+
     //public bool DynamicMacAddressEnabled { get; private set; }
 
     //public bool AllowPacketDirect { get; private set; }
@@ -80,14 +87,13 @@ public class VMNetworkAdapter : VirtualMachineDeviceInfo
     [PrivateIdentifier]
     public string SwitchName { get; init; }
 
-    [PrivateIdentifier]
-    public string VMName { get; init; }
+    [PrivateIdentifier] [CanBeNull] public string VMName { get; init; }
 
     [PrivateIdentifier]
     public Guid SwitchId { get; init; }
 
     [PrivateIdentifier]
-    public Guid VMId { get; init; }
+    public Guid? VMId { get; init; }
 
     //public VMNetworkAdapterBandwidthSetting BandwidthSetting { get; private set; }
 

--- a/src/core/src/Eryph.VmManagement.HyperV/Data/Full/VMNetworkAdapter.cs
+++ b/src/core/src/Eryph.VmManagement.HyperV/Data/Full/VMNetworkAdapter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Eryph.ConfigModel;
 using Eryph.VmManagement.Data.Core;
-using JetBrains.Annotations;
 
 namespace Eryph.VmManagement.Data.Full;
 
@@ -87,11 +87,19 @@ public class VMNetworkAdapter : VirtualMachineDeviceInfo
     [PrivateIdentifier]
     public string SwitchName { get; init; }
 
-    [PrivateIdentifier] [CanBeNull] public string VMName { get; init; }
+    /// <summary>
+    /// The name of the VM to which this adapter belongs. Only populated
+    /// when the adapter belongs to a VM.
+    /// </summary>
+    [PrivateIdentifier] [MaybeNull] public string VMName { get; init; }
 
     [PrivateIdentifier]
     public Guid SwitchId { get; init; }
 
+    /// <summary>
+    /// The ID of the VM to which this adapter belongs. Only populated
+    /// when the adapter belongs to a VM.
+    /// </summary>
     [PrivateIdentifier]
     public Guid? VMId { get; init; }
 

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostAdaptersInfo.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostAdaptersInfo.cs
@@ -10,6 +10,28 @@ namespace Eryph.Modules.HostAgent.Networks;
 public record HostAdaptersInfo(
     HashMap<string, HostAdapterInfo> Adapters);
 
+/// <summary>
+/// Represent a network adapter on the host.
+/// </summary>
+/// <param name="Name">
+/// The name of the network adapter
+/// </param>
+/// <param name="InterfaceId">
+/// The ID of the network adapter
+/// </param>
+/// <param name="ConfiguredName">
+/// The name of the network adapter at the time when it was configured
+/// with Open vSwitch. This property is used to handle renamed adapters
+/// gracefully.
+/// </param>
+/// <param name="IsPhysical">
+/// Indicates whether the adapter is a physical adapter.
+/// </param>
+/// <param name="SwitchId">
+/// The ID of the Hyper-V switch to which the adapter is connected.
+/// Will be <see cref="OptionNone"/> when the adapter is not attached
+/// to a Hyper-V switch.
+/// </param>
 public record HostAdapterInfo(
     string Name,
     Guid InterfaceId,

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostAdaptersInfo.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostAdaptersInfo.cs
@@ -14,4 +14,5 @@ public record HostAdapterInfo(
     string Name,
     Guid InterfaceId,
     Option<string> ConfiguredName,
-    bool IsPhysical);
+    bool IsPhysical,
+    Option<Guid> SwitchId);

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostNetworkCommands.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostNetworkCommands.cs
@@ -82,6 +82,13 @@ public class HostNetworkCommands<RT> : IHostNetworkCommands<RT>
         from netNat in psEngine.GetObjectValuesAsync<NetNat>(command).ToAff()
         select netNat.Strict();
 
+    public Aff<RT, Seq<NetRoute>> GetNetRoute() =>
+        from psEngine in default(RT).Powershell.ToAff()
+        let command = PsCommandBuilder.Create()
+            .AddCommand("Get-NetRoute")
+        from netNat in psEngine.GetObjectValuesAsync<NetRoute>(command).ToAff()
+        select netNat.Strict();
+
     public Aff<RT, Unit> EnableBridgeAdapter(string adapterName) =>
         from psEngine in default(RT).Powershell
         let command = PsCommandBuilder.Create()

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostNetworkCommands.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostNetworkCommands.cs
@@ -149,8 +149,8 @@ public class HostNetworkCommands<RT> : IHostNetworkCommands<RT>
         let command = PsCommandBuilder.Create()
             .AddCommand("Get-VMNetworkAdapter")
             .AddParameter("ManagementOS")
-        from adapters in psEngine.GetObjectsAsync<VMNetworkAdapter>(command).ToAff()
-        select adapters.Map(a => a.Value).Strict();
+        from adapters in psEngine.GetObjectValuesAsync<VMNetworkAdapter>(command).ToAff()
+        select adapters.Strict();
 
     public Aff<RT, Unit> DisconnectNetworkAdapters(Seq<TypedPsObject<VMNetworkAdapter>> adapters) =>
         from psEngine in default(RT).Powershell

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostNetworkCommands.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostNetworkCommands.cs
@@ -149,7 +149,6 @@ public class HostNetworkCommands<RT> : IHostNetworkCommands<RT>
         let command = PsCommandBuilder.Create()
             .AddCommand("Get-VMNetworkAdapter")
             .AddParameter("ManagementOS")
-            .AddParameter("ErrorAction", "SilentlyContinue")
         from adapters in psEngine.GetObjectsAsync<VMNetworkAdapter>(command).ToAff()
         select adapters.Map(a => a.Value).Strict();
 

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostRouteInfo.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostRouteInfo.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Net;
+using LanguageExt;
+
+namespace Eryph.Modules.HostAgent.Networks;
+
+public record HostRouteInfo(
+    Option<Guid> InterfaceId,
+    IPNetwork2 Destination,
+    IPAddress NextHop);

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostRouteInfo.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostRouteInfo.cs
@@ -4,6 +4,20 @@ using LanguageExt;
 
 namespace Eryph.Modules.HostAgent.Networks;
 
+/// <summary>
+/// Represents a route table entry on the host.
+/// </summary>
+/// <param name="InterfaceId">
+/// The ID of the network adapter to which the route table entry belongs.
+/// Can be <see cref="OptionNone"/> for routes which do not belong to
+/// an adapter (e.g. loopback routes) or when the adapter cannot be determined.
+/// </param>
+/// <param name="Destination">
+/// The destination network for the route.
+/// </param>
+/// <param name="NextHop">
+/// The IP address of the next hop for the route.
+/// </param>
 public record HostRouteInfo(
     Option<Guid> InterfaceId,
     IPNetwork2 Destination,

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostState.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostState.cs
@@ -9,5 +9,5 @@ public record HostState(
     Seq<VMSwitch> VMSwitches,
     HostAdaptersInfo HostAdapters,
     Seq<NetNat> NetNat,
-    Seq<HostRouteInfo> NetRoutes,
+    Seq<HostRouteInfo> HostRoutes,
     OvsBridgesInfo OvsBridges);

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostState.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostState.cs
@@ -1,5 +1,4 @@
-﻿using Eryph.Modules.HostAgent.Networks.Powershell;
-using Eryph.VmManagement.Data.Core;
+﻿using Eryph.VmManagement.Data.Core;
 using Eryph.VmManagement.Data.Full;
 using LanguageExt;
 
@@ -10,4 +9,5 @@ public record HostState(
     Seq<VMSwitch> VMSwitches,
     HostAdaptersInfo HostAdapters,
     Seq<NetNat> NetNat,
+    Seq<HostRouteInfo> NetRoutes,
     OvsBridgesInfo OvsBridges);

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostStateProvider.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostStateProvider.cs
@@ -11,7 +11,9 @@ using LanguageExt;
 using LanguageExt.Common;
 using LanguageExt.Effects.Traits;
 
+using static Eryph.Core.NetworkPrelude;
 using static LanguageExt.Prelude;
+
 
 namespace Eryph.Modules.HostAgent.Networks;
 
@@ -53,27 +55,29 @@ public static class HostStateProvider<RT>
         Func<double, Eff<Unit>> progressCallback) =>
         from ovsTool in default(RT).OVS
         from hostCommands in default(RT).HostNetworkCommands
-        from _1 in progressCallback(1/7d)
+        from _1 in progressCallback(1/8d)
         from vmSwitchExtensions in hostCommands.GetSwitchExtensions()
-        from _2 in progressCallback(2/7d)
+        from _2 in progressCallback(2/8d)
         from vmSwitches in hostCommands.GetSwitches()
-        from _3 in progressCallback(3/7d)
+        from _3 in progressCallback(3/8d)
         from hostAdapters in hostCommands.GetHostAdapters()
-        from _4 in progressCallback(4/7d)
+        from _4 in progressCallback(4/8d)
         from netNat in hostCommands.GetNetNat()
-        from _5 in progressCallback(5/7d)
+        from _5 in progressCallback(5/8d)
+        from netRoutes in hostCommands.GetNetRoute()
+        from _6 in progressCallback(6/8d)
         from ovsBridges in timeout(
             TimeSpan.FromSeconds(5),
             from ct in cancelToken<RT>()
             from b in ovsTool.GetBridges(ct).ToAff(e => e)
             select b)
-        from _6 in progressCallback(6/7d)
+        from _7 in progressCallback(7/8d)
         from ovsBridgePorts in timeout(
             TimeSpan.FromSeconds(5),
             from ct in cancelToken<RT>()
             from p in ovsTool.GetPorts(ct).ToAff(e => e)
             select p)
-        from _7 in progressCallback(1d)
+        from _8 in progressCallback(1d)
         from ovsInterfaces in timeout(
             TimeSpan.FromSeconds(5),
             from ct in cancelToken<RT>()
@@ -81,13 +85,15 @@ public static class HostStateProvider<RT>
             select i)
         let bridgesInfo = createBridgesInfo(ovsBridges, ovsBridgePorts, ovsInterfaces)
         from hostAdaptersInfo in createHostAdaptersInfo(hostAdapters)
+        from hostRouteInfos in CreateHostRouteInfos(netRoutes, hostAdapters)
         let hostState = new HostState(
             vmSwitchExtensions,
             vmSwitches,
             hostAdaptersInfo,
             netNat,
+            hostRouteInfos,
             bridgesInfo)
-        from _8 in Logger<RT>.logTrace<HostState>("Fetched host state: {HostState}", hostState)
+        from _9 in Logger<RT>.logTrace<HostState>("Fetched host state: {HostState}", hostState)
         select hostState;
 
     private static Validation<Error, Unit> checkHostInterface(
@@ -157,4 +163,32 @@ public static class HostStateProvider<RT>
             hostAdapter.InterfaceGuid,
             configuredAdapters.Find(hostAdapter.InterfaceGuid),
             !hostAdapter.Virtual);
+
+    private static Eff<Seq<HostRouteInfo>> CreateHostRouteInfos(
+        Seq<NetRoute> netRoutes,
+        Seq<HostNetworkAdapter> hostAdapters) =>
+        from _ in unitEff
+        let adaptersByIndex = hostAdapters
+            .Map(a => (a.InterfaceIndex, a.InterfaceGuid))
+            .ToHashMap()
+        from routeInfos in netRoutes
+            .Map(r => CreateHostRouteInfo(r, adaptersByIndex))
+            .Sequence()
+        select routeInfos;
+
+    private static Eff<HostRouteInfo> CreateHostRouteInfo(
+        NetRoute netRoute,
+        HashMap<int, Guid> hostAdapters) =>
+        from destination in parseIPNetwork2(netRoute.DestinationPrefix)
+            .ToEff()
+        from nextHop in parseIPAddress(netRoute.NextHop)
+            .ToEff()
+        // The routes only contain the interface index but no the
+        // interface ID. Hence, we need to look up the interface ID
+        // Some routes might have an interface index for which
+        // we do not have a corresponding adapter. One possibility
+        // are routes for the loopback interface for which no adapter
+        // exists.
+        let adapterId = hostAdapters.Find(netRoute.InterfaceIndex)
+        select new HostRouteInfo(adapterId, destination, nextHop);
 }

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostStateProvider.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostStateProvider.cs
@@ -154,7 +154,7 @@ public static class HostStateProvider<RT>
         Seq<VMSwitch> switches,
         Seq<VMNetworkAdapter> hostVirtualAdapters) =>
         from _ in unitEff
-        // A network adapter on host can be either a physical adapter
+        // A network adapter on the host can be either a physical adapter
         // or a virtual adapter. Unfortunately, we need to check different
         // locations to find out if the adapter is attached to a Hyper-V switch.
         let switchByPhysicalAdapterId = switches
@@ -201,12 +201,12 @@ public static class HostStateProvider<RT>
             .ToEff()
         from nextHop in parseIPAddress(netRoute.NextHop)
             .ToEff()
-        // The routes only contain the interface index but no the
+        // The routes only contain the interface index but not the
         // interface ID. Hence, we need to look up the interface ID
         // Some routes might have an interface index for which
         // we do not have a corresponding adapter. One possibility
-        // are routes for the loopback interface for which no adapter
-        // exists.
+        // are routes for the loopback pseudo interface for which no
+        // adapter exists.
         let adapterId = hostAdapters.Find(netRoute.InterfaceIndex)
         select new HostRouteInfo(adapterId, destination, nextHop);
 }

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostStateProvider.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/HostStateProvider.cs
@@ -15,7 +15,6 @@ using LanguageExt.Effects.Traits;
 using static Eryph.Core.NetworkPrelude;
 using static LanguageExt.Prelude;
 
-
 namespace Eryph.Modules.HostAgent.Networks;
 
 public static class HostStateProvider<RT>

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/IHostNetworkCommands.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/IHostNetworkCommands.cs
@@ -21,6 +21,9 @@ public interface IHostNetworkCommands<RT> where RT : struct, HasCancel<RT>
     Aff<RT, Seq<HostNetworkAdapter>> GetHostAdapters();
 
     Aff<RT, Seq<NetNat>> GetNetNat();
+
+    Aff<RT, Seq<NetRoute>> GetNetRoute();
+
     Aff<RT, Unit> EnableBridgeAdapter(string adapterName);
     Aff<RT, Unit> ConfigureAdapterIp(string adapterName, IPAddress ipAddress, IPNetwork2 network);
     Aff<RT, Seq<TypedPsObject<VMNetworkAdapter>>> GetNetAdaptersBySwitch(Guid switchId);

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/IHostNetworkCommands.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/IHostNetworkCommands.cs
@@ -26,8 +26,9 @@ public interface IHostNetworkCommands<RT> where RT : struct, HasCancel<RT>
 
     Aff<RT, Unit> EnableBridgeAdapter(string adapterName);
     Aff<RT, Unit> ConfigureAdapterIp(string adapterName, IPAddress ipAddress, IPNetwork2 network);
-    Aff<RT, Seq<TypedPsObject<VMNetworkAdapter>>> GetNetAdaptersBySwitch(Guid switchId);
-    Aff<RT, Unit> ConnectNetworkAdapters(Seq<TypedPsObject<VMNetworkAdapter>> adapters, string switchName);
+    public Aff<RT, Seq<TypedPsObject<VMNetworkAdapter>>> GetVmAdaptersBySwitch(Guid switchId);
+    public Aff<RT, Seq<VMNetworkAdapter>> GetHostVirtualAdapters();
+    Aff <RT, Unit> ConnectNetworkAdapters(Seq<TypedPsObject<VMNetworkAdapter>> adapters, string switchName);
     Aff<RT, Unit> DisconnectNetworkAdapters(Seq<TypedPsObject<VMNetworkAdapter>> adapters);
     Aff<RT, Unit> ReconnectNetworkAdapters(Seq<TypedPsObject<VMNetworkAdapter>> adapters);
     Aff<RT, Unit> CreateOverlaySwitch(Seq<string> adapters);

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/NetworkChangeOperationBuilder.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/NetworkChangeOperationBuilder.cs
@@ -318,7 +318,8 @@ public class NetworkChangeOperationBuilder<RT> where RT : struct,
 
     public Aff<RT, Unit> AddMissingNats(
         Seq<NewBridge> expectedBridges,
-        Seq<NetNat> netNats) =>
+        Seq<NetNat> netNats,
+        Seq<HostRouteInfo> unmanagedRoutes) =>
         from _1 in unitAff
         let unmanagedNats = netNats
             .Filter(n => !n.Name.StartsWith("eryph_"))
@@ -331,13 +332,14 @@ public class NetworkChangeOperationBuilder<RT> where RT : struct,
             .Filter(b => b.Nat.Match(
                 Some: newNat => !netNats.Exists(n => n.Name == newNat.NatName),
                 None: () => false))
-            .Map(b => AddMissingNat(b, unmanagedNats))
+            .Map(b => AddMissingNat(b, unmanagedNats, unmanagedRoutes))
             .SequenceSerial()
         select unit;
 
     private Aff<RT, Unit> AddMissingNat(
         NewBridge expectedBridge,
-        Seq<(string Name, IPNetwork2 Network)> unmanagedNats) =>
+        Seq<(string Name, IPNetwork2 Network)> unmanagedNats, 
+        Seq<HostRouteInfo> unmanagedRoutes) =>
         from newNat in expectedBridge.Nat
             .ToAff(Error.New($"BUG! NAT bridge '{expectedBridge.BridgeName}' has no NAT configuration."))
         from _1 in unmanagedNats.Find(un => un.Network.Overlap(newNat.Network)).Match(
@@ -345,7 +347,12 @@ public class NetworkChangeOperationBuilder<RT> where RT : struct,
                 $"The IP range '{newNat.Network}' of the provider '{expectedBridge.ProviderName}' overlaps "
                     + $"the IP range '{un.Network}' of the NAT '{un.Name}' which is not managed by eryph.")),
             None: () => unitEff)
-        from _2 in AddOperation(
+        from _2 in unmanagedRoutes.Find(ur => ur.Destination.Overlap(newNat.Network)).Match(
+            Some: ur => FailEff<Unit>(Error.New(
+                $"The IP range '{newNat.Network}' of the provider '{expectedBridge.ProviderName}' overlaps "
+                + $"the IP range '{ur.Destination}' of a network route which is not managed by eryph.")),
+            None: () => unitEff)
+        from _3 in AddOperation(
             () => from hostCommands in default(RT).HostNetworkCommands.ToAff()
                   from _1 in hostCommands.AddNetNat(newNat.NatName, newNat.Network)
                   select unit,

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/ProviderNetworkUpdate.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/ProviderNetworkUpdate.cs
@@ -174,7 +174,7 @@ public static class ProviderNetworkUpdate<RT>
         let overlayInterfaces = toHashSet(hostState.VMSwitches
             .Filter(s => s.Name == EryphConstants.OverlaySwitchName)
             .Bind(s => s.NetAdapterInterfaceGuid.ToSeq()))
-        let result = hostState.NetRoutes
+        let result = hostState.HostRoutes
             .Filter(r => r.InterfaceId.Match(
                 Some: i => !overlayInterfaces.Contains(i),
                 None: () => true))

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/ProviderNetworkUpdate.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/ProviderNetworkUpdate.cs
@@ -171,6 +171,7 @@ public static class ProviderNetworkUpdate<RT>
     private static Eff<Seq<HostRouteInfo>> prepareUnmanagedRoutes(
         HostState hostState) =>
         from _ in unitEff
+        // TODO we also need to exclude VMNetworkAdapter ManagementOS
         let overlayInterfaces = toHashSet(hostState.VMSwitches
             .Filter(s => s.Name == EryphConstants.OverlaySwitchName)
             .Bind(s => s.NetAdapterInterfaceGuid.ToSeq()))

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/OVSChassisService.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/OVSChassisService.cs
@@ -204,7 +204,8 @@ public class OVSChassisService : IHostedService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failure in automatic network provider update.");
+            _logger.LogCritical(ex, "Automatic configuration of network provider(s) failed. The networking might not work. "
+                                    + "Please run 'eryph-zero networks sync' to resolve the issues.");
         }
 
     }

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/HostStateProviderTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/HostStateProviderTests.cs
@@ -137,6 +137,9 @@ public class HostStateProviderTests
                     Virtual = true,
                 })));
 
+        _hostNetworkCommandsMock.Setup(x => x.GetHostVirtualAdapters())
+            .Returns(SuccessAff(Seq<VMNetworkAdapter>()));
+
         _hostNetworkCommandsMock.Setup(x => x.GetNetNat())
             .Returns(SuccessAff(Seq1(new NetNat
             {

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/HostStateProviderTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/HostStateProviderTests.cs
@@ -273,7 +273,7 @@ public class HostStateProviderTests
         pif1Info.ConfiguredName.Should().BeNone();
         otherAdapterInfo.IsPhysical.Should().BeFalse();
 
-        hostState.NetRoutes.Should().SatisfyRespectively(route =>
+        hostState.HostRoutes.Should().SatisfyRespectively(route =>
         {
             route.InterfaceId.Should().BeSome().Which.Should().Be(otherAdapterId);
             route.Destination.Should().Be(IPNetwork2.Parse("10.100.0.0/24"));

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/ProviderNetworkUpdateTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/ProviderNetworkUpdateTests.cs
@@ -51,6 +51,7 @@ public class ProviderNetworkUpdateTests
                 ("pif-2", new HostAdapterInfo("pif-2", pif2Id, None, true)),
                 ("pif-3", new HostAdapterInfo("pif-3", pif3Id, None, true)))),
             Seq<NetNat>(),
+            Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap(
                 ("br-pif", new OvsBridgeInfo("br-pif", HashMap(
                     ("br-pif-bond", new OvsBridgePortInfo(
@@ -104,6 +105,7 @@ public class ProviderNetworkUpdateTests
             new HostAdaptersInfo(HashMap(
                 ("pif-1", new HostAdapterInfo("pif-1", pif1Id, None, true)))),
             Seq<NetNat>(),
+            Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap(
                 ("br-pif", new OvsBridgeInfo("br-pif", HashMap(
                     ("pif-1", new OvsBridgePortInfo(
@@ -140,6 +142,7 @@ public class ProviderNetworkUpdateTests
             Seq<VMSwitch>(),
             new HostAdaptersInfo(HashMap<string, HostAdapterInfo>()),
             Seq<NetNat>(),
+            Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap<string, OvsBridgeInfo>()));
 
         var result = await importConfig(NetworkProvidersConfiguration.DefaultConfig)
@@ -167,6 +170,7 @@ public class ProviderNetworkUpdateTests
                 new VMSwitch { Id = Guid.NewGuid(), Name = EryphConstants.OverlaySwitchName }),
             new HostAdaptersInfo(HashMap<string, HostAdapterInfo>()),
             Seq<NetNat>(),
+            Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap<string, OvsBridgeInfo>()));
 
         var result = await importConfig(NetworkProvidersConfiguration.DefaultConfig)
@@ -431,6 +435,7 @@ public class ProviderNetworkUpdateTests
             Seq<VMSwitch>(),
             new HostAdaptersInfo(HashMap<string, HostAdapterInfo>()),
             Seq<NetNat>(),
+            Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap<string, OvsBridgeInfo>()));
 
         var result = await generateChanges(hostState, providersConfig, false).Run(_runtime);
@@ -467,6 +472,7 @@ public class ProviderNetworkUpdateTests
             new HostAdaptersInfo(HashMap(
                 ("test-adapter", new HostAdapterInfo("test-adapter", adapterId, None, true)))),
             Seq<NetNat>(),
+            Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap<string, OvsBridgeInfo>()));
 
         var result = await generateChanges(hostState, providersConfig, false).Run(_runtime);
@@ -510,6 +516,7 @@ public class ProviderNetworkUpdateTests
             Seq1(new VMSwitch { Name = EryphConstants.OverlaySwitchName }),
             new HostAdaptersInfo(HashMap<string, HostAdapterInfo>()),
             Seq1(new NetNat { Name = "other-nat", InternalIPInterfaceAddressPrefix = otherNetwork }),
+            Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap<string, OvsBridgeInfo>()));
 
         var result = await generateChanges(hostState, providersConfig, false).Run(_runtime);
@@ -534,5 +541,6 @@ public class ProviderNetworkUpdateTests
             }),
             new HostAdaptersInfo(HashMap<string, HostAdapterInfo>()),
             Seq<NetNat>(),
+            Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap<string, OvsBridgeInfo>()));
 }

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/ProviderNetworkUpdateTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/ProviderNetworkUpdateTests.cs
@@ -47,9 +47,9 @@ public class ProviderNetworkUpdateTests
             Seq<VMSwitchExtension>(),
             Seq<VMSwitch>(),
             new HostAdaptersInfo(HashMap(
-                ("pif-1", new HostAdapterInfo("pif-1", pif1Id, None, true)),
-                ("pif-2", new HostAdapterInfo("pif-2", pif2Id, None, true)),
-                ("pif-3", new HostAdapterInfo("pif-3", pif3Id, None, true)))),
+                ("pif-1", new HostAdapterInfo("pif-1", pif1Id, None, true, None)),
+                ("pif-2", new HostAdapterInfo("pif-2", pif2Id, None, true, None)),
+                ("pif-3", new HostAdapterInfo("pif-3", pif3Id, None, true, None)))),
             Seq<NetNat>(),
             Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap(
@@ -103,7 +103,7 @@ public class ProviderNetworkUpdateTests
             Seq<VMSwitchExtension>(),
             Seq<VMSwitch>(),
             new HostAdaptersInfo(HashMap(
-                ("pif-1", new HostAdapterInfo("pif-1", pif1Id, None, true)))),
+                ("pif-1", new HostAdapterInfo("pif-1", pif1Id, None, true, None)))),
             Seq<NetNat>(),
             Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap(
@@ -161,7 +161,7 @@ public class ProviderNetworkUpdateTests
     [Fact]
     public async Task GenerateChanges_MultipleOverlaySwitches_GeneratesRebuildOfOverlaySwitch()
     {
-        _hostNetworkCommandsMock.Setup(x => x.GetNetAdaptersBySwitch(It.IsAny<Guid>()))
+        _hostNetworkCommandsMock.Setup(x => x.GetVmAdaptersBySwitch(It.IsAny<Guid>()))
             .Returns(SuccessAff(Seq<TypedPsObject<VMNetworkAdapter>>()));
 
         var hostState = new HostState(
@@ -276,8 +276,8 @@ public class ProviderNetworkUpdateTests
                             new OvsInterfaceInfo("test-adapter", "", None, None, interfaceId, "test-adapter")))))
                 )))),
             HostAdapters = new HostAdaptersInfo(HashMap(
-                ("renamed-adapter", new HostAdapterInfo("renamed-adapter", interfaceId, None, true)),
-                ("br-test", new HostAdapterInfo("br-test", Guid.NewGuid(), None, false))
+                ("renamed-adapter", new HostAdapterInfo("renamed-adapter", interfaceId, None, true, None)),
+                ("br-test", new HostAdapterInfo("br-test", Guid.NewGuid(), None, false, None))
                 )),
         };
 
@@ -344,8 +344,8 @@ public class ProviderNetworkUpdateTests
                             new OvsInterfaceInfo("renamed-adapter", "", None, None, interfaceId, "test-adapter")))))
                 )))),
             HostAdapters = new HostAdaptersInfo(HashMap(
-                ("renamed-adapter", new HostAdapterInfo("renamed-adapter", interfaceId, None, true)),
-                ("br-test", new HostAdapterInfo("br-test", Guid.NewGuid(), None, false))
+                ("renamed-adapter", new HostAdapterInfo("renamed-adapter", interfaceId, None, true, None)),
+                ("br-test", new HostAdapterInfo("br-test", Guid.NewGuid(), None, false, None))
                 )),
         };
 
@@ -358,7 +358,7 @@ public class ProviderNetworkUpdateTests
     [Fact]
     public async Task GenerateChanges_AddOverlayWithBond_GeneratesChanges()
     {
-        _hostNetworkCommandsMock.Setup(x => x.GetNetAdaptersBySwitch(It.IsAny<Guid>()))
+        _hostNetworkCommandsMock.Setup(x => x.GetVmAdaptersBySwitch(It.IsAny<Guid>()))
             .Returns(SuccessAff(Seq<TypedPsObject<VMNetworkAdapter>>()));
 
         var providersConfig = new NetworkProvidersConfiguration
@@ -390,8 +390,8 @@ public class ProviderNetworkUpdateTests
         var hostState = CreateStateWithOverlaySwitch() with
         {
             HostAdapters = new HostAdaptersInfo(HashMap(
-                ("pif-1", new HostAdapterInfo("pif-1", pif1Id, None, true)),
-                ("pif-2", new HostAdapterInfo("pif-2", pif2Id, None, true)))),
+                ("pif-1", new HostAdapterInfo("pif-1", pif1Id, None, true, None)),
+                ("pif-2", new HostAdapterInfo("pif-2", pif2Id, None, true, None)))),
         };
 
         var result = await generateChanges(hostState, providersConfig, true).Run(_runtime);
@@ -470,7 +470,7 @@ public class ProviderNetworkUpdateTests
                 NetAdapterInterfaceGuid = [adapterId],
             }),
             new HostAdaptersInfo(HashMap(
-                ("test-adapter", new HostAdapterInfo("test-adapter", adapterId, None, true)))),
+                ("test-adapter", new HostAdapterInfo("test-adapter", adapterId, None, true, None)))),
             Seq<NetNat>(),
             Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap<string, OvsBridgeInfo>()));

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/ProviderNetworkConsoleTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/ProviderNetworkConsoleTests.cs
@@ -218,7 +218,7 @@ public class ProviderNetworkConsoleTests
                 NetAdapterInterfaceGuid = null
             }),
             new HostAdaptersInfo(HashMap(
-                ("Ethernet", new HostAdapterInfo("Ethernet", Guid.NewGuid(), None, true)))),
+                ("Ethernet", new HostAdapterInfo("Ethernet", Guid.NewGuid(), None, true, None)))),
             Seq1(new NetNat { Name = "docker_nat", InternalIPInterfaceAddressPrefix = "192.168.10.0/24" }),
             Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap<string, OvsBridgeInfo>()));
@@ -228,7 +228,7 @@ public class ProviderNetworkConsoleTests
 
     private void AddMocks()
     {
-        _hostNetworkCommandsMock.Setup(x => x.GetNetAdaptersBySwitch(It.IsAny<Guid>()))
+        _hostNetworkCommandsMock.Setup(x => x.GetVmAdaptersBySwitch(It.IsAny<Guid>()))
             .Returns(SuccessAff(Seq<TypedPsObject<VMNetworkAdapter>>()));
 
         _ovsControlMock.Setup(x => x.GetOVSTable(It.IsAny<CancellationToken>()))

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/ProviderNetworkConsoleTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/ProviderNetworkConsoleTests.cs
@@ -220,6 +220,7 @@ public class ProviderNetworkConsoleTests
             new HostAdaptersInfo(HashMap(
                 ("Ethernet", new HostAdapterInfo("Ethernet", Guid.NewGuid(), None, true)))),
             Seq1(new NetNat { Name = "docker_nat", InternalIPInterfaceAddressPrefix = "192.168.10.0/24" }),
+            Seq<HostRouteInfo>(),
             new OvsBridgesInfo(HashMap<string, OvsBridgeInfo>()));
 
         return hostState;


### PR DESCRIPTION
This PR adds logic for detecting routing conflicts with NAT overlay IP ranges. NAT network providers can no longer be configured with IP ranges for which routes are already configured on the host.

Closes #363