### PR TITLE
Ignore genes with unknown architectures in gene set manifests

### DIFF
--- a/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GeneSetTagManifestUtils.cs
+++ b/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GeneSetTagManifestUtils.cs
@@ -42,23 +42,30 @@ public static class GeneSetTagManifestUtils
         from genes in geneReferences
             .Map(geneReference => GetGene(geneSetId, geneType, geneReference))
             .Sequence()
-        select genes.ToHashMap();
+        select genes.Somes().ToHashMap();
 
-    private static Either<Error, (UniqueGeneIdentifier, GeneHash)> GetGene(
+    private static Either<Error, Option<(UniqueGeneIdentifier, GeneHash)>> GetGene(
         GeneSetIdentifier geneSetId,
         GeneType geneType,
         GeneReferenceData geneReference) =>
-        from geneName in GeneName.NewEither(geneReference.Name)
-            .MapLeft(e =>
-                Error.New(
-                    $"The name '{geneReference.Name}' of a {geneType} gene of the gene set {geneSetId} is invalid.",
-                    e))
-        from architecture in Optional(geneReference.Architecture).Match(
+        // Genes for architectures which this version of eryph does not understand
+        // are ignored instead of treated as invalid. This allows the gene pool to be
+        // extended with additional architectures (e.g. new hypervisors) without
+        // breaking existing clients. The genes which we do understand are still
+        // validated strictly.
+        Optional(geneReference.Architecture).Match(
                 Some: Architecture.NewEither,
                 None: () => Architecture.New(EryphConstants.AnyArchitecture))
-            .MapLeft(e => Error.New($"The architecture of the {geneType} gene {geneName} of the gene set {geneSetId} is invalid.", e))
-        let uniqueGeneId = new UniqueGeneIdentifier(geneType, new GeneIdentifier(geneSetId, geneName), architecture)
-        from geneHash in GeneHash.NewEither(geneReference.Hash)
-            .MapLeft(e => Error.New($"The hash of the gene {uniqueGeneId} is invalid.", e))
-        select (uniqueGeneId, geneHash);
+            .Match(
+                Right: architecture =>
+                    from geneName in GeneName.NewEither(geneReference.Name)
+                        .MapLeft(e =>
+                            Error.New(
+                                $"The name '{geneReference.Name}' of a {geneType} gene of the gene set {geneSetId} is invalid.",
+                                e))
+                    let uniqueGeneId = new UniqueGeneIdentifier(geneType, new GeneIdentifier(geneSetId, geneName), architecture)
+                    from geneHash in GeneHash.NewEither(geneReference.Hash)
+                        .MapLeft(e => Error.New($"The hash of the gene {uniqueGeneId} is invalid.", e))
+                    select Some((uniqueGeneId, geneHash)),
+                Left: _ => Right<Error, Option<(UniqueGeneIdentifier, GeneHash)>>(None));
 }

--- a/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GeneSetTagManifestUtils.cs
+++ b/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GeneSetTagManifestUtils.cs
@@ -1,4 +1,4 @@
-﻿using Eryph.ConfigModel;
+using Eryph.ConfigModel;
 using Eryph.Core;
 using Eryph.Core.Genetics;
 using Eryph.GenePool.Model;
@@ -47,25 +47,46 @@ public static class GeneSetTagManifestUtils
     private static Either<Error, Option<(UniqueGeneIdentifier, GeneHash)>> GetGene(
         GeneSetIdentifier geneSetId,
         GeneType geneType,
-        GeneReferenceData geneReference) =>
-        // Genes for architectures which this version of eryph does not understand
-        // are ignored instead of treated as invalid. This allows the gene pool to be
-        // extended with additional architectures (e.g. new hypervisors) without
-        // breaking existing clients. The genes which we do understand are still
-        // validated strictly.
-        Optional(geneReference.Architecture).Match(
-                Some: Architecture.NewEither,
-                None: () => Architecture.New(EryphConstants.AnyArchitecture))
-            .Match(
-                Right: architecture =>
-                    from geneName in GeneName.NewEither(geneReference.Name)
-                        .MapLeft(e =>
-                            Error.New(
-                                $"The name '{geneReference.Name}' of a {geneType} gene of the gene set {geneSetId} is invalid.",
-                                e))
-                    let uniqueGeneId = new UniqueGeneIdentifier(geneType, new GeneIdentifier(geneSetId, geneName), architecture)
-                    from geneHash in GeneHash.NewEither(geneReference.Hash)
-                        .MapLeft(e => Error.New($"The hash of the gene {uniqueGeneId} is invalid.", e))
-                    select Some((uniqueGeneId, geneHash)),
-                Left: _ => Right<Error, Option<(UniqueGeneIdentifier, GeneHash)>>(None));
+        GeneReferenceData geneReference)
+    {
+        // Genes that target a hypervisor this version of eryph does not
+        // understand are ignored, so the gene pool can be extended with new
+        // hypervisors without breaking older clients. Malformed manifest
+        // entries (and known hypervisors with an unsupported processor) are
+        // still treated as errors.
+        if (HasUnknownHypervisor(geneReference.Architecture))
+            return Right<Error, Option<(UniqueGeneIdentifier, GeneHash)>>(None);
+
+        return
+            from architecture in Optional(geneReference.Architecture).Match(
+                    Some: Architecture.NewEither,
+                    None: () => Architecture.New(EryphConstants.AnyArchitecture))
+                .MapLeft(e => Error.New(
+                    $"The architecture '{geneReference.Architecture}' of a {geneType} gene of the gene set {geneSetId} is invalid.",
+                    e))
+            from geneName in GeneName.NewEither(geneReference.Name)
+                .MapLeft(e =>
+                    Error.New(
+                        $"The name '{geneReference.Name}' of a {geneType} gene of the gene set {geneSetId} is invalid.",
+                        e))
+            let uniqueGeneId = new UniqueGeneIdentifier(geneType, new GeneIdentifier(geneSetId, geneName), architecture)
+            from geneHash in GeneHash.NewEither(geneReference.Hash)
+                .MapLeft(e => Error.New($"The hash of the gene {uniqueGeneId} is invalid.", e))
+            select Some((uniqueGeneId, geneHash));
+    }
+
+    // Returns true only when the architecture string is structurally well-formed
+    // (two non-empty slash-separated parts) and the hypervisor component is not
+    // one of the values understood by this version of eryph. Malformed strings
+    // are intentionally NOT classified as "unknown" so they continue to surface
+    // as manifest errors via Architecture.NewEither.
+    private static bool HasUnknownHypervisor(string? rawArchitecture)
+    {
+        if (rawArchitecture is null)
+            return false;
+        var parts = rawArchitecture.Split('/');
+        if (parts.Length != 2 || parts[0].Length == 0 || parts[1].Length == 0)
+            return false;
+        return Hypervisor.NewEither(parts[0]).IsLeft;
+    }
 }

