### PR TITLE
Allow recreation of deleted disks

### DIFF
--- a/src/data/src/Eryph.StateDb/Specifications/VirtualDiskSpecs.cs
+++ b/src/data/src/Eryph.StateDb/Specifications/VirtualDiskSpecs.cs
@@ -36,7 +36,8 @@ namespace Eryph.StateDb.Specifications
                                  && x.DataStore == dataStore
                                  && x.Environment == environment
                                  && x.StorageIdentifier == storageIdentifier
-                                 && x.Name == name);
+                                 && x.Name == name
+                                 && !x.Deleted);
             }
         }
 


### PR DESCRIPTION
This PR fixes an incorrect validation in the REST API which raised a conflict error when recreating a disk with the same name after deleting a disk.

Closes #369