### PR TITLE
Use workload identity in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
   steps:
   - task: DotNetCoreCLI@2
     displayName: Install AzureSignTool
-    condition: ne(variables['Build.Reason'], 'PullRequest')
+    #condition: ne(variables['Build.Reason'], 'PullRequest')
     inputs:
       command: 'custom'
       custom: 'tool'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
   steps:
   - task: DotNetCoreCLI@2
     displayName: Install AzureSignTool
-    #condition: ne(variables['Build.Reason'], 'PullRequest')
+    condition: ne(variables['Build.Reason'], 'PullRequest')
     inputs:
       command: 'custom'
       custom: 'tool'
@@ -26,7 +26,7 @@ jobs:
       
   - task: AzureCLI@2
     displayName: download signed ovs package
-    #condition: ne(variables['Build.Reason'], 'PullRequest')
+    condition: ne(variables['Build.Reason'], 'PullRequest')
     inputs:
       azureSubscription: 'WebApps (releases)'
       scriptType: 'batch'
@@ -107,12 +107,11 @@ jobs:
 
   - task: AzureCLI@2
     displayName: 'Sign executables'
-    #condition: ne(variables['Build.Reason'], 'PullRequest')
+    condition: ne(variables['Build.Reason'], 'PullRequest')
     inputs:
       scriptType: ps
       scriptLocation: inlineScript
       azureSubscription: 'WebApps (releases)'
-      #addSpnToEnvironment: true
       workingDirectory: '$(Build.ArtifactStagingDirectory)\zero_build\bin'
       inlineScript: |
         AzureSignTool sign -kvu "https://dbosoft-hsm-vault.vault.azure.net" -kvm -tr http://timestamp.acs.microsoft.com/ -kvc "codesigning-2025" -v eryph-zero.exe

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
     displayName: download signed ovs package
     #condition: ne(variables['Build.Reason'], 'PullRequest')
     inputs:
-      azureSubscription: 'dbosoft Azure PN'
+      azureSubscription: 'WebApps (releases)'
       scriptType: 'batch'
       scriptLocation: 'inlineScript'
       inlineScript: 'az storage blob download --file=$(Build.SourcesDirectory)\ovspackage.zip --container-name=internal --name=ovs/3.3.90.1/ovspackage_signed.zip --account-name=dbosoftreleaseseuwest'
@@ -111,7 +111,7 @@ jobs:
     inputs:
       scriptType: ps
       scriptLocation: inlineScript
-      azureSubscription: 'dbosoft Azure PN'
+      azureSubscription: 'WebApps (releases)'
       #addSpnToEnvironment: true
       workingDirectory: '$(Build.ArtifactStagingDirectory)\zero_build\bin'
       inlineScript: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
       
   - task: AzureCLI@2
     displayName: download signed ovs package
-    condition: ne(variables['Build.Reason'], 'PullRequest')
+    #condition: ne(variables['Build.Reason'], 'PullRequest')
     inputs:
       azureSubscription: 'dbosoft Azure PN'
       scriptType: 'batch'
@@ -107,16 +107,16 @@ jobs:
 
   - task: AzureCLI@2
     displayName: 'Sign executables'
-    condition: ne(variables['Build.Reason'], 'PullRequest')
+    #condition: ne(variables['Build.Reason'], 'PullRequest')
     inputs:
       scriptType: ps
       scriptLocation: inlineScript
       azureSubscription: 'dbosoft Azure PN'
-      addSpnToEnvironment: true
+      #addSpnToEnvironment: true
       workingDirectory: '$(Build.ArtifactStagingDirectory)\zero_build\bin'
       inlineScript: |
-        AzureSignTool sign -kvu "https://dbosoft-hsm-vault.vault.azure.net" -kvi $Env:servicePrincipalId -kvt $Env:tenantId -kvs $Env:servicePrincipalKey -tr http://rfc3161timestamp.globalsign.com/advanced -kvc "codesigning-2025" -v eryph-zero.exe
-        AzureSignTool sign -kvu "https://dbosoft-hsm-vault.vault.azure.net" -kvi $Env:servicePrincipalId -kvt $Env:tenantId -kvs $Env:servicePrincipalKey -tr http://rfc3161timestamp.globalsign.com/advanced -kvc "codesigning-2025" -v eryph-uninstaller.exe
+        AzureSignTool sign -kvu "https://dbosoft-hsm-vault.vault.azure.net" -kvm -tr http://timestamp.acs.microsoft.com/ -kvc "codesigning-2025" -v eryph-zero.exe
+        AzureSignTool sign -kvu "https://dbosoft-hsm-vault.vault.azure.net" -kvm -tr http://timestamp.acs.microsoft.com/ -kvc "codesigning-2025" -v eryph-uninstaller.exe
 
   - task: CopyFiles@2
     displayName: copy ovs package to zero build


### PR DESCRIPTION
This PR updates the Azure DevOps pipeline to use the workload identity provided by Azure DevOps.