### PR TITLE
Upgrade to .NET 10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "8.0.11",
+      "version": "9.0.0",
       "commands": [
         "dotnet-ef"
       ]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,4 +2,13 @@
   <PropertyGroup>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
+
+  <!--
+    System.Text.Json 6.0.0 (GHSA-8g4q-xg66-9fp4) is pulled in transitively by Rebus,
+    but on .NET (Core) it ships in-box and the package version is never loaded at
+    runtime. Suppress the audit advisory rather than fighting NuGet's resolution.
+  -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,10 +5,10 @@
 
   <!--
     System.Text.Json 6.0.0 (GHSA-8g4q-xg66-9fp4) is pulled in transitively by Rebus,
-    but on .NET (Core) it ships in-box and the package version is never loaded at
-    runtime. Suppress the audit advisory rather than fighting NuGet's resolution.
+    but ships in-box on .NET and is never loaded at runtime. Suppress the advisory
+    rather than fighting NuGet's resolution.
   -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+  <ItemGroup>
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-8g4q-xg66-9fp4" />
   </ItemGroup>
 </Project>

--- a/src/apps/src/Eryph-zero/Configuration/Clients/SystemClientGenerator.cs
+++ b/src/apps/src/Eryph-zero/Configuration/Clients/SystemClientGenerator.cs
@@ -96,7 +96,7 @@ namespace Eryph.Runtime.Zero.Configuration.Clients
         {
             try
             {
-                using var certificate = new X509Certificate2(Convert.FromBase64String(certificateData));
+                using var certificate = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(certificateData));
                 return certificate.GetRSAPublicKey();
             }
             catch (Exception)

--- a/src/apps/src/Eryph-zero/Program.cs
+++ b/src/apps/src/Eryph-zero/Program.cs
@@ -320,9 +320,13 @@ internal static class Program
                                 options.AddStartupHandler<DatabaseResetHandler>();
 
                                 container.RegisterInstance(changeTrackingConfig);
-                                options.AddSeeding(changeTrackingConfig);
+                                // Change tracking must be registered before seeding so its
+                                // hosted services enable their queues in StartAsync before
+                                // SeedFromConfigHandler saves any changes. Otherwise seeded
+                                // changes would hit a disabled queue and be dropped.
                                 if (changeTrackingConfig.TrackChanges)
                                     options.AddChangeTracking();
+                                options.AddSeeding(changeTrackingConfig);
                             });
                         })
                         // The logger must not be disposed here as it is used for error reporting

--- a/src/apps/src/Eryph-zero/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/apps/src/Eryph-zero/Properties/PublishProfiles/FolderProfile.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Debug</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net8.0-windows\win-x64\publish\win-x64\</PublishDir>
+    <PublishDir>bin\Release\net10.0-windows\win-x64\publish\win-x64\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/src/apps/src/Eryph-zero/eryph-zero.csproj
+++ b/src/apps/src/Eryph-zero/eryph-zero.csproj
@@ -1,23 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <RootNamespace>Eryph.Runtime.Zero</RootNamespace>
   </PropertyGroup>
-  <ItemGroup>
-    <!--
-    Suppress advisories for System.Private.Uri which is provided by the runtime packages.
-    The advisories are a false positive in our case as we target .NET 8.
-    This should be removed once the tooling in the dotnet SDK is fixed.
-    See https://github.com/dotnet/sdk/issues/42651#issuecomment-2372410311.
-    -->
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-5f2m-466j-3848" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-x5qj-9vmx-7g6g" />
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-xhfc-gr8f-ffwc" />
-  </ItemGroup>
   <ItemGroup>
     <None Remove="appsettings.Development.json" />
     <None Remove="appsettings.json" />
@@ -53,7 +42,7 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
     <PackageReference Include="WinHttpUrlAclDotNet" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\src\Eryph.Configuration\Eryph.Configuration.csproj" />
@@ -84,13 +73,13 @@
        correct place by default. See https://github.com/PowerShell/PowerShell/issues/15274 -->
   <Target Name="PwshModulesAfterBuild" AfterTargets="Build">
     <ItemGroup>
-      <FilesToMove Include="$(OutputPath)runtimes\win\lib\net8.0\**\*.*" />
+      <FilesToMove Include="$(OutputPath)runtimes\win\lib\net10.0\**\*.*" />
     </ItemGroup>
     <Copy SourceFiles="@(FilesToMove)" DestinationFolder="$(OutputPath)%(RecursiveDir)" />
   </Target>
   <Target Name="PwshModulesAfterPublish" AfterTargets="Publish">
     <ItemGroup>
-      <FilesToMove Include="$(PublishDir)runtimes\win\lib\net8.0\**\*.*" />
+      <FilesToMove Include="$(PublishDir)runtimes\win\lib\net10.0\**\*.*" />
     </ItemGroup>
     <Move SourceFiles="@(FilesToMove)" DestinationFolder="$(PublishDir)%(RecursiveDir)" />
     <RemoveDir Directories="$(PublishDir)runtimes" />

--- a/src/apps/src/Eryph.Agent/Eryph.Agent.csproj
+++ b/src/apps/src/Eryph.Agent/Eryph.Agent.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">

--- a/src/apps/src/Eryph.ApiEndpoint/Eryph.ApiEndpoint.csproj
+++ b/src/apps/src/Eryph.ApiEndpoint/Eryph.ApiEndpoint.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <DockerComposeProjectPath>..\..\docker-compose.dcproj</DockerComposeProjectPath>
     <LangVersion>latest</LangVersion>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/src/apps/src/Eryph.AppCore/Eryph.AppCore.csproj
+++ b/src/apps/src/Eryph.AppCore/Eryph.AppCore.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Eryph</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/apps/src/Eryph.Controller/Eryph.Controller.csproj
+++ b/src/apps/src/Eryph.Controller/Eryph.Controller.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
@@ -9,7 +9,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Rebus.MySql" Version="4.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eryph.AppCore\Eryph.AppCore.csproj" />

--- a/src/apps/src/Eryph.Identity/Eryph.Identity.csproj
+++ b/src/apps/src/Eryph.Identity/Eryph.Identity.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <LangVersion>7.1</LangVersion>

--- a/src/core/src/Eryph.CatletManagement/Eryph.CatletManagement.csproj
+++ b/src/core/src/Eryph.CatletManagement/Eryph.CatletManagement.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/core/src/Eryph.Configuration/Eryph.Configuration.csproj
+++ b/src/core/src/Eryph.Configuration/Eryph.Configuration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Eryph</RootNamespace>
   </PropertyGroup>
 

--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="15.1.1" />

--- a/src/core/src/Eryph.Core/ResourceAuthContext.cs
+++ b/src/core/src/Eryph.Core/ResourceAuthContext.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Eryph.Core
 {
-    public record AuthContext(Guid TenantId, string[] Identities, Guid[] IdentityRoles);
+    public record AuthContext(Guid TenantId, IReadOnlyList<string> Identities, IReadOnlyList<Guid> IdentityRoles);
 
 }

--- a/src/core/src/Eryph.Messages/Eryph.Messages.csproj
+++ b/src/core/src/Eryph.Messages/Eryph.Messages.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eryph.VmConfig.Primitives\Eryph.Primitives.csproj" />

--- a/src/core/src/Eryph.Security.Cryptography/Eryph.Security.Cryptography.csproj
+++ b/src/core/src/Eryph.Security.Cryptography/Eryph.Security.Cryptography.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>Eryph.Security.Cryptography</AssemblyName>
     <RootNamespace>Eryph.Security.Cryptography</RootNamespace>
     <Nullable>enable</Nullable>
@@ -10,6 +10,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/src/core/src/Eryph.VmConfig.Primitives/Eryph.Primitives.csproj
+++ b/src/core/src/Eryph.VmConfig.Primitives/Eryph.Primitives.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Eryph</RootNamespace>
     <AssemblyName>Eryph.Primitives</AssemblyName>
   </PropertyGroup>

--- a/src/core/src/Eryph.VmManagement.HyperV/Eryph.VmManagement.HyperV.csproj
+++ b/src/core/src/Eryph.VmManagement.HyperV/Eryph.VmManagement.HyperV.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <RootNamespace>Eryph.VmManagement</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.6" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.6.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>

--- a/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
+++ b/src/core/src/Eryph.VmManagement/Eryph.VmManagement.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageReference Include="System.Management" Version="8.0.0" />
+    <PackageReference Include="System.Management" Version="10.0.0" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/test/Eryph.CatletManagement.Tests/Eryph.CatletManagement.Tests.csproj
+++ b/src/core/test/Eryph.CatletManagement.Tests/Eryph.CatletManagement.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/core/test/Eryph.Core.Tests/Eryph.Core.Tests.csproj
+++ b/src/core/test/Eryph.Core.Tests/Eryph.Core.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/core/test/Eryph.Security.Cryptography.Test/Eryph.Security.Cryptography.Test.csproj
+++ b/src/core/test/Eryph.Security.Cryptography.Test/Eryph.Security.Cryptography.Test.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/core/test/Eryph.VMManagement.HyperV.Test/Eryph.VmManagement.HyperV.Test.csproj
+++ b/src/core/test/Eryph.VMManagement.HyperV.Test/Eryph.VmManagement.HyperV.Test.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>

--- a/src/core/test/Eryph.VmManagement.HyperV.TestBase/Eryph.VmManagement.HyperV.TestBase.csproj
+++ b/src/core/test/Eryph.VmManagement.HyperV.TestBase/Eryph.VmManagement.HyperV.TestBase.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/core/test/Eryph.VmManagement.Test/Eryph.VmManagement.Test.csproj
+++ b/src/core/test/Eryph.VmManagement.Test/Eryph.VmManagement.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/core/test/Eryph.VmManagement.TestBase/Eryph.VmManagement.TestBase.csproj
+++ b/src/core/test/Eryph.VmManagement.TestBase/Eryph.VmManagement.TestBase.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/data/src/Eryph.Data/Eryph.Data.csproj
+++ b/src/data/src/Eryph.Data/Eryph.Data.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="6.0.1" />
@@ -8,8 +8,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\core\src\Eryph.Core\Eryph.Core.csproj" />

--- a/src/data/src/Eryph.IdentityDb/Eryph.IdentityDb.csproj
+++ b/src/data/src/Eryph.IdentityDb/Eryph.IdentityDb.csproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.10.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eryph.Data\Eryph.Data.csproj" />

--- a/src/data/src/Eryph.StateDb.Design/Eryph.StateDb.Design.csproj
+++ b/src/data/src/Eryph.StateDb.Design/Eryph.StateDb.Design.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 	
 	  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/data/src/Eryph.StateDb.InMemory/Eryph.StateDb.InMemory.csproj