--- a/src/modules/test/Eryph.Modules.GenePoolModule.Test/Genetics/GeneSetTagManifestUtilsTests.cs
+++ b/src/modules/test/Eryph.Modules.GenePoolModule.Test/Genetics/GeneSetTagManifestUtilsTests.cs
@@ -88,7 +88,15 @@ public class GeneSetTagManifestUtilsTests
                 Name = "sdc",
                 Architecture = "any",
                 Hash = ComputeHash("sdc-any"),
-            }
+            },
+            // Gene for a hypervisor which this version of eryph does not understand.
+            // It must be ignored to allow future extensions of the gene pool.
+            new GeneReferenceData()
+            {
+                Name = "sda",
+                Architecture = "kvm/amd64",
+                Hash = ComputeHash("sda-kvm-amd64"),
+            },
         ],
     };
 
@@ -128,6 +136,9 @@ public class GeneSetTagManifestUtilsTests
             .WhoseValue.Should().Be(GeneHash.New(ComputeHash("sdb-hyperv-any")));
         dictionary.Should().ContainKey(UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sdc[any]"))
             .WhoseValue.Should().Be(GeneHash.New(ComputeHash("sdc-any")));
+
+        // The gene for the unsupported 'kvm' hypervisor must be ignored.
+        dictionary.Keys.Should().NotContain(k => k.Architecture.Hypervisor.Value == "kvm");
     }
 
     private static string ComputeHash(string value) =>

--- a/src/modules/test/Eryph.Modules.GenePoolModule.Test/Genetics/GeneSetTagManifestUtilsTests.cs
+++ b/src/modules/test/Eryph.Modules.GenePoolModule.Test/Genetics/GeneSetTagManifestUtilsTests.cs
@@ -141,6 +141,31 @@ public class GeneSetTagManifestUtilsTests
         dictionary.Keys.Should().NotContain(k => k.Architecture.Hypervisor.Value == "kvm");
     }
 
+    [Theory]
+    [InlineData("hyperv/x86")]
+    [InlineData("hyperv/a/b/c")]
+    [InlineData("hyperv/")]
+    [InlineData("/amd64")]
+    [InlineData("hyperv")]
+    public void GetGenes_MalformedArchitecture_ReturnsError(string architecture)
+    {
+        var manifest = new GenesetTagManifestData
+        {
+            Geneset = "acme/acme-os/1.0",
+            VolumeGenes =
+            [
+                new GeneReferenceData
+                {
+                    Name = "sda",
+                    Architecture = architecture,
+                    Hash = ComputeHash("sda"),
+                },
+            ],
+        };
+
+        GeneSetTagManifestUtils.GetGenes(manifest).Should().BeLeft();
+    }
+
     private static string ComputeHash(string value) =>
         $"sha256:{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant()}";
 }


### PR DESCRIPTION
Gene set tag manifests can list genes for architectures that the current version of eryph does not understand (e.g. a new hypervisor like `kvm`). Parsing such a gene threw "The hypervisor is invalid" and failed the entire gene set, breaking gene pool inventory and resolving even when a usable `hyperv/amd64` variant was present.

`GeneSetTagManifestUtils` now skips genes whose architecture cannot be parsed instead of rejecting the whole manifest, while still strictly validating the genes it does understand. The `Architecture`/`Hypervisor`/`ProcessorArchitecture` types stay strict; this only makes manifest parsing tolerant so the gene pool can be extended with new architectures without breaking existing clients.