### PR TITLE
Compatibility fixes for v0.4 catlets and clients

### DIFF
--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/ApiVersionResponse.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Model/V1/ApiVersionResponse.cs
@@ -11,6 +11,6 @@ public class ApiVersionResponse
     public required ApiVersion LatestVersion { get; init; } = new()
     {
         Major = 1,
-        Minor = 3,
+        Minor = 2,
     };
 }

--- a/src/modules/src/Eryph.Modules.ComputeApi/ComputeApiVersion.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/ComputeApiVersion.cs
@@ -4,5 +4,5 @@ internal static class ComputeApiVersion
 {
     public const int Major = 1;
 
-    public const int Minor = 1;
+    public const int Minor = 2;
 }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/ExpandCatletConfig.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/ExpandCatletConfig.cs
@@ -30,6 +30,12 @@ public class ExpandCatletConfig(
     {
         var config = CatletConfigJsonSerializer.Deserialize(request.Body.Configuration);
 
+        // Force the expansion into the catlet's project. The base endpoint already
+        // checked the caller has write access to that project; ignoring whatever
+        // project the payload contains prevents a caller from expanding configs in
+        // the context of a project they do not own.
+        config.Project = model.Project.Name;
+
         return new ExpandNewCatletConfigCommand
         {
             CorrelationId = request.Body.CorrelationId.GetOrGenerate(),

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/ExpandCatletConfig.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/ExpandCatletConfig.cs
@@ -1,0 +1,67 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Eryph.ConfigModel.Json;
+using Eryph.Core;
+using Eryph.Messages.Resources.Catlets.Commands;
+using Eryph.Modules.AspNetCore;
+using Eryph.Modules.AspNetCore.ApiProvider;
+using Eryph.Modules.AspNetCore.ApiProvider.Endpoints;
+using Eryph.Modules.AspNetCore.ApiProvider.Handlers;
+using Eryph.Modules.AspNetCore.ApiProvider.Model;
+using Eryph.StateDb.Model;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using Operation = Eryph.Modules.AspNetCore.ApiProvider.Model.V1.Operation;
+
+namespace Eryph.Modules.ComputeApi.Endpoints.V1.Catlets;
+
+// Compatibility shim for v0.4 clients (Eryph.ComputeClient v0.12/v0.13 `Test-Catlet -Id`).
+// The original ExpandCatletConfigCommand pipeline was removed in v0.5; this endpoint
+// validates the catlet exists and the caller has access, then expands the supplied
+// config via ExpandNewCatletConfigCommand. Catlet-specific state is no longer factored
+// in — clients should migrate to the new catlet specification endpoints.
+public class ExpandCatletConfig(
+    IEntityOperationRequestHandler<Catlet> operationHandler,
+    ISingleEntitySpecBuilder<SingleEntityRequest, Catlet> specBuilder)
+    : ResourceOperationEndpoint<ExpandCatletConfigRequest, Catlet>(operationHandler, specBuilder)
+{
+    protected override object CreateOperationMessage(Catlet model, ExpandCatletConfigRequest request)
+    {
+        var config = CatletConfigJsonSerializer.Deserialize(request.Body.Configuration);
+
+        return new ExpandNewCatletConfigCommand
+        {
+            CorrelationId = request.Body.CorrelationId.GetOrGenerate(),
+            Config = config,
+            ShowSecrets = request.Body.ShowSecrets.GetValueOrDefault(),
+        };
+    }
+
+    [Authorize(Policy = "compute:catlets:write")]
+    [HttpPost("catlets/{id}/config/expand")]
+    [SwaggerOperation(
+        Summary = "Expand catlet config",
+        Description = "Expand the supplied config in the context of an existing catlet. "
+            + "Deprecated: existing catlet state is no longer factored into the expansion; "
+            + "the supplied config is expanded as if for a new catlet. "
+            + "Retained for compatibility with Eryph.ComputeClient v0.12 / v0.13 "
+            + "(`Test-Catlet -Id`). New clients should use POST /catlets/config/expand.",
+        OperationId = "Catlets_ExpandConfig",
+        Tags = ["Catlets"])
+    ]
+    public override async Task<ActionResult<Operation>> HandleAsync(
+        [FromRoute] ExpandCatletConfigRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var validation = RequestValidations.ValidateCatletConfig(
+            request.Body.Configuration);
+        if (validation.IsFail)
+            return ValidationProblem(
+                detail: "The catlet configuration is invalid.",
+                modelStateDictionary: validation.ToModelStateDictionary(
+                    nameof(ExpandCatletConfigRequestBody.Configuration)));
+
+        return await base.HandleAsync(request, cancellationToken);
+    }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/ExpandCatletConfigRequest.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Catlets/ExpandCatletConfigRequest.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Text.Json;
+using Eryph.Modules.AspNetCore.ApiProvider.Model;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Eryph.Modules.ComputeApi.Endpoints.V1.Catlets;
+
+public class ExpandCatletConfigRequest : SingleEntityRequest
+{
+    [FromBody] public required ExpandCatletConfigRequestBody Body { get; set; }
+}
+
+public class ExpandCatletConfigRequestBody
+{
+    public Guid? CorrelationId { get; set; }
+
+    public required JsonElement Configuration { get; set; }
+
+    public bool? ShowSecrets { get; set; }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Ardalis.Specification;
 using Eryph.CatletManagement;
+using Eryph.ConfigModel.Catlets;
 using Eryph.ConfigModel.Json;
 using Eryph.Core.Genetics;
 using Eryph.Modules.AspNetCore;
@@ -8,7 +9,6 @@ using Eryph.Modules.ComputeApi.Model.V1;
 using Eryph.StateDb;
 using Eryph.StateDb.Model;
 using Eryph.StateDb.Specifications;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading;
@@ -18,7 +18,6 @@ using Catlet = Eryph.StateDb.Model.Catlet;
 namespace Eryph.Modules.ComputeApi.Handlers;
 
 internal class GetCatletConfigurationHandler(
-    IApiResultFactory resultFactory,
     IStateStore stateStore)
     : IGetRequestHandler<Catlet, CatletConfiguration>
 {
@@ -43,29 +42,27 @@ internal class GetCatletConfigurationHandler(
         if (catlet == null)
             return new NotFoundResult();
 
-        if (catlet.IsDeprecated)
-        {
-            return resultFactory.Problem(
-                statusCode: StatusCodes.Status400BadRequest,
-                detail: $"The catlet cannot be managed because it has been created with an old version of eryph.");
-        }
-
         var networkPorts = await stateStore.Read<CatletNetworkPort>().ListAsync(
             new CatletNetworkPortSpecs.GetByCatletMetadataId(catlet.MetadataId),
             cancellationToken);
 
         var metadata = await stateStore.Read<CatletMetadata>().GetByIdAsync(
             catlet.MetadataId, cancellationToken);
-        if (metadata is null || metadata.IsDeprecated || metadata.Metadata is null)
+        if (metadata is null)
             throw new InvalidOperationException(
-                $"The metadata for catlet {catletIdResult.Id} is missing or incomplete.");
+                $"The metadata for catlet {catletIdResult.Id} is missing.");
 
-        var config = CatletConfigGenerator.Generate(catlet, networkPorts.ToSeq().Strict(), metadata.Metadata.Config);
+        // Deprecated catlets carry only partial metadata salvaged from v0.4 records
+        // (typically just Parent and Architecture). Variables and fodder were never
+        // recovered, so we omit them rather than emit defaults that pretend completeness.
+        var originalConfig = metadata.Metadata?.Config ?? new CatletConfig();
+
+        var config = CatletConfigGenerator.Generate(catlet, networkPorts.ToSeq().Strict(), originalConfig);
 
         // Variables and fodder cannot change after the first deployment. Hence, we
         // take them from metadata.
-        config.Variables = metadata.Metadata.Config.Variables;
-        config.Fodder = metadata.Metadata.Config.Fodder;
+        config.Variables = originalConfig.Variables;
+        config.Fodder = originalConfig.Fodder;
 
         var sanitizedConfig = CatletConfigRedactor.RedactSecrets(config);
         var trimmedConfig = CatletConfigNormalizer.Trim(sanitizedConfig);

--- a/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Handlers/GetCatletConfigurationHandler.cs
@@ -52,6 +52,13 @@ internal class GetCatletConfigurationHandler(
             throw new InvalidOperationException(
                 $"The metadata for catlet {catletIdResult.Id} is missing.");
 
+        // Only deprecated (v0.4) catlets may have incomplete metadata. For modern
+        // catlets a null Metadata is state corruption and must surface as an error
+        // rather than silently produce a partial config.
+        if (!metadata.IsDeprecated && metadata.Metadata is null)
+            throw new InvalidOperationException(
+                $"The metadata for catlet {catletIdResult.Id} is incomplete.");
+
         // Deprecated catlets carry only partial metadata salvaged from v0.4 records
         // (typically just Parent and Architecture). Variables and fodder were never
         // recovered, so we omit them rather than emit defaults that pretend completeness.

--- a/src/modules/src/Eryph.Modules.Controller/Seeding/CatletMetadataSeeder.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Seeding/CatletMetadataSeeder.cs
@@ -119,17 +119,11 @@ internal class CatletMetadataSeeder : SeederBase
         if (string.IsNullOrEmpty(rawArchitecture))
             return Architecture.New(EryphConstants.DefaultArchitecture);
 
-        try
-        {
-            return Architecture.New(rawArchitecture);
-        }
-        catch
-        {
-            // The v0.4 metadata may contain an architecture value which the
-            // current validation rejects. Fall back to the default rather
-            // than aborting the entire seeding pass for a single bad record.
-            return Architecture.New(EryphConstants.DefaultArchitecture);
-        }
+        // The v0.4 metadata may contain an architecture value which the
+        // current validation rejects. Fall back to the default rather
+        // than aborting the entire seeding pass for a single bad record.
+        return Architecture.NewEither(rawArchitecture).IfLeft(
+            _ => Architecture.New(EryphConstants.DefaultArchitecture));
     }
 
     private static string? SalvageString(JsonElement root, string propertyName) =>

--- a/src/modules/src/Eryph.Modules.Controller/Seeding/CatletMetadataSeeder.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Seeding/CatletMetadataSeeder.cs
@@ -3,9 +3,13 @@ using System.IO.Abstractions;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Eryph.ConfigModel.Catlets;
+using Eryph.Core;
+using Eryph.Core.Genetics;
 using Eryph.Modules.Controller.ChangeTracking;
 using Eryph.Modules.Controller.DataServices;
 using Eryph.Modules.Controller.Serializers;
+using Eryph.Resources.Machines;
 using Eryph.Serializers;
 using Eryph.StateDb;
 using Eryph.StateDb.Model;
@@ -81,10 +85,59 @@ internal class CatletMetadataSeeder : SeederBase
             IsDeprecated = true,
             SecretDataHidden = root.TryGetProperty("SecureDataHidden", out var secretDataHidden)
                                && secretDataHidden.GetBoolean(),
+            Metadata = SalvageContent(root),
         };
-            
+
         await _metadataService.AddMetadata(metadata, cancellationToken);
     }
+
+    /// <summary>
+    /// Salvage what we can from a v0.4 metadata document so the
+    /// read-only endpoints can still report at least the parent of
+    /// deprecated catlets. The result is intentionally incomplete:
+    /// <see cref="CatletMetadataContent.PinnedGenes"/> are not recoverable
+    /// because v0.4 never persisted gene hashes, so deprecated catlets
+    /// remain locked for write operations.
+    /// </summary>
+    private static CatletMetadataContent SalvageContent(JsonElement root)
+    {
+        return new CatletMetadataContent
+        {
+            Architecture = SalvageArchitecture(root),
+            Config = new CatletConfig
+            {
+                Parent = SalvageString(root, "Parent"),
+            },
+            ContentType = "",
+            OriginalConfig = "",
+        };
+    }
+
+    private static Architecture SalvageArchitecture(JsonElement root)
+    {
+        var rawArchitecture = SalvageString(root, "Architecture");
+        if (string.IsNullOrEmpty(rawArchitecture))
+            return Architecture.New(EryphConstants.DefaultArchitecture);
+
+        try
+        {
+            return Architecture.New(rawArchitecture);
+        }
+        catch
+        {
+            // The v0.4 metadata may contain an architecture value which the
+            // current validation rejects. Fall back to the default rather
+            // than aborting the entire seeding pass for a single bad record.
+            return Architecture.New(EryphConstants.DefaultArchitecture);
+        }
+    }
+
+    private static string? SalvageString(JsonElement root, string propertyName) =>
+        root.TryGetProperty(propertyName, out var element)
+        && element.ValueKind == JsonValueKind.String
+        && !string.IsNullOrWhiteSpace(element.GetString())
+            ? element.GetString()
+            : null;
 
     private async Task SeedMetadata(
         JsonDocument document,

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Catlets/CatletTestBase.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Catlets/CatletTestBase.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+using Dbosoft.Hosuto.Modules.Testing;
+using Eryph.Core;
+using Eryph.Resources.Machines;
+using Eryph.StateDb;
+using Eryph.StateDb.Model;
+using Eryph.StateDb.TestBase;
+using Xunit.Abstractions;
+
+namespace Eryph.Modules.ComputeApi.Tests.Integration.Endpoints.Catlets;
+
+public abstract class CatletTestBase : InMemoryStateDbTestBase
+{
+    protected readonly WebModuleFactory<ComputeApiModule> Factory;
+
+    protected static readonly Guid CatletId = Guid.NewGuid();
+    protected static readonly Guid CatletMetadataId = Guid.NewGuid();
+    protected static readonly Guid OtherClientId = Guid.NewGuid();
+    protected static readonly Guid OtherProjectId = Guid.NewGuid();
+    protected const string OtherProjectName = "other";
+
+    protected CatletTestBase(ITestOutputHelper outputHelper)
+        : base(outputHelper)
+    {
+        Factory = new WebModuleFactory<ComputeApiModule>()
+            .WithApiHost(ConfigureDatabase, RegisterStateStore);
+    }
+
+    protected override async Task SeedAsync(IStateStore stateStore)
+    {
+        await SeedDefaultTenantAndProject();
+
+        await stateStore.For<Project>().AddAsync(new Project
+        {
+            Id = OtherProjectId,
+            TenantId = EryphConstants.DefaultTenantId,
+            Name = OtherProjectName,
+        });
+
+        var metadata = await stateStore.For<CatletMetadata>().AddAsync(new CatletMetadata
+        {
+            Id = CatletMetadataId,
+            Metadata = new CatletMetadataContent(),
+        });
+
+        await stateStore.For<Catlet>().AddAsync(new Catlet
+        {
+            Id = CatletId,
+            ProjectId = EryphConstants.DefaultProjectId,
+            MetadataId = metadata.Id,
+            Name = "test-catlet",
+            DataStore = EryphConstants.DefaultDataStoreName,
+            Environment = EryphConstants.DefaultEnvironmentName,
+        });
+    }
+
+    protected async Task ArrangeOtherUserAccess(BuiltinRole role, Guid projectId)
+    {
+        await WithScope(async stateStore =>
+        {
+            await stateStore.For<ProjectRoleAssignment>().AddAsync(
+                new ProjectRoleAssignment
+                {
+                    ProjectId = projectId,
+                    IdentityId = OtherClientId.ToString(),
+                    RoleId = role.ToRoleId(),
+                });
+            await stateStore.SaveChangesAsync();
+        });
+    }
+
+    protected async Task WithScope(Func<IStateStore, Task> func)
+    {
+        await using var scope = CreateScope();
+        var stateStore = scope.GetInstance<IStateStore>();
+        await func(stateStore);
+    }
+
+    public override async Task DisposeAsync()
+    {
+        Factory.Dispose();
+        await base.DisposeAsync();
+    }
+}

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Catlets/ExpandCatletConfigTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Integration/Endpoints/Catlets/ExpandCatletConfigTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Eryph.ConfigModel.Catlets;
+using Eryph.ConfigModel.Json;
+using Eryph.Core;
+using Eryph.Messages.Resources.Catlets.Commands;
+using Eryph.Modules.AspNetCore.ApiProvider;
+using Eryph.Modules.AspNetCore.TestBase;
+using Eryph.Modules.ComputeApi.Endpoints.V1.Catlets;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Eryph.Modules.ComputeApi.Tests.Integration.Endpoints.Catlets;
+
+public class ExpandCatletConfigTests(ITestOutputHelper outputHelper)
+    : CatletTestBase(outputHelper)
+{
+    [Theory]
+    [InlineData(BuiltinRole.Contributor, "compute:read", HttpStatusCode.Forbidden)]
+    [InlineData(BuiltinRole.Reader, "compute:write", HttpStatusCode.NotFound)]
+    public async Task Config_is_not_expanded_when_not_authorized(
+        BuiltinRole role, string scope, HttpStatusCode expectedStatusCode)
+    {
+        await ArrangeOtherUserAccess(role, EryphConstants.DefaultProjectId);
+
+        var response = await Factory.CreateDefaultClient()
+            .SetEryphToken(EryphConstants.DefaultTenantId, OtherClientId, scope, false)
+            .PostAsJsonAsync($"v1/catlets/{CatletId}/config/expand", new ExpandCatletConfigRequestBody
+            {
+                Configuration = CatletConfigJsonSerializer.SerializeToElement(new CatletConfig()),
+            },
+            options: ApiJsonSerializerOptions.Options);
+
+        response.StatusCode.Should().Be(expectedStatusCode);
+    }
+
+    [Fact]
+    public async Task Config_is_not_expanded_when_catlet_is_in_other_project()
+    {
+        // Caller has write access to the "other" project but the catlet lives
+        // in the default project. The spec builder hides the catlet, so the
+        // shim must return 404 rather than expanding the config.
+        await ArrangeOtherUserAccess(BuiltinRole.Contributor, OtherProjectId);
+
+        var response = await Factory.CreateDefaultClient()
+            .SetEryphToken(EryphConstants.DefaultTenantId, OtherClientId, "compute:write", false)
+            .PostAsJsonAsync($"v1/catlets/{CatletId}/config/expand", new ExpandCatletConfigRequestBody
+            {
+                Configuration = CatletConfigJsonSerializer.SerializeToElement(new CatletConfig()),
+            },
+            options: ApiJsonSerializerOptions.Options);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Config_is_not_expanded_when_payload_is_invalid()
+    {
+        var response = await Factory.CreateDefaultClient()
+            .SetEryphToken(EryphConstants.DefaultTenantId, EryphConstants.SystemClientId, "compute:write", true)
+            .PostAsJsonAsync($"v1/catlets/{CatletId}/config/expand", new ExpandCatletConfigRequestBody
+            {
+                Configuration = CatletConfigJsonSerializer.SerializeToElement(new CatletConfig
+                {
+                    // A name containing an invalid character must be rejected by
+                    // CatletConfigValidations.
+                    Name = "invalid name!",
+                }),
+            },
+            options: ApiJsonSerializerOptions.Options);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Config_is_expanded()
+    {
+        var response = await Factory.CreateDefaultClient()
+            .SetEryphToken(EryphConstants.DefaultTenantId, EryphConstants.SystemClientId, "compute:write", true)
+            .PostAsJsonAsync($"v1/catlets/{CatletId}/config/expand", new ExpandCatletConfigRequestBody
+            {
+                Configuration = CatletConfigJsonSerializer.SerializeToElement(new CatletConfig
+                {
+                    Name = "test-config",
+                }),
+                ShowSecrets = true,
+            },
+            options: ApiJsonSerializerOptions.Options);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var messages = Factory.GetPendingRebusMessages<ExpandNewCatletConfigCommand>();
+        messages.Should().SatisfyRespectively(m =>
+        {
+            m.Config.Should().NotBeNull();
+            m.Config!.Name.Should().Be("test-config");
+            m.Config.Project.Should().Be(EryphConstants.DefaultProjectName);
+            m.ShowSecrets.Should().BeTrue();
+        });
+    }
+
+    [Fact]
+    public async Task Config_project_is_overridden_with_catlet_project()
+    {
+        // The shim must ignore the project specified in the payload and use the
+        // catlet's project instead. This prevents a caller from expanding the
+        // config in the context of a project they may not own.
+        var response = await Factory.CreateDefaultClient()
+            .SetEryphToken(EryphConstants.DefaultTenantId, EryphConstants.SystemClientId, "compute:write", true)
+            .PostAsJsonAsync($"v1/catlets/{CatletId}/config/expand", new ExpandCatletConfigRequestBody
+            {
+                Configuration = CatletConfigJsonSerializer.SerializeToElement(new CatletConfig
+                {
+                    Project = OtherProjectName,
+                }),
+            },
+            options: ApiJsonSerializerOptions.Options);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        var messages = Factory.GetPendingRebusMessages<ExpandNewCatletConfigCommand>();
+        messages.Should().SatisfyRespectively(m =>
+        {
+            m.Config!.Project.Should().Be(EryphConstants.DefaultProjectName);
+        });
+    }
+}

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletMetadataSeederTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletMetadataSeederTests.cs
@@ -10,6 +10,8 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Eryph.Core;
+using Eryph.Core.Genetics;
 using Eryph.Modules.Controller.Serializers;
 using Eryph.Serializers;
 using Xunit.Abstractions;
@@ -111,7 +113,13 @@ public abstract class CatletMetadataSeederTests(
             metadata.IsDeprecated.Should().BeTrue();
             metadata.SecretDataHidden.Should().BeTrue();
             metadata.Genes.Should().BeEmpty();
-            metadata.Metadata.Should().BeNull();
+            metadata.Metadata.Should().NotBeNull();
+            metadata.Metadata!.Architecture.Value.Should().Be(EryphConstants.DefaultArchitecture);
+            metadata.Metadata.Config.Should().NotBeNull();
+            metadata.Metadata.Config.Parent.Should().BeNull();
+            metadata.Metadata.PinnedGenes.Should().BeEmpty();
+            metadata.Metadata.ContentType.Should().BeEmpty();
+            metadata.Metadata.OriginalConfig.Should().BeEmpty();
         });
 
         var backupContent = await MockFileSystem.File.ReadAllTextAsync(
@@ -127,9 +135,75 @@ public abstract class CatletMetadataSeederTests(
         configModel.VmId.Should().Be(vmId);
         configModel.IsDeprecated.Should().BeTrue();
         configModel.SecretDataHidden.Should().BeTrue();
-        configModel.Metadata.Should().BeNull();
+        configModel.Metadata.Should().NotBeNull();
         configModel.SpecificationId.Should().BeNull();
         configModel.SpecificationVersionId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Deprecated_metadata_salvages_parent_and_architecture()
+    {
+        var metadataId = Guid.Parse("0b8e3f55-22a8-4f7b-9f5a-5d11d1f4f9aa");
+        var catletId = Guid.Parse("ab02c8ca-2c70-4f4d-a4d6-ab1b3a90c9aa");
+        var vmId = Guid.Parse("a4b1f8d2-7d8a-4a2a-9f6e-9f9f9e0aabba");
+        var json = $$"""
+                     {
+                       "Id": "{{ metadataId }}",
+                       "VMId": "{{ vmId }}",
+                       "MachineId": "{{ catletId }}",
+                       "Architecture": "hyperv/amd64",
+                       "Parent": "dbosoft/ubuntu-22.04/starter",
+                       "SecureDataHidden": false
+                     }
+                     """;
+
+        await MockFileSystem.File.WriteAllTextAsync(
+            Path.Combine(ChangeTrackingConfig.VirtualMachinesConfigPath, $"{metadataId}.json"),
+            json);
+
+        await ExecuteSeeder();
+
+        await WithScope(async stateStore =>
+        {
+            var metadata = await stateStore.Read<CatletMetadata>().GetByIdAsync(metadataId);
+            metadata.Should().NotBeNull();
+            metadata!.IsDeprecated.Should().BeTrue();
+            metadata.Metadata.Should().NotBeNull();
+            metadata.Metadata!.Architecture.Value.Should().Be("hyperv/amd64");
+            metadata.Metadata.Config.Parent.Should().Be("dbosoft/ubuntu-22.04/starter");
+        });
+    }
+
+    [Fact]
+    public async Task Deprecated_metadata_with_invalid_architecture_falls_back_to_default()
+    {
+        var metadataId = Guid.Parse("d59a52f0-6e36-4f6d-b3f9-1c8b3f2c1aaa");
+        var catletId = Guid.Parse("c5e72f8a-bd05-4c25-b21a-2c8b3f2c2aaa");
+        var vmId = Guid.Parse("ec9a37ee-2c0e-4c0e-9f8a-3c8b3f2c3aaa");
+        var json = $$"""
+                     {
+                       "Id": "{{ metadataId }}",
+                       "VMId": "{{ vmId }}",
+                       "MachineId": "{{ catletId }}",
+                       "Architecture": "not-a-real-arch",
+                       "Parent": "some/parent/tag"
+                     }
+                     """;
+
+        await MockFileSystem.File.WriteAllTextAsync(
+            Path.Combine(ChangeTrackingConfig.VirtualMachinesConfigPath, $"{metadataId}.json"),
+            json);
+
+        await ExecuteSeeder();
+
+        await WithScope(async stateStore =>
+        {
+            var metadata = await stateStore.Read<CatletMetadata>().GetByIdAsync(metadataId);
+            metadata.Should().NotBeNull();
+            metadata!.Metadata.Should().NotBeNull();
+            metadata.Metadata!.Architecture.Value.Should().Be(EryphConstants.DefaultArchitecture);
+            metadata.Metadata.Config.Parent.Should().Be("some/parent/tag");
+        });
     }
 
     private async Task ExecuteSeeder()


### PR DESCRIPTION
## Summary
- Restore `POST /catlets/{id}/config/expand` as a shim so `Test-Catlet -Id` keeps working against v0.12/v0.13 Eryph.ComputeClient.
- Salvage `Parent` and `Architecture` from v0.4 metadata during seeding so deprecated catlets expose a usable config via `GET /catlets/{id}/config` (no more error toast in eryph-app for legacy catlets). Write paths remain correctly blocked because pinned gene hashes were never persisted in v0.4.
- Bump REST API minor version to `1.2` so clients can gate on the new catlet-specification endpoints, model fields, and the `config_type` response field.

## Test plan
- [ ] Upgrade from a v0.4 install with existing catlets — confirm catlet list page in eryph-app loads without per-catlet errors and shows the parent.
- [ ] `Test-Catlet -Id <existing>` against the new server returns an expanded config (no 404).
- [ ] `Update-Catlet` against a deprecated catlet still fails with the existing "old version of eryph" message (write paths stay blocked).
- [ ] `GET /v1/version` reports `1.2`.