+++ b/src/data/src/Eryph.StateDb.InMemory/Eryph.StateDb.InMemory.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/data/src/Eryph.StateDb.MySql/Eryph.StateDb.MySql.csproj
+++ b/src/data/src/Eryph.StateDb.MySql/Eryph.StateDb.MySql.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/data/src/Eryph.StateDb.Sqlite/Eryph.StateDb.Sqlite.csproj
+++ b/src/data/src/Eryph.StateDb.Sqlite/Eryph.StateDb.Sqlite.csproj
@@ -1,13 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/data/src/Eryph.StateDb/Eryph.StateDb.csproj
+++ b/src/data/src/Eryph.StateDb/Eryph.StateDb.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/data/src/Eryph.StateDb/Specifications/CatletNetworkPortSpecs.cs
+++ b/src/data/src/Eryph.StateDb/Specifications/CatletNetworkPortSpecs.cs
@@ -46,7 +46,7 @@ public sealed class CatletNetworkPortSpecs
     {
         public GetUnused(Guid catletMetadataId, Seq<string> usedPortNames)
         {
-            var values = usedPortNames.ToArray();
+            IEnumerable<string> values = usedPortNames.ToArray();
             Query.Where(p => p.CatletMetadataId == catletMetadataId
                              && !values.Contains(p.Name))
                 .Include(p => p.FloatingPort!);

--- a/src/data/test/Eryph.StateDb.TestBase/Eryph.StateDb.TestBase.csproj
+++ b/src/data/test/Eryph.StateDb.TestBase/Eryph.StateDb.TestBase.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.5.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.5.0" />
     <PackageReference Include="Testcontainers" Version="4.1.0" />

--- a/src/data/test/Eryph.StateDb.Tests/Eryph.StateDb.Tests.csproj
+++ b/src/data/test/Eryph.StateDb.Tests/Eryph.StateDb.Tests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/infrastructure/src/Eryph.DistributedLock/Eryph.DistributedLock.csproj
+++ b/src/infrastructure/src/Eryph.DistributedLock/Eryph.DistributedLock.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/infrastructure/src/Eryph.Rebus/Eryph.Rebus.csproj
+++ b/src/infrastructure/src/Eryph.Rebus/Eryph.Rebus.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.Functional.Json" Version="3.2.0" />

--- a/src/infrastructure/test/Eryph.DistributedLock.Tests/Eryph.DistributedLock.Tests.csproj
+++ b/src/infrastructure/test/Eryph.DistributedLock.Tests/Eryph.DistributedLock.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/infrastructure/test/Eryph.Rebus.Tests/Eryph.Rebus.Tests.csproj
+++ b/src/infrastructure/test/Eryph.Rebus.Tests/Eryph.Rebus.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/modules/src/Eryph.AnsiConsole/Eryph.AnsiConsole.csproj
+++ b/src/modules/src/Eryph.AnsiConsole/Eryph.AnsiConsole.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/modules/src/Eryph.ModuleCore/Eryph.ModuleCore.csproj
+++ b/src/modules/src/Eryph.ModuleCore/Eryph.ModuleCore.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Swagger/SwaggerDefaultValues.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Swagger/SwaggerDefaultValues.cs
@@ -25,7 +25,7 @@ public class SwaggerDefaultValues : IOperationFilter
     {
         var apiDescription = context.ApiDescription;
 
-        operation.Deprecated |= apiDescription.IsDeprecated();
+        operation.Deprecated |= apiDescription.IsDeprecated;
 
         // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1752#issue-663991077
         foreach (var responseType in context.ApiDescription.SupportedResponseTypes)

--- a/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Eryph.Modules.AspNetCore.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Eryph.Modules.AspNetCore</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <!--<FrameworkReference Include="Microsoft.AspNetCore.App" />-->
     <PackageReference Include="Ardalis.ApiEndpoints" Version="4.1.0" />
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
 
     <PackageReference Include="Eryph.ConfigModel.Catlets.Json" Version="0.9.1-ci.3" />
     <PackageReference Include="Eryph.ConfigModel.Networks.Json" Version="0.9.1-ci.3" />
@@ -22,7 +22,7 @@
     <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc.Core" Version="5.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eryph.ModuleCore\Eryph.ModuleCore.csproj" />

--- a/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Eryph.Modules.ComputeApi.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/Catlets/CatletSpecificationVersionChangeHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/Catlets/CatletSpecificationVersionChangeHandler.cs
@@ -18,18 +18,15 @@ internal class CatletSpecificationVersionChangeHandler : IChangeHandler<CatletSp
     private readonly ChangeTrackingConfig _config;
     private readonly IFileSystem _fileSystem;
     private readonly IStateStore _stateStore;
-    private readonly Microsoft.Extensions.Logging.ILogger<CatletSpecificationVersionChangeHandler> _logger;
 
     public CatletSpecificationVersionChangeHandler(
         ChangeTrackingConfig config,
         IFileSystem fileSystem,
-        IStateStore stateStore,
-        Microsoft.Extensions.Logging.ILogger<CatletSpecificationVersionChangeHandler> logger)
+        IStateStore stateStore)
     {
         _config = config;
         _fileSystem = fileSystem;
         _stateStore = stateStore;
-        _logger = logger;
     }
 
     public async Task HandleChangeAsync(
@@ -42,7 +39,6 @@ internal class CatletSpecificationVersionChangeHandler : IChangeHandler<CatletSp
         var specificationVersion
             = await _stateStore.For<CatletSpecificationVersion>()
             .GetByIdAsync(id, cancellationToken);
-        Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(_logger, "CTDIAG VersionHandler id={Id} found={Found}", id, specificationVersion is not null);
         if (specificationVersion is null)
         {
             _fileSystem.File.Delete(path);
@@ -82,6 +78,5 @@ internal class CatletSpecificationVersionChangeHandler : IChangeHandler<CatletSp
 
         var json = CatletSpecificationVersionConfigModelJsonSerializer.Serialize(versionConfig);
         await _fileSystem.File.WriteAllTextAsync(path, json, Encoding.UTF8, cancellationToken);
-        Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(_logger, "CTDIAG VersionHandler wrote file id={Id} path={Path}", id, path);
     }
 }

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/Catlets/CatletSpecificationVersionChangeHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/Catlets/CatletSpecificationVersionChangeHandler.cs
@@ -18,15 +18,18 @@ internal class CatletSpecificationVersionChangeHandler : IChangeHandler<CatletSp
     private readonly ChangeTrackingConfig _config;
     private readonly IFileSystem _fileSystem;
     private readonly IStateStore _stateStore;
+    private readonly Microsoft.Extensions.Logging.ILogger<CatletSpecificationVersionChangeHandler> _logger;
 
     public CatletSpecificationVersionChangeHandler(
         ChangeTrackingConfig config,
         IFileSystem fileSystem,
-        IStateStore stateStore)
+        IStateStore stateStore,
+        Microsoft.Extensions.Logging.ILogger<CatletSpecificationVersionChangeHandler> logger)
     {
         _config = config;
         _fileSystem = fileSystem;
         _stateStore = stateStore;
+        _logger = logger;
     }
 
     public async Task HandleChangeAsync(
@@ -39,6 +42,7 @@ internal class CatletSpecificationVersionChangeHandler : IChangeHandler<CatletSp
         var specificationVersion
             = await _stateStore.For<CatletSpecificationVersion>()
             .GetByIdAsync(id, cancellationToken);
+        Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(_logger, "CTDIAG VersionHandler id={Id} found={Found}", id, specificationVersion is not null);
         if (specificationVersion is null)
         {
             _fileSystem.File.Delete(path);
@@ -78,5 +82,6 @@ internal class CatletSpecificationVersionChangeHandler : IChangeHandler<CatletSp
 
         var json = CatletSpecificationVersionConfigModelJsonSerializer.Serialize(versionConfig);
         await _fileSystem.File.WriteAllTextAsync(path, json, Encoding.UTF8, cancellationToken);
+        Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(_logger, "CTDIAG VersionHandler wrote file id={Id} path={Path}", id, path);
     }
 }

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
@@ -43,17 +43,14 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEventData eventData,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogWarning("CTDIAG savepoint {TChange} ctx={Ctx} tx={Tx}", typeof(TChange).Name, eventData.Context is not null, eventData.TransactionId);
         if (eventData.Context is null)
         {
             await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
             return;
         }
 
-        var detected = await DetectChanges(eventData.Context, cancellationToken);
-        _logger.LogWarning("CTDIAG savepoint detected {Count} for {TChange} -- entries={Entries}", detected.Count, typeof(TChange).Name, string.Join(",", detected));
-        var currentChanges = detected
-            .Map(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
+        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
+            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
 
         _changes = _changes.Union(currentChanges);
 
@@ -66,14 +63,11 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         InterceptionResult result,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogWarning("CTDIAG committing {TChange} ctx={Ctx} tx={Tx}", typeof(TChange).Name, eventData.Context is not null, eventData.TransactionId);
         if (eventData.Context is null)
             return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
 
-        var detected = await DetectChanges(eventData.Context, cancellationToken);
-        _logger.LogWarning("CTDIAG committing detected {Count} for {TChange} -- entries={Entries}", detected.Count, typeof(TChange).Name, string.Join(",", detected));
-        var currentChanges = detected
-            .Map(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
+        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
+            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
 
         _changes = _changes.Union(currentChanges);
 
@@ -85,12 +79,11 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEndEventData eventData,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogWarning("CTDIAG committed {TChange} _changes={Count} tx={Tx}", typeof(TChange).Name, _changes.Count, eventData.TransactionId);
         foreach (var item in _changes)
         {
-            _logger.LogWarning("CTDIAG enqueueing {TChange} tx={Tx} change={Change}", typeof(TChange).Name, item.TransactionId, item.Changes);
+            _logger.LogDebug("Detected relevant changes in transaction {TransactionId}: {Changes}",
+                item.TransactionId, item.Changes);
             await _queue.EnqueueAsync(item, cancellationToken);
-            _logger.LogWarning("CTDIAG enqueued {TChange} tx={Tx}", typeof(TChange).Name, item.TransactionId);
         }
     }
 

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
@@ -43,7 +43,6 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEventData eventData,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogWarning("CTDIAG CreatedSavepointAsync fired for {TChange}, ctx={HasContext}", typeof(TChange).Name, eventData.Context is not null);
         if (eventData.Context is null)
         {
             await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
@@ -53,7 +52,6 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
             .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
 
-        _logger.LogWarning("CTDIAG CreatedSavepointAsync captured {Count} for {TChange}", currentChanges.Count, typeof(TChange).Name);
         _changes = _changes.Union(currentChanges);
 
         await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
@@ -65,14 +63,12 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         InterceptionResult result,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogWarning("CTDIAG TransactionCommittingAsync fired for {TChange}, ctx={HasContext}", typeof(TChange).Name, eventData.Context is not null);
         if (eventData.Context is null)
             return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
 
         var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
             .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
 
-        _logger.LogWarning("CTDIAG TransactionCommittingAsync captured {Count} for {TChange}", currentChanges.Count, typeof(TChange).Name);
         _changes = _changes.Union(currentChanges);
 
         return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
@@ -83,7 +79,6 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEndEventData eventData,
         CancellationToken cancellationToken = default)
     {
-        _logger.LogWarning("CTDIAG TransactionCommittedAsync fired for {TChange}, _changes count={Count}", typeof(TChange).Name, _changes.Count);
         foreach (var item in _changes)
         {
             _logger.LogDebug("Detected relevant changes in transaction {TransactionId}: {Changes}",

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,14 +13,13 @@ namespace Eryph.Modules.Controller.ChangeTracking;
 /// Base class for change interceptors that detect changes in the database.
 /// </summary>
 /// <remarks>
-/// We use both <see cref="CreatedSavepointAsync(DbTransaction, TransactionEventData, CancellationToken)"/>
-/// and <see cref="TransactionCommittingAsync(DbTransaction, TransactionEventData, InterceptionResult, CancellationToken)"/>
-/// to detect changes. EF Core will implicitly create a savepoint when
-/// <c>SaveChangesAsync()</c> is called. We must detect changes when a savepoint
-/// is created. Otherwise, we would miss deleted entities as EF Core seems
-/// to remove them from the change tracker after the <c>SaveChangesAsync()</c>.
+/// Changes are captured in <see cref="ISaveChangesInterceptor.SavingChangesAsync"/>
+/// while the EF change tracker is still fully populated (including deleted
+/// entries, which EF removes from the tracker once <c>SaveChanges</c> has run).
+/// Enqueueing is deferred until <see cref="TransactionCommittedAsync"/> so that
+/// downstream handlers only see changes that were actually committed.
 /// </remarks>
-internal abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor
+internal abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor, ISaveChangesInterceptor
 {
     private readonly IChangeTrackingQueue<TChange> _queue;
     private readonly ILogger _logger;
@@ -38,40 +37,20 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         DbContext dbContext,
         CancellationToken cancellationToken = default);
 
-    public override async Task CreatedSavepointAsync(
-        DbTransaction transaction,
-        TransactionEventData eventData,
+    public async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+        DbContextEventData eventData,
+        InterceptionResult<int> result,
         CancellationToken cancellationToken = default)
     {
         if (eventData.Context is null)
-        {
-            await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
-            return;
-        }
+            return result;
 
+        var transactionId = eventData.Context.Database.CurrentTransaction?.TransactionId ?? Guid.Empty;
         var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
-            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
+            .MapT(changes => new ChangeTrackingQueueItem<TChange>(transactionId, changes));
 
         _changes = _changes.Union(currentChanges);
-
-        await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
-    }
-
-    public override async ValueTask<InterceptionResult> TransactionCommittingAsync(
-        DbTransaction transaction,
-        TransactionEventData eventData,
-        InterceptionResult result,
-        CancellationToken cancellationToken = default)
-    {
-        if (eventData.Context is null)
-            return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
-
-        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
-            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
-
-        _changes = _changes.Union(currentChanges);
-
-        return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
+        return result;
     }
 
     public override async Task TransactionCommittedAsync(
@@ -85,7 +64,26 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
                 item.TransactionId, item.Changes);
             await _queue.EnqueueAsync(item, cancellationToken);
         }
+
+        _changes = HashSet<ChangeTrackingQueueItem<TChange>>.Empty;
     }
+
+    int ISaveChangesInterceptor.SavedChanges(SaveChangesCompletedEventData eventData, int result) => result;
+
+    InterceptionResult<int> ISaveChangesInterceptor.SavingChanges(
+        DbContextEventData eventData,
+        InterceptionResult<int> result) => throw new NotSupportedException();
+
+    void ISaveChangesInterceptor.SaveChangesFailed(DbContextErrorEventData eventData) { }
+
+    Task ISaveChangesInterceptor.SaveChangesFailedAsync(
+        DbContextErrorEventData eventData,
+        CancellationToken cancellationToken) => Task.CompletedTask;
+
+    ValueTask<int> ISaveChangesInterceptor.SavedChangesAsync(
+        SaveChangesCompletedEventData eventData,
+        int result,
+        CancellationToken cancellationToken) => ValueTask.FromResult(result);
 
     public override void CreatedSavepoint(
         DbTransaction transaction,

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
@@ -13,10 +13,13 @@ namespace Eryph.Modules.Controller.ChangeTracking;
 /// Base class for change interceptors that detect changes in the database.
 /// </summary>
 /// <remarks>
-/// Changes are captured in <see cref="ISaveChangesInterceptor.SavingChangesAsync"/>
-/// while the EF change tracker is still fully populated (including deleted
-/// entries, which EF removes from the tracker once <c>SaveChanges</c> has run).
-/// Enqueueing is deferred until <see cref="TransactionCommittedAsync"/> so that
+/// Changes are captured from multiple hooks so that we observe the change
+/// tracker while it is still fully populated regardless of provider/version
+/// quirks: <see cref="ISaveChangesInterceptor.SavingChangesAsync"/> is the
+/// primary capture point (always fires before EF clears deleted entries),
+/// while <see cref="CreatedSavepointAsync"/> and
+/// <see cref="TransactionCommittingAsync"/> remain as defensive fallbacks.
+/// Enqueueing is deferred until <see cref="TransactionCommittedAsync"/> so
 /// downstream handlers only see changes that were actually committed.
 /// </remarks>
 internal abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor, ISaveChangesInterceptor
@@ -46,11 +49,31 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
             return result;
 
         var transactionId = eventData.Context.Database.CurrentTransaction?.TransactionId ?? Guid.Empty;
-        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
-            .MapT(changes => new ChangeTrackingQueueItem<TChange>(transactionId, changes));
-
-        _changes = _changes.Union(currentChanges);
+        await CaptureChangesAsync(eventData.Context, transactionId, cancellationToken);
         return result;
+    }
+
+    public override async Task CreatedSavepointAsync(
+        DbTransaction transaction,
+        TransactionEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is not null)
+            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, cancellationToken);
+
+        await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
+    }
+
+    public override async ValueTask<InterceptionResult> TransactionCommittingAsync(
+        DbTransaction transaction,
+        TransactionEventData eventData,
+        InterceptionResult result,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is not null)
+            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, cancellationToken);
+
+        return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
     }
 
     public override async Task TransactionCommittedAsync(
@@ -66,6 +89,17 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         }
 
         _changes = HashSet<ChangeTrackingQueueItem<TChange>>.Empty;
