### PR TITLE
Upgrade AutoMapper to 15.1.1 (CVE-2026-32933)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,8 @@ jobs:
       command: test
       projects: '**/test/**/*.csproj'
       arguments: '--configuration $(buildConfiguration) --collect "Code coverage" --no-build --filter "Category!=Docker"'
+    env:
+      ERYPH_AUTOMAPPER_LICENSE: $(automapperLicense)
 
   - task: DotNetCoreCLI@2
     displayName: publish zero app
@@ -142,6 +144,7 @@ jobs:
     vmImage: ubuntu-22.04
 
   variables:
+   - group: 'eryph'
    - name: buildConfiguration
      value: 'Release'
 
@@ -153,7 +156,7 @@ jobs:
       projects: '**/*.csproj'
       feedsToUse: 'config'
       nugetConfigPath: 'nuget.config'
-      
+
   - task: DotNetCoreCLI@2
     displayName: dotnet build
     inputs:
@@ -168,3 +171,5 @@ jobs:
       # We exclude projects which require Windows to avoid errors
       projects: '**/test/**/!(*VmHostAgent*|*VmManagement*).csproj'
       arguments: '--configuration $(buildConfiguration) --collect "Code coverage" --no-build --filter "Category=Docker"'
+    env:
+      ERYPH_AUTOMAPPER_LICENSE: $(automapperLicense)

--- a/src/core/src/Eryph.Core/AutoMapperLicense.cs
+++ b/src/core/src/Eryph.Core/AutoMapperLicense.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Eryph.Core;
+
+/// <summary>
+/// Provides the AutoMapper license key used by every <c>MapperConfiguration</c>
+/// in eryph. The key is read from the <c>ERYPH_AUTOMAPPER_LICENSE</c> environment
+/// variable. When the variable is not set, AutoMapper falls back to its Community
+/// behavior and emits warning logs on startup; it does not block runtime mapping.
+/// </summary>
+public static class AutoMapperLicense
+{
+    public const string EnvironmentVariable = "ERYPH_AUTOMAPPER_LICENSE";
+
+    public static string? Key =>
+        Environment.GetEnvironmentVariable(EnvironmentVariable) is { Length: > 0 } key
+            ? key
+            : null;
+}

--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <PackageReference Include="AutoMapper" Version="15.1.1" />
     <PackageReference Include="Dbosoft.Functional" Version="3.2.0" />
     <PackageReference Include="Eryph.ConfigModel.Catlets" Version="0.9.1-ci.3" />
     <PackageReference Include="Eryph.ConfigModel.Catlets.Validation" Version="0.9.1-ci.3" />

--- a/src/core/src/Eryph.VmManagement.HyperV/Eryph.VmManagement.HyperV.csproj
+++ b/src/core/src/Eryph.VmManagement.HyperV/Eryph.VmManagement.HyperV.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/src/Eryph.VmManagement.HyperV/TypedPsObjectMapping.cs
+++ b/src/core/src/Eryph.VmManagement.HyperV/TypedPsObjectMapping.cs
@@ -4,12 +4,14 @@ using System.Linq;
 using System.Management.Automation;
 using System.Reflection;
 using AutoMapper;
+using Eryph.Core;
 using Eryph.Resources.Machines;
 using Eryph.VmManagement.Data;
 using Eryph.VmManagement.Data.Core;
 using Eryph.VmManagement.Data.Full;
 using Eryph.VmManagement.Data.Planned;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Management.Infrastructure;
 
 namespace Eryph.VmManagement;
@@ -52,6 +54,7 @@ public class TypedPsObjectMapping : ITypedPsObjectMapping
 
             var config = new MapperConfiguration(cfg =>
             {
+                cfg.LicenseKey = AutoMapperLicense.Key;
                 cfg.CreateProfile("Powershell", c =>
                 {
                     c.CreateMap<CommandInfo, PowershellCommand>();
@@ -133,7 +136,7 @@ public class TypedPsObjectMapping : ITypedPsObjectMapping
                     c.AddCimInstanceMapping<CimHgsKeyProtector>();
                     c.IgnoreUnmapped(_logger);
                 });
-            });
+            }, NullLoggerFactory.Instance);
 
             try
             {

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Management" Version="8.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>

--- a/src/infrastructure/src/Eryph.Rebus/Eryph.Rebus.csproj
+++ b/src/infrastructure/src/Eryph.Rebus/Eryph.Rebus.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Rebus" Version="8.7.1" />
-    <PackageReference Include="Rebus.Microsoft.Extensions.Logging" Version="5.1.0" />
+    <PackageReference Include="Rebus.Microsoft.Extensions.Logging" Version="5.2.0" />
     <PackageReference Include="Rebus.RabbitMq" Version="9.4.1" />
     <PackageReference Include="Rebus.TransactionScopes" Version="7.0.1" />
     <PackageReference Include="Rebus.UnitOfWork" Version="7.0.1" />

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiModule.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiModule.cs
@@ -76,7 +76,10 @@ public abstract class ApiModule<TModule> : WebModule where TModule : WebModule
             services.TryAddSingleton<IPolicyEvaluator, DisableAuthenticationPolicyEvaluator>();
 #endif
 
-        services.AddAutoMapper(typeof(TModule).Assembly, typeof(MapperProfile).Assembly);
+        services.AddAutoMapper(
+            cfg => cfg.LicenseKey = AutoMapperLicense.Key,
+            typeof(TModule).Assembly,
+            typeof(MapperProfile).Assembly);
     }
 
     public void Configure(IApplicationBuilder app)


### PR DESCRIPTION
## Summary
- Bump AutoMapper 13.0.1 → 15.1.1 to fix [GHSA-rvv3-g6hj-g44x / CVE-2026-32933](https://github.com/advisories/GHSA-rvv3-g6hj-g44x).
- Wire the AutoMapper license key via a new `Eryph.Core.AutoMapperLicense` helper. The key is sourced exclusively from the `ERYPH_AUTOMAPPER_LICENSE` environment variable — never committed to source.
- Both DI (`ApiModule`) and the standalone `MapperConfiguration` in `TypedPsObjectMapping` consume the same helper.
- Pipeline: both jobs in `azure-pipelines.yml` now map `$(automapperLicense)` from the `eryph` variable group into the env for `dotnet test` steps.
- Transitive deps bumped: `Microsoft.Extensions.Logging.Abstractions 8.0.2 → 10.0.0`, `Rebus.Microsoft.Extensions.Logging 5.1.0 → 5.2.0`.

## Prerequisite before merging
- [ ] Add `automapperLicense` as a **secret** variable in the `eryph` Azure DevOps variable group with the dbosoft Community license JWT.

## Behavior without the env var
AutoMapper still functions — it only emits warning logs on startup. No runtime restrictions.

## Customer / installer note
Production installs of eryph-zero need `ERYPH_AUTOMAPPER_LICENSE` set in the service environment to suppress the warning logs. Untouched in this PR; should be handled by the installer repo.

## Test plan
- [ ] CI build is clean (no NU1107/NU1605 conflicts, no NU1903 AutoMapper advisory).
- [ ] CI tests run with the env var injected from the secret (no AutoMapper license warnings in test output).
- [ ] eryph-zero starts and serves `/v1/version`.
- [ ] `Get-Catlet` works (confirms `ApiModule.AddAutoMapper` wiring).
- [ ] Hyper-V inventory continues to map VMs correctly (confirms `TypedPsObjectMapping` under AutoMapper 15).