+    }
+
+    private async Task CaptureChangesAsync(
+        DbContext context,
+        Guid transactionId,
+        CancellationToken cancellationToken)
+    {
+        var currentChanges = await DetectChanges(context, cancellationToken)
+            .MapT(changes => new ChangeTrackingQueueItem<TChange>(transactionId, changes));
+
+        _changes = _changes.Union(currentChanges);
     }
 
     int ISaveChangesInterceptor.SavedChanges(SaveChangesCompletedEventData eventData, int result) => result;

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,15 +13,14 @@ namespace Eryph.Modules.Controller.ChangeTracking;
 /// Base class for change interceptors that detect changes in the database.
 /// </summary>
 /// <remarks>
-/// Changes are captured from multiple hooks so we always observe the change
-/// tracker while it is still fully populated, regardless of provider/version
-/// quirks. <see cref="ISaveChangesInterceptor.SavingChangesAsync"/> is the
-/// primary capture point (always fires before EF clears deleted entries);
-/// <see cref="CreatedSavepointAsync"/> and <see cref="TransactionCommittingAsync"/>
-/// stay as defensive fallbacks. Enqueueing is deferred until
-/// <see cref="TransactionCommittedAsync"/> so handlers only see committed work.
+/// We use both <see cref="CreatedSavepointAsync(DbTransaction, TransactionEventData, CancellationToken)"/>
+/// and <see cref="TransactionCommittingAsync(DbTransaction, TransactionEventData, InterceptionResult, CancellationToken)"/>
+/// to detect changes. EF Core will implicitly create a savepoint when
+/// <c>SaveChangesAsync()</c> is called. We must detect changes when a savepoint
+/// is created. Otherwise, we would miss deleted entities as EF Core seems
+/// to remove them from the change tracker after the <c>SaveChangesAsync()</c>.
 /// </remarks>
-internal abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor, ISaveChangesInterceptor
+internal abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor
 {
     private readonly IChangeTrackingQueue<TChange> _queue;
     private readonly ILogger _logger;
@@ -39,27 +38,23 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         DbContext dbContext,
         CancellationToken cancellationToken = default);
 
-    public async ValueTask<InterceptionResult<int>> SavingChangesAsync(
-        DbContextEventData eventData,
-        InterceptionResult<int> result,
-        CancellationToken cancellationToken = default)
-    {
-        if (eventData.Context is not null)
-        {
-            var transactionId = eventData.Context.Database.CurrentTransaction?.TransactionId ?? Guid.Empty;
-            await CaptureChangesAsync(eventData.Context, transactionId, cancellationToken);
-        }
-
-        return result;
-    }
-
     public override async Task CreatedSavepointAsync(
         DbTransaction transaction,
         TransactionEventData eventData,
         CancellationToken cancellationToken = default)
     {
-        if (eventData.Context is not null)
-            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, cancellationToken);
+        _logger.LogWarning("CTDIAG CreatedSavepointAsync fired for {TChange}, ctx={HasContext}", typeof(TChange).Name, eventData.Context is not null);
+        if (eventData.Context is null)
+        {
+            await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
+            return;
+        }
+
+        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
+            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
+
+        _logger.LogWarning("CTDIAG CreatedSavepointAsync captured {Count} for {TChange}", currentChanges.Count, typeof(TChange).Name);
+        _changes = _changes.Union(currentChanges);
 
         await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
     }
@@ -70,8 +65,15 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         InterceptionResult result,
         CancellationToken cancellationToken = default)
     {
-        if (eventData.Context is not null)
-            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, cancellationToken);
+        _logger.LogWarning("CTDIAG TransactionCommittingAsync fired for {TChange}, ctx={HasContext}", typeof(TChange).Name, eventData.Context is not null);
+        if (eventData.Context is null)
+            return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
+
+        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
+            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
+
+        _logger.LogWarning("CTDIAG TransactionCommittingAsync captured {Count} for {TChange}", currentChanges.Count, typeof(TChange).Name);
+        _changes = _changes.Union(currentChanges);
 
         return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
     }
@@ -81,46 +83,14 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEndEventData eventData,
         CancellationToken cancellationToken = default)
     {
+        _logger.LogWarning("CTDIAG TransactionCommittedAsync fired for {TChange}, _changes count={Count}", typeof(TChange).Name, _changes.Count);
         foreach (var item in _changes)
         {
             _logger.LogDebug("Detected relevant changes in transaction {TransactionId}: {Changes}",
                 item.TransactionId, item.Changes);
             await _queue.EnqueueAsync(item, cancellationToken);
         }
-
-        _changes = HashSet<ChangeTrackingQueueItem<TChange>>.Empty;
     }
-
-    private async Task CaptureChangesAsync(
-        DbContext context,
-        Guid transactionId,
-        CancellationToken cancellationToken)
-    {
-        var currentChanges = await DetectChanges(context, cancellationToken)
-            .MapT(changes => new ChangeTrackingQueueItem<TChange>(transactionId, changes));
-
-        _changes = _changes.Union(currentChanges);
-    }
-
-    InterceptionResult<int> ISaveChangesInterceptor.SavingChanges(
-        DbContextEventData eventData,
-        InterceptionResult<int> result) => result;
-
-    int ISaveChangesInterceptor.SavedChanges(
-        SaveChangesCompletedEventData eventData,
-        int result) => result;
-
-    void ISaveChangesInterceptor.SaveChangesFailed(
-        DbContextErrorEventData eventData) { }
-
-    Task ISaveChangesInterceptor.SaveChangesFailedAsync(
-        DbContextErrorEventData eventData,
-        CancellationToken cancellationToken) => Task.CompletedTask;
-
-    ValueTask<int> ISaveChangesInterceptor.SavedChangesAsync(
-        SaveChangesCompletedEventData eventData,
-        int result,
-        CancellationToken cancellationToken) => ValueTask.FromResult(result);
 
     public override void CreatedSavepoint(
         DbTransaction transaction,

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
@@ -43,14 +43,17 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEventData eventData,
         CancellationToken cancellationToken = default)
     {
+        _logger.LogWarning("CTDIAG savepoint {TChange} ctx={Ctx} tx={Tx}", typeof(TChange).Name, eventData.Context is not null, eventData.TransactionId);
         if (eventData.Context is null)
         {
             await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
             return;
         }
 
-        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
-            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
+        var detected = await DetectChanges(eventData.Context, cancellationToken);
+        _logger.LogWarning("CTDIAG savepoint detected {Count} for {TChange} -- entries={Entries}", detected.Count, typeof(TChange).Name, string.Join(",", detected));
+        var currentChanges = detected
+            .Map(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
 
         _changes = _changes.Union(currentChanges);
 
@@ -63,11 +66,14 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         InterceptionResult result,
         CancellationToken cancellationToken = default)
     {
+        _logger.LogWarning("CTDIAG committing {TChange} ctx={Ctx} tx={Tx}", typeof(TChange).Name, eventData.Context is not null, eventData.TransactionId);
         if (eventData.Context is null)
             return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
 
-        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
-            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
+        var detected = await DetectChanges(eventData.Context, cancellationToken);
+        _logger.LogWarning("CTDIAG committing detected {Count} for {TChange} -- entries={Entries}", detected.Count, typeof(TChange).Name, string.Join(",", detected));
+        var currentChanges = detected
+            .Map(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
 
         _changes = _changes.Union(currentChanges);
 
@@ -79,11 +85,12 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEndEventData eventData,
         CancellationToken cancellationToken = default)
     {
+        _logger.LogWarning("CTDIAG committed {TChange} _changes={Count} tx={Tx}", typeof(TChange).Name, _changes.Count, eventData.TransactionId);
         foreach (var item in _changes)
         {
-            _logger.LogDebug("Detected relevant changes in transaction {TransactionId}: {Changes}",
-                item.TransactionId, item.Changes);
+            _logger.LogWarning("CTDIAG enqueueing {TChange} tx={Tx} change={Change}", typeof(TChange).Name, item.TransactionId, item.Changes);
             await _queue.EnqueueAsync(item, cancellationToken);
+            _logger.LogWarning("CTDIAG enqueued {TChange} tx={Tx}", typeof(TChange).Name, item.TransactionId);
         }
     }
 

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
@@ -45,11 +45,12 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         InterceptionResult<int> result,
         CancellationToken cancellationToken = default)
     {
+        Console.WriteLine($"#CTDIAG# SavingChangesAsync {typeof(TChange).Name} ctx={eventData.Context is not null}");
         if (eventData.Context is null)
             return result;
 
         var transactionId = eventData.Context.Database.CurrentTransaction?.TransactionId ?? Guid.Empty;
-        await CaptureChangesAsync(eventData.Context, transactionId, cancellationToken);
+        await CaptureChangesAsync(eventData.Context, transactionId, "Saving", cancellationToken);
         return result;
     }
 
@@ -58,8 +59,9 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEventData eventData,
         CancellationToken cancellationToken = default)
     {
+        Console.WriteLine($"#CTDIAG# CreatedSavepointAsync {typeof(TChange).Name} ctx={eventData.Context is not null} tx={eventData.TransactionId}");
         if (eventData.Context is not null)
-            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, cancellationToken);
+            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, "Savepoint", cancellationToken);
 
         await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
     }
@@ -70,8 +72,9 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         InterceptionResult result,
         CancellationToken cancellationToken = default)
     {
+        Console.WriteLine($"#CTDIAG# TransactionCommittingAsync {typeof(TChange).Name} ctx={eventData.Context is not null} tx={eventData.TransactionId}");
         if (eventData.Context is not null)
-            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, cancellationToken);
+            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, "Committing", cancellationToken);
 
         return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
     }
@@ -81,6 +84,7 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEndEventData eventData,
         CancellationToken cancellationToken = default)
     {
+        Console.WriteLine($"#CTDIAG# TransactionCommittedAsync {typeof(TChange).Name} _changes={_changes.Count} tx={eventData.TransactionId}");
         foreach (var item in _changes)
         {
             _logger.LogDebug("Detected relevant changes in transaction {TransactionId}: {Changes}",
@@ -94,10 +98,13 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
     private async Task CaptureChangesAsync(
         DbContext context,
         Guid transactionId,
+        string hookName,
         CancellationToken cancellationToken)
     {
-        var currentChanges = await DetectChanges(context, cancellationToken)
-            .MapT(changes => new ChangeTrackingQueueItem<TChange>(transactionId, changes));
+        var detected = await DetectChanges(context, cancellationToken);
+        Console.WriteLine($"#CTDIAG# {hookName} captured {detected.Count} for {typeof(TChange).Name} tx={transactionId}");
+        var currentChanges = detected
+            .Map(changes => new ChangeTrackingQueueItem<TChange>(transactionId, changes));
 
         _changes = _changes.Union(currentChanges);
     }

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeInterceptorBase.cs
@@ -13,14 +13,13 @@ namespace Eryph.Modules.Controller.ChangeTracking;
 /// Base class for change interceptors that detect changes in the database.
 /// </summary>
 /// <remarks>
-/// Changes are captured from multiple hooks so that we observe the change
-/// tracker while it is still fully populated regardless of provider/version
-/// quirks: <see cref="ISaveChangesInterceptor.SavingChangesAsync"/> is the
-/// primary capture point (always fires before EF clears deleted entries),
-/// while <see cref="CreatedSavepointAsync"/> and
-/// <see cref="TransactionCommittingAsync"/> remain as defensive fallbacks.
-/// Enqueueing is deferred until <see cref="TransactionCommittedAsync"/> so
-/// downstream handlers only see changes that were actually committed.
+/// Changes are captured from multiple hooks so we always observe the change
+/// tracker while it is still fully populated, regardless of provider/version
+/// quirks. <see cref="ISaveChangesInterceptor.SavingChangesAsync"/> is the
+/// primary capture point (always fires before EF clears deleted entries);
+/// <see cref="CreatedSavepointAsync"/> and <see cref="TransactionCommittingAsync"/>
+/// stay as defensive fallbacks. Enqueueing is deferred until
+/// <see cref="TransactionCommittedAsync"/> so handlers only see committed work.
 /// </remarks>
 internal abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor, ISaveChangesInterceptor
 {
@@ -45,12 +44,12 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         InterceptionResult<int> result,
         CancellationToken cancellationToken = default)
     {
-        Console.WriteLine($"#CTDIAG# SavingChangesAsync {typeof(TChange).Name} ctx={eventData.Context is not null}");
-        if (eventData.Context is null)
-            return result;
+        if (eventData.Context is not null)
+        {
+            var transactionId = eventData.Context.Database.CurrentTransaction?.TransactionId ?? Guid.Empty;
+            await CaptureChangesAsync(eventData.Context, transactionId, cancellationToken);
+        }
 
-        var transactionId = eventData.Context.Database.CurrentTransaction?.TransactionId ?? Guid.Empty;
-        await CaptureChangesAsync(eventData.Context, transactionId, "Saving", cancellationToken);
         return result;
     }
 
@@ -59,9 +58,8 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEventData eventData,
         CancellationToken cancellationToken = default)
     {
-        Console.WriteLine($"#CTDIAG# CreatedSavepointAsync {typeof(TChange).Name} ctx={eventData.Context is not null} tx={eventData.TransactionId}");
         if (eventData.Context is not null)
-            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, "Savepoint", cancellationToken);
+            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, cancellationToken);
 
         await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
     }
@@ -72,9 +70,8 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         InterceptionResult result,
         CancellationToken cancellationToken = default)
     {
-        Console.WriteLine($"#CTDIAG# TransactionCommittingAsync {typeof(TChange).Name} ctx={eventData.Context is not null} tx={eventData.TransactionId}");
         if (eventData.Context is not null)
-            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, "Committing", cancellationToken);
+            await CaptureChangesAsync(eventData.Context, eventData.TransactionId, cancellationToken);
 
         return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
     }
@@ -84,7 +81,6 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
         TransactionEndEventData eventData,
         CancellationToken cancellationToken = default)
     {
-        Console.WriteLine($"#CTDIAG# TransactionCommittedAsync {typeof(TChange).Name} _changes={_changes.Count} tx={eventData.TransactionId}");
         foreach (var item in _changes)
         {
             _logger.LogDebug("Detected relevant changes in transaction {TransactionId}: {Changes}",
@@ -98,24 +94,24 @@ internal abstract class ChangeInterceptorBase<TChange> : DbTransactionIntercepto
     private async Task CaptureChangesAsync(
         DbContext context,
         Guid transactionId,
-        string hookName,
         CancellationToken cancellationToken)
     {
-        var detected = await DetectChanges(context, cancellationToken);
-        Console.WriteLine($"#CTDIAG# {hookName} captured {detected.Count} for {typeof(TChange).Name} tx={transactionId}");
-        var currentChanges = detected
-            .Map(changes => new ChangeTrackingQueueItem<TChange>(transactionId, changes));
+        var currentChanges = await DetectChanges(context, cancellationToken)
+            .MapT(changes => new ChangeTrackingQueueItem<TChange>(transactionId, changes));
 
         _changes = _changes.Union(currentChanges);
     }
 
-    int ISaveChangesInterceptor.SavedChanges(SaveChangesCompletedEventData eventData, int result) => result;
-
     InterceptionResult<int> ISaveChangesInterceptor.SavingChanges(
         DbContextEventData eventData,
-        InterceptionResult<int> result) => throw new NotSupportedException();
+        InterceptionResult<int> result) => result;
 
-    void ISaveChangesInterceptor.SaveChangesFailed(DbContextErrorEventData eventData) { }
+    int ISaveChangesInterceptor.SavedChanges(
+        SaveChangesCompletedEventData eventData,
+        int result) => result;
+
+    void ISaveChangesInterceptor.SaveChangesFailed(
+        DbContextErrorEventData eventData) { }
 
     Task ISaveChangesInterceptor.SaveChangesFailedAsync(
         DbContextErrorEventData eventData,

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
@@ -32,16 +32,19 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
         // begin running, so enabling inside ExecuteAsync races with the
         // first SaveChanges on busy hosts (e.g. CI agents).
         _queue.Enable();
+        _logger.LogWarning("CTDIAG BG StartAsync enabled queue for {TChange}", typeof(TChange).Name);
         return base.StartAsync(cancellationToken);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        _logger.LogWarning("CTDIAG BG ExecuteAsync running for {TChange}", typeof(TChange).Name);
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
                 var queueItem = await _queue.DequeueAsync(stoppingToken);
+                _logger.LogWarning("CTDIAG BG dequeued {TChange} tx={Tx}", typeof(TChange).Name, queueItem.TransactionId);
                 await HandleChangeAsync(queueItem);
             }
             catch (OperationCanceledException)
@@ -56,11 +59,11 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
 
     private async Task FlushQueue()
     {
-        _logger.LogInformation("Going to flush {Count} remaining queue item(s).",
-            _queue.GetCount());
+        _logger.LogWarning("CTDIAG BG flushing {Count} items for {TChange}", _queue.GetCount(), typeof(TChange).Name);
         while (_queue.GetCount() > 0)
         {
             var queueItem = await _queue.DequeueAsync();
+            _logger.LogWarning("CTDIAG BG flush dequeued {TChange} tx={Tx}", typeof(TChange).Name, queueItem.TransactionId);
             await HandleChangeAsync(queueItem);
         }
     }
@@ -74,9 +77,11 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
             await using var scope = AsyncScopedLifestyle.BeginScope(_container);
             var handler = scope.GetInstance<IChangeHandler<TChange>>();
             await handler.HandleChangeAsync(queueItem.Changes);
+            _logger.LogWarning("CTDIAG BG handler completed {TChange} tx={Tx}", typeof(TChange).Name, queueItem.TransactionId);
         }
         catch (Exception ex)
         {
+            _logger.LogWarning("CTDIAG BG handler FAILED {TChange}: {Ex}", typeof(TChange).Name, ex.GetType().Name + ": " + ex.Message);
             // We need to catch all exceptions here. Otherwise, the background
             // service will stop when an exception occurs. We always want to write
             // as many of the changes as possible to the filesystem.

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
@@ -24,9 +24,11 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
         _queue = queue;
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken) 
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        _logger.LogWarning("CTDIAG BG ExecuteAsync starting for {TChange}", typeof(TChange).Name);
         _queue.Enable();
+        _logger.LogWarning("CTDIAG BG queue enabled for {TChange}", typeof(TChange).Name);
         while (!stoppingToken.IsCancellationRequested)
         {
             try
@@ -57,6 +59,7 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
 
     private async Task HandleChangeAsync(ChangeTrackingQueueItem<TChange> queueItem)
     {
+        _logger.LogWarning("CTDIAG BG dequeued change for {TChange} tx={Tx}", typeof(TChange).Name, queueItem.TransactionId);
         _logger.LogDebug("Processing changes of transaction {TransactionId}", queueItem.TransactionId);
 
         try
@@ -64,6 +67,7 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
             await using var scope = AsyncScopedLifestyle.BeginScope(_container);
             var handler = scope.GetInstance<IChangeHandler<TChange>>();
             await handler.HandleChangeAsync(queueItem.Changes);
+            _logger.LogWarning("CTDIAG BG handler completed for {TChange} tx={Tx}", typeof(TChange).Name, queueItem.TransactionId);
         }
         catch (Exception ex)
         {

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
@@ -24,11 +24,9 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
         _queue = queue;
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken) 
     {
-        Console.WriteLine($"#CTDIAG# BG ExecuteAsync starting for {typeof(TChange).Name}");
         _queue.Enable();
-        Console.WriteLine($"#CTDIAG# BG queue enabled for {typeof(TChange).Name}");
         while (!stoppingToken.IsCancellationRequested)
         {
             try
@@ -59,7 +57,6 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
 
     private async Task HandleChangeAsync(ChangeTrackingQueueItem<TChange> queueItem)
     {
-        Console.WriteLine($"#CTDIAG# BG HandleChangeAsync invoking handler for {typeof(TChange).Name} tx={queueItem.TransactionId}");
         _logger.LogDebug("Processing changes of transaction {TransactionId}", queueItem.TransactionId);
 
         try
@@ -67,11 +64,9 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
             await using var scope = AsyncScopedLifestyle.BeginScope(_container);
             var handler = scope.GetInstance<IChangeHandler<TChange>>();
             await handler.HandleChangeAsync(queueItem.Changes);
-            Console.WriteLine($"#CTDIAG# BG HandleChangeAsync done for {typeof(TChange).Name} tx={queueItem.TransactionId}");
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"#CTDIAG# BG HandleChangeAsync FAILED for {typeof(TChange).Name}: {ex.GetType().Name} {ex.Message}");
             // We need to catch all exceptions here. Otherwise, the background
             // service will stop when an exception occurs. We always want to write
             // as many of the changes as possible to the filesystem.

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
@@ -24,9 +24,11 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
         _queue = queue;
     }
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken) 
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        Console.WriteLine($"#CTDIAG# BG ExecuteAsync starting for {typeof(TChange).Name}");
         _queue.Enable();
+        Console.WriteLine($"#CTDIAG# BG queue enabled for {typeof(TChange).Name}");
         while (!stoppingToken.IsCancellationRequested)
         {
             try
@@ -57,6 +59,7 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
 
     private async Task HandleChangeAsync(ChangeTrackingQueueItem<TChange> queueItem)
     {
+        Console.WriteLine($"#CTDIAG# BG HandleChangeAsync invoking handler for {typeof(TChange).Name} tx={queueItem.TransactionId}");
         _logger.LogDebug("Processing changes of transaction {TransactionId}", queueItem.TransactionId);
 
         try
@@ -64,9 +67,11 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
             await using var scope = AsyncScopedLifestyle.BeginScope(_container);
             var handler = scope.GetInstance<IChangeHandler<TChange>>();
             await handler.HandleChangeAsync(queueItem.Changes);
+            Console.WriteLine($"#CTDIAG# BG HandleChangeAsync done for {typeof(TChange).Name} tx={queueItem.TransactionId}");
         }
         catch (Exception ex)
         {
+            Console.WriteLine($"#CTDIAG# BG HandleChangeAsync FAILED for {typeof(TChange).Name}: {ex.GetType().Name} {ex.Message}");
             // We need to catch all exceptions here. Otherwise, the background
             // service will stop when an exception occurs. We always want to write
             // as many of the changes as possible to the filesystem.

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
@@ -24,11 +24,19 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
         _queue = queue;
     }
 
+    public override Task StartAsync(CancellationToken cancellationToken)
+    {
+        // Enable the queue synchronously during StartAsync so producers
+        // can never observe a disabled queue. The Host awaits StartAsync
+        // before returning, but does not wait for ExecuteAsync to actually
+        // begin running, so enabling inside ExecuteAsync races with the
+        // first SaveChanges on busy hosts (e.g. CI agents).
+        _queue.Enable();
+        return base.StartAsync(cancellationToken);
+    }
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger.LogWarning("CTDIAG BG ExecuteAsync starting for {TChange}", typeof(TChange).Name);
-        _queue.Enable();
-        _logger.LogWarning("CTDIAG BG queue enabled for {TChange}", typeof(TChange).Name);
         while (!stoppingToken.IsCancellationRequested)
         {
             try
@@ -59,7 +67,6 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
 
     private async Task HandleChangeAsync(ChangeTrackingQueueItem<TChange> queueItem)
     {
-        _logger.LogWarning("CTDIAG BG dequeued change for {TChange} tx={Tx}", typeof(TChange).Name, queueItem.TransactionId);
         _logger.LogDebug("Processing changes of transaction {TransactionId}", queueItem.TransactionId);
 
         try
@@ -67,7 +74,6 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
             await using var scope = AsyncScopedLifestyle.BeginScope(_container);
             var handler = scope.GetInstance<IChangeHandler<TChange>>();
             await handler.HandleChangeAsync(queueItem.Changes);
-            _logger.LogWarning("CTDIAG BG handler completed for {TChange} tx={Tx}", typeof(TChange).Name, queueItem.TransactionId);
         }
         catch (Exception ex)
         {

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/ChangeTrackingBackgroundService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -32,19 +32,16 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
         // begin running, so enabling inside ExecuteAsync races with the
         // first SaveChanges on busy hosts (e.g. CI agents).
         _queue.Enable();
-        _logger.LogWarning("CTDIAG BG StartAsync enabled queue for {TChange}", typeof(TChange).Name);
         return base.StartAsync(cancellationToken);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        _logger.LogWarning("CTDIAG BG ExecuteAsync running for {TChange}", typeof(TChange).Name);
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
                 var queueItem = await _queue.DequeueAsync(stoppingToken);
-                _logger.LogWarning("CTDIAG BG dequeued {TChange} tx={Tx}", typeof(TChange).Name, queueItem.TransactionId);
                 await HandleChangeAsync(queueItem);
             }
             catch (OperationCanceledException)
@@ -59,11 +56,11 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
 
     private async Task FlushQueue()
     {
-        _logger.LogWarning("CTDIAG BG flushing {Count} items for {TChange}", _queue.GetCount(), typeof(TChange).Name);
+        _logger.LogInformation("Going to flush {Count} remaining queue item(s).",
+            _queue.GetCount());
         while (_queue.GetCount() > 0)
         {
             var queueItem = await _queue.DequeueAsync();
-            _logger.LogWarning("CTDIAG BG flush dequeued {TChange} tx={Tx}", typeof(TChange).Name, queueItem.TransactionId);
             await HandleChangeAsync(queueItem);
         }
     }
@@ -77,11 +74,9 @@ internal class ChangeTrackingBackgroundService<TChange> : BackgroundService
             await using var scope = AsyncScopedLifestyle.BeginScope(_container);
             var handler = scope.GetInstance<IChangeHandler<TChange>>();
             await handler.HandleChangeAsync(queueItem.Changes);
-            _logger.LogWarning("CTDIAG BG handler completed {TChange} tx={Tx}", typeof(TChange).Name, queueItem.TransactionId);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning("CTDIAG BG handler FAILED {TChange}: {Ex}", typeof(TChange).Name, ex.GetType().Name + ": " + ex.Message);
             // We need to catch all exceptions here. Otherwise, the background
             // service will stop when an exception occurs. We always want to write
             // as many of the changes as possible to the filesystem.

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualMachines/CatletMetadataChangeHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualMachines/CatletMetadataChangeHandler.cs
@@ -16,15 +16,18 @@ internal class CatletMetadataChangeHandler : IChangeHandler<CatletMetadataChange
     private readonly ChangeTrackingConfig _config;
     private readonly IFileSystem _fileSystem;
     private readonly IStateStore _stateStore;
+    private readonly Microsoft.Extensions.Logging.ILogger<CatletMetadataChangeHandler> _logger;
 
     public CatletMetadataChangeHandler(
         ChangeTrackingConfig config,
         IFileSystem fileSystem,
-        IStateStore stateStore)
+        IStateStore stateStore,
+        Microsoft.Extensions.Logging.ILogger<CatletMetadataChangeHandler> logger)
     {
         _config = config;
         _fileSystem = fileSystem;
         _stateStore = stateStore;
+        _logger = logger;
     }
 
     public async Task HandleChangeAsync(
@@ -36,6 +39,7 @@ internal class CatletMetadataChangeHandler : IChangeHandler<CatletMetadataChange
 
         var metadata = await _stateStore.For<CatletMetadata>()
             .GetByIdAsync(metadataId, cancellationToken);
+        Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(_logger, "CTDIAG HANDLER metadata id={Id} found={Found}", metadataId, metadata is not null);
         if (metadata is null)
         {
             _fileSystem.File.Delete(path);

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualMachines/CatletMetadataChangeHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualMachines/CatletMetadataChangeHandler.cs
@@ -16,18 +16,15 @@ internal class CatletMetadataChangeHandler : IChangeHandler<CatletMetadataChange
     private readonly ChangeTrackingConfig _config;
     private readonly IFileSystem _fileSystem;
     private readonly IStateStore _stateStore;
-    private readonly Microsoft.Extensions.Logging.ILogger<CatletMetadataChangeHandler> _logger;
 
     public CatletMetadataChangeHandler(
         ChangeTrackingConfig config,
         IFileSystem fileSystem,
-        IStateStore stateStore,
-        Microsoft.Extensions.Logging.ILogger<CatletMetadataChangeHandler> logger)
+        IStateStore stateStore)
     {
         _config = config;
         _fileSystem = fileSystem;
         _stateStore = stateStore;
-        _logger = logger;
     }
 
     public async Task HandleChangeAsync(
@@ -39,7 +36,6 @@ internal class CatletMetadataChangeHandler : IChangeHandler<CatletMetadataChange
 
         var metadata = await _stateStore.For<CatletMetadata>()
             .GetByIdAsync(metadataId, cancellationToken);
-        Microsoft.Extensions.Logging.LoggerExtensions.LogWarning(_logger, "CTDIAG HANDLER metadata id={Id} found={Found}", metadataId, metadata is not null);
         if (metadata is null)
         {
             _fileSystem.File.Delete(path);

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualMachines/CatletMetadataChangeHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualMachines/CatletMetadataChangeHandler.cs
@@ -36,7 +36,6 @@ internal class CatletMetadataChangeHandler : IChangeHandler<CatletMetadataChange
 
         var metadata = await _stateStore.For<CatletMetadata>()
             .GetByIdAsync(metadataId, cancellationToken);
-        System.Console.WriteLine($"#CTDIAG# HANDLER CatletMetadata {metadataId} => {(metadata is null ? "NULL (delete file)" : "exists (write file)")}");
         if (metadata is null)
         {
             _fileSystem.File.Delete(path);

--- a/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualMachines/CatletMetadataChangeHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ChangeTracking/VirtualMachines/CatletMetadataChangeHandler.cs
@@ -36,6 +36,7 @@ internal class CatletMetadataChangeHandler : IChangeHandler<CatletMetadataChange
 
         var metadata = await _stateStore.For<CatletMetadata>()
             .GetByIdAsync(metadataId, cancellationToken);
+        System.Console.WriteLine($"#CTDIAG# HANDLER CatletMetadata {metadataId} => {(metadata is null ? "NULL (delete file)" : "exists (write file)")}");
         if (metadata is null)
         {
             _fileSystem.File.Delete(path);

--- a/src/modules/src/Eryph.Modules.Controller/ControllerModule.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ControllerModule.cs
@@ -154,10 +154,17 @@ namespace Eryph.Modules.Controller
         [UsedImplicitly]
         public void AddSimpleInjector(SimpleInjectorAddOptions options)
         {
-            options.AddSeeding(_changeTrackingConfig);
-            
+            // Change tracking must be registered before seeding so its
+            // hosted services run StartAsync (which enables the queues)
+            // before SeedFromConfigHandler.StartAsync saves any changes.
+            // Otherwise seeded changes would be enqueued against a disabled
+            // queue and silently dropped, and seed-derived data (e.g. the
+            // v0.4 -> v2 metadata salvage in CatletMetadataSeeder) would
+            // never be persisted back to disk.
             if(_changeTrackingConfig.TrackChanges)
                 options.AddChangeTracking();
+
+            options.AddSeeding(_changeTrackingConfig);
 
             options.AddStartupHandler<SyncNetworksHandler>();
             options.AddStartupHandler<StartBusModuleHandler>();

--- a/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
+++ b/src/modules/src/Eryph.Modules.Controller/Eryph.Modules.Controller.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
@@ -24,11 +24,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
     <PackageReference Include="Quartz" Version="3.13.1" />
     <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.13.1" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.13.1" />
-    <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
+    <PackageReference Include="System.IO.Hashing" Version="10.0.0" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="21.2.1" />
     <PackageReference Include="IdGen" Version="3.0.7" />
   </ItemGroup>

--- a/src/modules/src/Eryph.Modules.GenePoolModule/Eryph.Modules.GenePoolModule.csproj
+++ b/src/modules/src/Eryph.Modules.GenePoolModule/Eryph.Modules.GenePoolModule.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>annotations</Nullable>
     <RootNamespace>Eryph.Modules.GenePool</RootNamespace>
   </PropertyGroup>
@@ -24,7 +24,7 @@
     </PackageReference>
     <PackageReference Include="Joveler.Compression.XZ" Version="4.3.0" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="Quartz" Version="3.13.1" />
     <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.13.1" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.13.1" />

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Eryph.Modules.HostAgent.HyperV.csproj
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Eryph.Modules.HostAgent.HyperV.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <Nullable>annotations</Nullable>
     <RootNamespace>Eryph.Modules.HostAgent</RootNamespace>
   </PropertyGroup>
@@ -20,7 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="Quartz" Version="3.13.1" />
     <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.13.1" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.13.1" />

--- a/src/modules/src/Eryph.Modules.Identity/Eryph.Modules.Identity.csproj
+++ b/src/modules/src/Eryph.Modules.Identity/Eryph.Modules.Identity.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/src/modules/src/Eryph.Modules.Identity/Events/Validations/ValidateClientSecretEvents.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Events/Validations/ValidateClientSecretEvents.cs
@@ -101,7 +101,7 @@ public class ValidateClientSecretEvents
                 return;
             }
 
-            using var certificate = new X509Certificate2(Convert.FromBase64String(application.Certificate));
+            using var certificate = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(application.Certificate));
             var securityKey = new X509SecurityKey(certificate);
 
 

--- a/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
+++ b/src/modules/src/Eryph.Modules.NetworkModule/Eryph.Modules.NetworkModule.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>Eryph.Modules.Network</RootNamespace>
   </PropertyGroup>

--- a/src/modules/test/Eryph.ModuleCore.Tests/Eryph.ModuleCore.Tests.csproj
+++ b/src/modules/test/Eryph.ModuleCore.Tests/Eryph.ModuleCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/modules/test/Eryph.Modules.AspNetCore.TestBase/Eryph.Modules.AspNetCore.TestBase.csproj
+++ b/src/modules/test/Eryph.Modules.AspNetCore.TestBase/Eryph.Modules.AspNetCore.TestBase.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/modules/test/Eryph.Modules.AspNetCore.Tests/Eryph.Modules.AspNetCore.Tests.csproj
+++ b/src/modules/test/Eryph.Modules.AspNetCore.Tests/Eryph.Modules.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/Eryph.Modules.ComputeApi.Tests.csproj
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/Eryph.Modules.ComputeApi.Tests.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\data\src\Eryph.StateDb.InMemory\Eryph.StateDb.InMemory.csproj" />

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
@@ -11,10 +11,8 @@ using Eryph.Modules.Controller.Seeding;
 using Eryph.StateDb;
 using Eryph.StateDb.Sqlite;
 using Eryph.StateDb.TestBase;
-using MartinCostello.Logging.XUnit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Moq;
 using SimpleInjector;
 using SimpleInjector.Lifestyles;
@@ -55,7 +53,7 @@ public abstract class ChangeTrackingTestBase(
         var builder = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
-                services.AddLogging(b => b.AddXUnit(outputHelper).SetMinimumLevel(LogLevel.Warning));
+                services.AddLogging();
                 services.AddSimpleInjector(container, options =>
                 {
                     options.AddLogging();

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
@@ -6,10 +6,8 @@ using Eryph.Modules.Controller.Seeding;
 using Eryph.StateDb;
 using Eryph.StateDb.Sqlite;
 using Eryph.StateDb.TestBase;
-using MartinCostello.Logging.XUnit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Moq;
 using SimpleInjector;
 using SimpleInjector.Lifestyles;
@@ -50,7 +48,7 @@ public abstract class ChangeTrackingTestBase(
         var builder = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
-                services.AddLogging(b => b.AddXUnit(outputHelper).SetMinimumLevel(LogLevel.Trace));
+                services.AddLogging();
                 services.AddSimpleInjector(container, options =>
                 {
                     options.AddLogging();

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
@@ -6,8 +6,10 @@ using Eryph.Modules.Controller.Seeding;
 using Eryph.StateDb;
 using Eryph.StateDb.Sqlite;
 using Eryph.StateDb.TestBase;
+using MartinCostello.Logging.XUnit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Moq;
 using SimpleInjector;
 using SimpleInjector.Lifestyles;
@@ -48,7 +50,7 @@ public abstract class ChangeTrackingTestBase(
         var builder = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
-                services.AddLogging();
+                services.AddLogging(b => b.AddXUnit(outputHelper).SetMinimumLevel(LogLevel.Warning));
                 services.AddSimpleInjector(container, options =>
                 {
                     options.AddLogging();

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
@@ -88,7 +88,7 @@ public abstract class ChangeTrackingTestBase(
         // can race against a BackgroundService whose ExecuteAsync has not
         // yet been scheduled by the thread pool, causing the test to assert
         // before the change handler runs.
-        await ChangeTrackingTestHelpers.WaitForIdleAsync(container, TimeSpan.FromSeconds(10));
+        await ChangeTrackingTestHelpers.WaitForIdleAsync(host, TimeSpan.FromSeconds(10));
 
         await host.StopAsync();
     }

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
@@ -6,8 +6,10 @@ using Eryph.Modules.Controller.Seeding;
 using Eryph.StateDb;
 using Eryph.StateDb.Sqlite;
 using Eryph.StateDb.TestBase;
+using MartinCostello.Logging.XUnit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Moq;
 using SimpleInjector;
 using SimpleInjector.Lifestyles;
@@ -48,7 +50,7 @@ public abstract class ChangeTrackingTestBase(
         var builder = Host.CreateDefaultBuilder()
             .ConfigureServices(services =>
             {
-                services.AddLogging();
+                services.AddLogging(b => b.AddXUnit(outputHelper).SetMinimumLevel(LogLevel.Trace));
                 services.AddSimpleInjector(container, options =>
                 {
                     options.AddLogging();

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
@@ -2,11 +2,6 @@
 using System.IO.Abstractions.TestingHelpers;
 using Eryph.Core;
 using Eryph.Modules.Controller.ChangeTracking;
-using Eryph.Modules.Controller.ChangeTracking.Catlets;
-using Eryph.Modules.Controller.ChangeTracking.NetworkProviders;
-using Eryph.Modules.Controller.ChangeTracking.Projects;
-using Eryph.Modules.Controller.ChangeTracking.VirtualMachines;
-using Eryph.Modules.Controller.ChangeTracking.VirtualNetworks;
 using Eryph.Modules.Controller.Seeding;
 using Eryph.StateDb;
 using Eryph.StateDb.Sqlite;
@@ -93,43 +88,10 @@ public abstract class ChangeTrackingTestBase(
         // can race against a BackgroundService whose ExecuteAsync has not
         // yet been scheduled by the thread pool, causing the test to assert
         // before the change handler runs.
-        await WaitForChangeTrackingIdleAsync(container, TimeSpan.FromSeconds(10));
+        await ChangeTrackingTestHelpers.WaitForIdleAsync(container, TimeSpan.FromSeconds(10));
 
         await host.StopAsync();
     }
-
-    private static async Task WaitForChangeTrackingIdleAsync(Container container, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline)
-        {
-            if (AllQueuesEmpty(container))
-            {
-                // Brief grace period for any in-flight handler to complete
-                await Task.Delay(20);
-                if (AllQueuesEmpty(container))
-                    return;
-            }
-            await Task.Delay(10);
-        }
-
-        throw new TimeoutException(
-            "Change tracking queues did not drain in time. Counts: " +
-            $"VN={container.GetInstance<IChangeTrackingQueue<VirtualNetworkChange>>().GetCount()}, " +
-            $"NP={container.GetInstance<IChangeTrackingQueue<NetworkProvidersChange>>().GetCount()}, " +
-            $"Pr={container.GetInstance<IChangeTrackingQueue<ProjectChange>>().GetCount()}, " +
-            $"CM={container.GetInstance<IChangeTrackingQueue<CatletMetadataChange>>().GetCount()}, " +
-            $"CS={container.GetInstance<IChangeTrackingQueue<CatletSpecificationChange>>().GetCount()}, " +
-            $"CSV={container.GetInstance<IChangeTrackingQueue<CatletSpecificationVersionChange>>().GetCount()}");
-    }
-
-    private static bool AllQueuesEmpty(Container c) =>
-        c.GetInstance<IChangeTrackingQueue<VirtualNetworkChange>>().GetCount() == 0
-        && c.GetInstance<IChangeTrackingQueue<NetworkProvidersChange>>().GetCount() == 0
-        && c.GetInstance<IChangeTrackingQueue<ProjectChange>>().GetCount() == 0
-        && c.GetInstance<IChangeTrackingQueue<CatletMetadataChange>>().GetCount() == 0
-        && c.GetInstance<IChangeTrackingQueue<CatletSpecificationChange>>().GetCount() == 0
-        && c.GetInstance<IChangeTrackingQueue<CatletSpecificationVersionChange>>().GetCount() == 0;
 
     public override async Task InitializeAsync()
     {

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestBase.cs
@@ -2,6 +2,11 @@
 using System.IO.Abstractions.TestingHelpers;
 using Eryph.Core;
 using Eryph.Modules.Controller.ChangeTracking;
+using Eryph.Modules.Controller.ChangeTracking.Catlets;
+using Eryph.Modules.Controller.ChangeTracking.NetworkProviders;
+using Eryph.Modules.Controller.ChangeTracking.Projects;
+using Eryph.Modules.Controller.ChangeTracking.VirtualMachines;
+using Eryph.Modules.Controller.ChangeTracking.VirtualNetworks;
 using Eryph.Modules.Controller.Seeding;
 using Eryph.StateDb;
 using Eryph.StateDb.Sqlite;
@@ -79,13 +84,54 @@ public abstract class ChangeTrackingTestBase(
             // should also use transactions for the tests. The behavior
             // for deleted entities changes when using transactions.
             await using var dbTransaction = await dbContext.Database.BeginTransactionAsync();
-            
+
             await action(stateStore);
-            
+
             await dbTransaction.CommitAsync();
         }
+
+        // Wait for the change-tracking background services to drain their
+        // queues before tearing the host down. Without this, host.StopAsync
+        // can race against a BackgroundService whose ExecuteAsync has not
+        // yet been scheduled by the thread pool, causing the test to assert
+        // before the change handler runs.
+        await WaitForChangeTrackingIdleAsync(container, TimeSpan.FromSeconds(10));
+
         await host.StopAsync();
     }
+
+    private static async Task WaitForChangeTrackingIdleAsync(Container container, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (AllQueuesEmpty(container))
+            {
+                // Brief grace period for any in-flight handler to complete
+                await Task.Delay(20);
+                if (AllQueuesEmpty(container))
+                    return;
+            }
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException(
+            "Change tracking queues did not drain in time. Counts: " +
+            $"VN={container.GetInstance<IChangeTrackingQueue<VirtualNetworkChange>>().GetCount()}, " +
+            $"NP={container.GetInstance<IChangeTrackingQueue<NetworkProvidersChange>>().GetCount()}, " +
+            $"Pr={container.GetInstance<IChangeTrackingQueue<ProjectChange>>().GetCount()}, " +
+            $"CM={container.GetInstance<IChangeTrackingQueue<CatletMetadataChange>>().GetCount()}, " +
+            $"CS={container.GetInstance<IChangeTrackingQueue<CatletSpecificationChange>>().GetCount()}, " +
+            $"CSV={container.GetInstance<IChangeTrackingQueue<CatletSpecificationVersionChange>>().GetCount()}");
+    }
+
+    private static bool AllQueuesEmpty(Container c) =>
+        c.GetInstance<IChangeTrackingQueue<VirtualNetworkChange>>().GetCount() == 0
+        && c.GetInstance<IChangeTrackingQueue<NetworkProvidersChange>>().GetCount() == 0
+        && c.GetInstance<IChangeTrackingQueue<ProjectChange>>().GetCount() == 0
+        && c.GetInstance<IChangeTrackingQueue<CatletMetadataChange>>().GetCount() == 0
+        && c.GetInstance<IChangeTrackingQueue<CatletSpecificationChange>>().GetCount() == 0
+        && c.GetInstance<IChangeTrackingQueue<CatletSpecificationVersionChange>>().GetCount() == 0;
 
     public override async Task InitializeAsync()
     {

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestHelpers.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestHelpers.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading.Tasks;
+using Eryph.Modules.Controller.ChangeTracking;
+using Eryph.Modules.Controller.ChangeTracking.Catlets;
+using Eryph.Modules.Controller.ChangeTracking.NetworkProviders;
+using Eryph.Modules.Controller.ChangeTracking.Projects;
+using Eryph.Modules.Controller.ChangeTracking.VirtualMachines;
+using Eryph.Modules.Controller.ChangeTracking.VirtualNetworks;
+using SimpleInjector;
+
+namespace Eryph.Modules.Controller.Tests.ChangeTracking;
+
+internal static class ChangeTrackingTestHelpers
+{
+    // Poll until every change-tracking queue is empty, then briefly re-check
+    // to ensure no handler is still in flight. Used by tests to avoid racing
+    // host.StopAsync against a BackgroundService whose ExecuteAsync has not
+    // yet been scheduled by the thread pool.
+    public static async Task WaitForIdleAsync(Container container, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (AllQueuesEmpty(container))
+            {
+                await Task.Delay(20);
+                if (AllQueuesEmpty(container))
+                    return;
+            }
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException(
+            "Change tracking queues did not drain in time. Counts: " +
+            $"VN={GetCount<VirtualNetworkChange>(container)}, " +
+            $"NP={GetCount<NetworkProvidersChange>(container)}, " +
+            $"Pr={GetCount<ProjectChange>(container)}, " +
+            $"CM={GetCount<CatletMetadataChange>(container)}, " +
+            $"CS={GetCount<CatletSpecificationChange>(container)}, " +
+            $"CSV={GetCount<CatletSpecificationVersionChange>(container)}");
+    }
+
+    private static bool AllQueuesEmpty(Container c) =>
+        GetCount<VirtualNetworkChange>(c) == 0
+        && GetCount<NetworkProvidersChange>(c) == 0
+        && GetCount<ProjectChange>(c) == 0
+        && GetCount<CatletMetadataChange>(c) == 0
+        && GetCount<CatletSpecificationChange>(c) == 0
+        && GetCount<CatletSpecificationVersionChange>(c) == 0;
+
+    private static int GetCount<TChange>(Container c) =>
+        c.GetInstance<IChangeTrackingQueue<TChange>>().GetCount();
+}

--- a/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestHelpers.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/ChangeTracking/ChangeTrackingTestHelpers.cs
@@ -1,53 +1,66 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Eryph.Modules.Controller.ChangeTracking;
-using Eryph.Modules.Controller.ChangeTracking.Catlets;
-using Eryph.Modules.Controller.ChangeTracking.NetworkProviders;
-using Eryph.Modules.Controller.ChangeTracking.Projects;
-using Eryph.Modules.Controller.ChangeTracking.VirtualMachines;
-using Eryph.Modules.Controller.ChangeTracking.VirtualNetworks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using SimpleInjector;
 
 namespace Eryph.Modules.Controller.Tests.ChangeTracking;
 
 internal static class ChangeTrackingTestHelpers
 {
-    // Poll until every change-tracking queue is empty, then briefly re-check
-    // to ensure no handler is still in flight. Used by tests to avoid racing
-    // host.StopAsync against a BackgroundService whose ExecuteAsync has not
-    // yet been scheduled by the thread pool.
-    public static async Task WaitForIdleAsync(Container container, TimeSpan timeout)
+    // Poll until every registered change-tracking queue is empty, then briefly
+    // re-check to ensure no handler is still in flight. Used by tests to avoid
+    // racing host.StopAsync against a BackgroundService whose ExecuteAsync has
+    // not yet been scheduled by the thread pool.
+    //
+    // The queue list is derived from the ChangeTrackingBackgroundService<>
+    // hosted services registered on the host. Adding another change type
+    // (one more AddHostedService<ChangeTrackingBackgroundService<TNew>>() in
+    // ChangeTrackingContainerExtensions) is picked up automatically; no
+    // update to this helper is required.
+    public static async Task WaitForIdleAsync(IHost host, TimeSpan timeout)
     {
+        var queues = ResolveQueues(host);
+
         var deadline = DateTime.UtcNow + timeout;
         while (DateTime.UtcNow < deadline)
         {
-            if (AllQueuesEmpty(container))
+            if (queues.All(q => q.GetCount() == 0))
             {
                 await Task.Delay(20);
-                if (AllQueuesEmpty(container))
+                if (queues.All(q => q.GetCount() == 0))
                     return;
             }
             await Task.Delay(10);
         }
 
-        throw new TimeoutException(
-            "Change tracking queues did not drain in time. Counts: " +
-            $"VN={GetCount<VirtualNetworkChange>(container)}, " +
-            $"NP={GetCount<NetworkProvidersChange>(container)}, " +
-            $"Pr={GetCount<ProjectChange>(container)}, " +
-            $"CM={GetCount<CatletMetadataChange>(container)}, " +
-            $"CS={GetCount<CatletSpecificationChange>(container)}, " +
-            $"CSV={GetCount<CatletSpecificationVersionChange>(container)}");
+        var counts = string.Join(", ", queues.Select(q => $"{q.ChangeTypeName}={q.GetCount()}"));
+        throw new TimeoutException($"Change tracking queues did not drain in time. Counts: {counts}");
     }
 
-    private static bool AllQueuesEmpty(Container c) =>
-        GetCount<VirtualNetworkChange>(c) == 0
-        && GetCount<NetworkProvidersChange>(c) == 0
-        && GetCount<ProjectChange>(c) == 0
-        && GetCount<CatletMetadataChange>(c) == 0
-        && GetCount<CatletSpecificationChange>(c) == 0
-        && GetCount<CatletSpecificationVersionChange>(c) == 0;
+    private static IReadOnlyList<QueueProbe> ResolveQueues(IHost host)
+    {
+        var container = host.Services.GetRequiredService<Container>();
+        return host.Services.GetServices<IHostedService>()
+            .Select(s => s.GetType())
+            .Where(t => t.IsGenericType
+                        && t.GetGenericTypeDefinition() == typeof(ChangeTrackingBackgroundService<>))
+            .Select(t =>
+            {
+                var changeType = t.GetGenericArguments()[0];
+                var queueType = typeof(IChangeTrackingQueue<>).MakeGenericType(changeType);
+                var queue = container.GetInstance(queueType);
+                var getCount = (Func<int>)Delegate.CreateDelegate(
+                    typeof(Func<int>),
+                    queue,
+                    queueType.GetMethod(nameof(IChangeTrackingQueue<object>.GetCount))!);
+                return new QueueProbe(changeType.Name, getCount);
+            })
+            .ToList();
+    }
 
-    private static int GetCount<TChange>(Container c) =>
-        c.GetInstance<IChangeTrackingQueue<TChange>>().GetCount();
+    private sealed record QueueProbe(string ChangeTypeName, Func<int> GetCount);
 }

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Eryph.Modules.Controller.Tests.csproj
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Eryph.Modules.Controller.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.5.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="21.2.1" />

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletMetadataSeederTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletMetadataSeederTests.cs
@@ -212,7 +212,7 @@ public abstract class CatletMetadataSeederTests(
         using var host = CreateHost();
         await host.StartAsync();
         var container = host.Services.GetRequiredService<SimpleInjector.Container>();
-        await WaitForChangeTrackingIdleAsync(container, TimeSpan.FromSeconds(10));
+        await ChangeTrackingTestHelpers.WaitForIdleAsync(container, TimeSpan.FromSeconds(10));
         await host.StopAsync();
     }
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletMetadataSeederTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletMetadataSeederTests.cs
@@ -14,6 +14,7 @@ using Eryph.Core;
 using Eryph.Core.Genetics;
 using Eryph.Modules.Controller.Serializers;
 using Eryph.Serializers;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Eryph.Modules.Controller.Tests.Seeding;
@@ -210,6 +211,8 @@ public abstract class CatletMetadataSeederTests(
     {
         using var host = CreateHost();
         await host.StartAsync();
+        var container = host.Services.GetRequiredService<SimpleInjector.Container>();
+        await WaitForChangeTrackingIdleAsync(container, TimeSpan.FromSeconds(10));
         await host.StopAsync();
     }
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletMetadataSeederTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletMetadataSeederTests.cs
@@ -211,8 +211,7 @@ public abstract class CatletMetadataSeederTests(
     {
         using var host = CreateHost();
         await host.StartAsync();
-        var container = host.Services.GetRequiredService<SimpleInjector.Container>();
-        await ChangeTrackingTestHelpers.WaitForIdleAsync(container, TimeSpan.FromSeconds(10));
+        await ChangeTrackingTestHelpers.WaitForIdleAsync(host, TimeSpan.FromSeconds(10));
         await host.StopAsync();
     }
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletSpecificationSeederTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletSpecificationSeederTests.cs
@@ -1,5 +1,6 @@
 ﻿using Eryph.ConfigModel.Json;
 using Eryph.Core.Genetics;
+using Eryph.Modules.Controller.Tests.ChangeTracking;
 using Eryph.StateDb;
 using Eryph.StateDb.Model;
 using Eryph.StateDb.TestBase;
@@ -92,7 +93,7 @@ public abstract class CatletSpecificationSeederTests(
         using var host = CreateHost();
         await host.StartAsync();
         var container = host.Services.GetRequiredService<SimpleInjector.Container>();
-        await WaitForChangeTrackingIdleAsync(container, TimeSpan.FromSeconds(10));
+        await ChangeTrackingTestHelpers.WaitForIdleAsync(container, TimeSpan.FromSeconds(10));
         await host.StopAsync();
     }
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletSpecificationSeederTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletSpecificationSeederTests.cs
@@ -92,8 +92,7 @@ public abstract class CatletSpecificationSeederTests(
     {
         using var host = CreateHost();
         await host.StartAsync();
-        var container = host.Services.GetRequiredService<SimpleInjector.Container>();
-        await ChangeTrackingTestHelpers.WaitForIdleAsync(container, TimeSpan.FromSeconds(10));
+        await ChangeTrackingTestHelpers.WaitForIdleAsync(host, TimeSpan.FromSeconds(10));
         await host.StopAsync();
     }
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletSpecificationSeederTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/CatletSpecificationSeederTests.cs
@@ -3,6 +3,7 @@ using Eryph.Core.Genetics;
 using Eryph.StateDb;
 using Eryph.StateDb.Model;
 using Eryph.StateDb.TestBase;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit.Abstractions;
 
 namespace Eryph.Modules.Controller.Tests.Seeding;
@@ -90,6 +91,8 @@ public abstract class CatletSpecificationSeederTests(
     {
         using var host = CreateHost();
         await host.StartAsync();
+        var container = host.Services.GetRequiredService<SimpleInjector.Container>();
+        await WaitForChangeTrackingIdleAsync(container, TimeSpan.FromSeconds(10));
         await host.StopAsync();
     }
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/SeederTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/SeederTestBase.cs
@@ -1,12 +1,8 @@
 ﻿using Eryph.Core;
 using Eryph.Modules.Controller.ChangeTracking;
-using Eryph.Modules.Controller.ChangeTracking.Catlets;
-using Eryph.Modules.Controller.ChangeTracking.NetworkProviders;
-using Eryph.Modules.Controller.ChangeTracking.Projects;
-using Eryph.Modules.Controller.ChangeTracking.VirtualMachines;
-using Eryph.Modules.Controller.ChangeTracking.VirtualNetworks;
 using Eryph.Modules.Controller.Networks;
 using Eryph.Modules.Controller.Seeding;
+using Eryph.Modules.Controller.Tests.ChangeTracking;
 using Eryph.StateDb;
 using Eryph.StateDb.Sqlite;
 using Eryph.StateDb.TestBase;
@@ -114,41 +110,9 @@ public abstract class SeederTestBase : StateDbTestBase
 
             await dbTransaction.CommitAsync();
         }
-        await WaitForChangeTrackingIdleAsync(container, TimeSpan.FromSeconds(10));
+        await ChangeTrackingTestHelpers.WaitForIdleAsync(container, TimeSpan.FromSeconds(10));
         await host.StopAsync();
     }
-
-    protected static async Task WaitForChangeTrackingIdleAsync(Container container, TimeSpan timeout)
-    {
-        var deadline = DateTime.UtcNow + timeout;
-        while (DateTime.UtcNow < deadline)
-        {
-            if (AllQueuesEmpty(container))
-            {
-                await Task.Delay(20);
-                if (AllQueuesEmpty(container))
-                    return;
-            }
-            await Task.Delay(10);
-        }
-
-        throw new TimeoutException(
-            "Change tracking queues did not drain in time. Counts: " +
-            $"VN={container.GetInstance<IChangeTrackingQueue<VirtualNetworkChange>>().GetCount()}, " +
-            $"NP={container.GetInstance<IChangeTrackingQueue<NetworkProvidersChange>>().GetCount()}, " +
-            $"Pr={container.GetInstance<IChangeTrackingQueue<ProjectChange>>().GetCount()}, " +
-            $"CM={container.GetInstance<IChangeTrackingQueue<CatletMetadataChange>>().GetCount()}, " +
-            $"CS={container.GetInstance<IChangeTrackingQueue<CatletSpecificationChange>>().GetCount()}, " +
-            $"CSV={container.GetInstance<IChangeTrackingQueue<CatletSpecificationVersionChange>>().GetCount()}");
-    }
-
-    private static bool AllQueuesEmpty(Container c) =>
-        c.GetInstance<IChangeTrackingQueue<VirtualNetworkChange>>().GetCount() == 0
-        && c.GetInstance<IChangeTrackingQueue<NetworkProvidersChange>>().GetCount() == 0
-        && c.GetInstance<IChangeTrackingQueue<ProjectChange>>().GetCount() == 0
-        && c.GetInstance<IChangeTrackingQueue<CatletMetadataChange>>().GetCount() == 0
-        && c.GetInstance<IChangeTrackingQueue<CatletSpecificationChange>>().GetCount() == 0
-        && c.GetInstance<IChangeTrackingQueue<CatletSpecificationVersionChange>>().GetCount() == 0;
 
     public override async Task InitializeAsync()
     {

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/SeederTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/SeederTestBase.cs
@@ -110,7 +110,7 @@ public abstract class SeederTestBase : StateDbTestBase
 
             await dbTransaction.CommitAsync();
         }
-        await ChangeTrackingTestHelpers.WaitForIdleAsync(container, TimeSpan.FromSeconds(10));
+        await ChangeTrackingTestHelpers.WaitForIdleAsync(host, TimeSpan.FromSeconds(10));
         await host.StopAsync();
     }
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/SeederTestBase.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Seeding/SeederTestBase.cs
@@ -1,5 +1,10 @@
 ﻿using Eryph.Core;
 using Eryph.Modules.Controller.ChangeTracking;
+using Eryph.Modules.Controller.ChangeTracking.Catlets;
+using Eryph.Modules.Controller.ChangeTracking.NetworkProviders;
+using Eryph.Modules.Controller.ChangeTracking.Projects;
+using Eryph.Modules.Controller.ChangeTracking.VirtualMachines;
+using Eryph.Modules.Controller.ChangeTracking.VirtualNetworks;
 using Eryph.Modules.Controller.Networks;
 using Eryph.Modules.Controller.Seeding;
 using Eryph.StateDb;
@@ -109,8 +114,41 @@ public abstract class SeederTestBase : StateDbTestBase
 
             await dbTransaction.CommitAsync();
         }
+        await WaitForChangeTrackingIdleAsync(container, TimeSpan.FromSeconds(10));
         await host.StopAsync();
     }
+
+    protected static async Task WaitForChangeTrackingIdleAsync(Container container, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (AllQueuesEmpty(container))
+            {
+                await Task.Delay(20);
+                if (AllQueuesEmpty(container))
+                    return;
+            }
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException(
+            "Change tracking queues did not drain in time. Counts: " +
+            $"VN={container.GetInstance<IChangeTrackingQueue<VirtualNetworkChange>>().GetCount()}, " +
+            $"NP={container.GetInstance<IChangeTrackingQueue<NetworkProvidersChange>>().GetCount()}, " +
+            $"Pr={container.GetInstance<IChangeTrackingQueue<ProjectChange>>().GetCount()}, " +
+            $"CM={container.GetInstance<IChangeTrackingQueue<CatletMetadataChange>>().GetCount()}, " +
+            $"CS={container.GetInstance<IChangeTrackingQueue<CatletSpecificationChange>>().GetCount()}, " +
+            $"CSV={container.GetInstance<IChangeTrackingQueue<CatletSpecificationVersionChange>>().GetCount()}");
+    }
+
+    private static bool AllQueuesEmpty(Container c) =>
+        c.GetInstance<IChangeTrackingQueue<VirtualNetworkChange>>().GetCount() == 0
+        && c.GetInstance<IChangeTrackingQueue<NetworkProvidersChange>>().GetCount() == 0
+        && c.GetInstance<IChangeTrackingQueue<ProjectChange>>().GetCount() == 0
+        && c.GetInstance<IChangeTrackingQueue<CatletMetadataChange>>().GetCount() == 0
+        && c.GetInstance<IChangeTrackingQueue<CatletSpecificationChange>>().GetCount() == 0
+        && c.GetInstance<IChangeTrackingQueue<CatletSpecificationVersionChange>>().GetCount() == 0;
 
     public override async Task InitializeAsync()
     {

--- a/src/modules/test/Eryph.Modules.GenePoolModule.Test/Eryph.Modules.GenePoolModule.Test.csproj
+++ b/src/modules/test/Eryph.Modules.GenePoolModule.Test/Eryph.Modules.GenePoolModule.Test.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Eryph.Modules.HostAgent.HyperV.Test.csproj
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Eryph.Modules.HostAgent.HyperV.Test.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>12</LangVersion>

--- a/src/modules/test/Eryph.Modules.Identity.Test/Eryph.Modules.Identity.Test.csproj
+++ b/src/modules/test/Eryph.Modules.Identity.Test/Eryph.Modules.Identity.Test.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Eryph.Modules.Identity\Eryph.Modules.Identity.csproj" />


### PR DESCRIPTION
Upgrade all target frameworks from net8.0 to net10.0 and bump runtime/ASP.NET/PowerShell packages accordingly. EF Core moves to 9.0.0 (latest supported by Pomelo MySQL). Updates obsoleted APIs: `new X509Certificate2(byte[])` → `X509CertificateLoader.LoadCertificate`, and `ApiDescription.IsDeprecated()` extension → property.