### PR TITLE
Download genes concurrently (#367)

### DIFF
--- a/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GenePoolConstants.cs
+++ b/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GenePoolConstants.cs
@@ -4,6 +4,14 @@ public static class GenePoolConstants
 {
     public const string PartClientName = "gene_part_client";
 
+    /// <summary>
+    /// The maximum number of genes which are downloaded/provided concurrently.
+    /// Requests for different genes are processed in parallel up to this limit,
+    /// while multiple requests for the same gene are still deduplicated and
+    /// served by a single download (see <see cref="GeneRequestRegistry"/>).
+    /// </summary>
+    public const int MaxConcurrentGeneRequests = 3;
+
     public static GenePoolSettings ProductionGenePool => new (
         "eryph-genepool",
         new("https://genepool-api.eryph.io/"),

--- a/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GeneRequestRegistry.cs
+++ b/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GeneRequestRegistry.cs
@@ -167,7 +167,11 @@ internal sealed class GeneRequestRegistry(
         }
 
         // Update the number of pending tasks for the remaining tasks in the queue.
-        // We skip the first entry in the queue as it will be picked up for processing.
+        // Completing this request frees up exactly one worker, which will pick up
+        // the first queued entry next. We therefore skip that first entry and report
+        // the number of queued tasks ahead of each remaining task. With multiple
+        // workers other genes may still be processed in parallel, so this count is
+        // the queue position and not the total number of in-flight tasks.
         foreach (var (tasks, index) in tasksToUpdate.Select((t, i) => (t, i)))
         {
             var message = $"Waiting for {index + 1} other task(s)...";

--- a/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GeneticsRequestWatcherService.cs
+++ b/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GeneticsRequestWatcherService.cs
@@ -26,7 +26,8 @@ internal class GeneticsRequestWatcherService(
         // consumed by multiple workers in parallel.
         var workers = Enumerable
             .Range(0, GenePoolConstants.MaxConcurrentGeneRequests)
-            .Select(_ => RunWorker(stoppingToken));
+            .Select(_ => RunWorker(stoppingToken))
+            .ToArray();
         await Task.WhenAll(workers);
     }
 

--- a/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GeneticsRequestWatcherService.cs
+++ b/src/modules/src/Eryph.Modules.GenePoolModule/Genetics/GeneticsRequestWatcherService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Eryph.Core;
@@ -18,6 +19,18 @@ internal class GeneticsRequestWatcherService(
     ILogger logger) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Run multiple workers so that requests for different genes can be
+        // downloaded concurrently. Requests for the same gene are deduplicated
+        // by the GeneRequestRegistry, and DequeueGeneRequest supports being
+        // consumed by multiple workers in parallel.
+        var workers = Enumerable
+            .Range(0, GenePoolConstants.MaxConcurrentGeneRequests)
+            .Select(_ => RunWorker(stoppingToken));
+        await Task.WhenAll(workers);
+    }
+
+    private async Task RunWorker(CancellationToken stoppingToken)
     {
         while (!stoppingToken.IsCancellationRequested)
         {

--- a/src/modules/test/Eryph.Modules.GenePoolModule.Test/Genetics/GeneticsRequestWatcherServiceTests.cs
+++ b/src/modules/test/Eryph.Modules.GenePoolModule.Test/Genetics/GeneticsRequestWatcherServiceTests.cs
@@ -74,9 +74,12 @@ public class GeneticsRequestWatcherServiceTests
         }
         finally
         {
-            // Unblock the workers so the background service can shut down.
+            // Unblock the workers so the background service can shut down, and make
+            // sure it actually stops (workers must observe cancellation and exit).
             provider.ReleaseAll();
-            await service.StopAsync(CancellationToken.None);
+            var stopped = service.StopAsync(CancellationToken.None);
+            (await Task.WhenAny(stopped, Task.Delay(TimeSpan.FromSeconds(10))))
+                .Should().BeSameAs(stopped, "the background service should shut down its workers cleanly");
         }
     }
 
@@ -122,7 +125,10 @@ public class GeneticsRequestWatcherServiceTests
         public void RegisterGene(UniqueGeneIdentifier geneId) =>
             _started[geneId.Value] = new TaskCompletionSource();
 
-        public Task Started(UniqueGeneIdentifier geneId) => _started[geneId.Value].Task;
+        public Task Started(UniqueGeneIdentifier geneId) => Gate(geneId).Task;
+
+        private TaskCompletionSource Gate(UniqueGeneIdentifier geneId) =>
+            _started.GetOrAdd(geneId.Value, _ => new TaskCompletionSource());
 
         public void ReleaseAll() => _release.TrySetResult();
 
@@ -134,7 +140,7 @@ public class GeneticsRequestWatcherServiceTests
             {
                 var current = Interlocked.Increment(ref _current);
                 UpdateMax(current);
-                _started[uniqueGeneId.Value].TrySetResult();
+                Gate(uniqueGeneId).TrySetResult();
                 try
                 {
                     await _release.Task.ConfigureAwait(false);

--- a/src/modules/test/Eryph.Modules.GenePoolModule.Test/Genetics/GeneticsRequestWatcherServiceTests.cs
+++ b/src/modules/test/Eryph.Modules.GenePoolModule.Test/Genetics/GeneticsRequestWatcherServiceTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Dbosoft.Rebus.Operations;
+using Eryph.ConfigModel;
+using Eryph.Core.Genetics;
+using Eryph.Core.Sys;
+using Eryph.Messages.Genes.Commands;
+using Eryph.Modules.GenePool.Genetics;
+using LanguageExt;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SimpleInjector;
+using SimpleInjector.Lifestyles;
+
+using static LanguageExt.Prelude;
+
+using GenesetTagManifestData = Eryph.GenePool.Model.GenesetTagManifestData;
+
+namespace Eryph.Modules.GenePoolModule.Test.Genetics;
+
+public class GeneticsRequestWatcherServiceTests
+{
+    private static readonly GeneHash GeneHash1 = GeneHash.New(
+        "sha256:a8a2f6ebe286697c527eb35a58b5539532e9b3ae3b64d4eb0a46fb657b41562c");
+
+    private static readonly GeneHash GeneHash2 = GeneHash.New(
+        "sha256:b8a2f6ebe286697c527eb35a58b5539532e9b3ae3b64d4eb0a46fb657b41562c");
+
+    private static readonly UniqueGeneIdentifier Gene1 = new(
+        GeneType.Volume,
+        GeneIdentifier.New("gene:acme/acme-os/1.0:sda"),
+        Architecture.New("hyperv/amd64"));
+
+    private static readonly UniqueGeneIdentifier Gene2 = new(
+        GeneType.Volume,
+        GeneIdentifier.New("gene:acme/acme-os/1.0:sdb"),
+        Architecture.New("hyperv/amd64"));
+
+    /// <summary>
+    /// Regression test for https://github.com/eryph-org/eryph/issues/367.
+    /// A long-running download for one gene must not block the download of a
+    /// different gene. Both fake downloads block until released; if the watcher
+    /// processed requests serially, the second gene would never start and the
+    /// test would time out.
+    /// </summary>
+    [Fact]
+    public async Task Requests_for_different_genes_are_processed_concurrently()
+    {
+        using var container = CreateContainer();
+        var provider = new BlockingGeneProvider();
+        provider.RegisterGene(Gene1);
+        provider.RegisterGene(Gene2);
+        container.RegisterInstance<IGeneProvider>(provider);
+
+        var registry = new GeneRequestRegistry(container, NullLogger.Instance);
+        var service = new GeneticsRequestWatcherService(container, registry, NullLogger.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            await registry.EnqueueGeneRequest(CreateTask(Gene1, GeneHash1), CancellationToken.None);
+            await registry.EnqueueGeneRequest(CreateTask(Gene2, GeneHash2), CancellationToken.None);
+
+            var bothStarted = Task.WhenAll(
+                provider.Started(Gene1),
+                provider.Started(Gene2));
+            var finished = await Task.WhenAny(bothStarted, Task.Delay(TimeSpan.FromSeconds(10)));
+
+            finished.Should().BeSameAs(bothStarted,
+                "a download for one gene must not block the download of a different gene");
+            provider.MaxConcurrency.Should().BeGreaterThanOrEqualTo(2);
+        }
+        finally
+        {
+            // Unblock the workers so the background service can shut down.
+            provider.ReleaseAll();
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    private static Container CreateContainer()
+    {
+        var container = new Container();
+        container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+        // The registry resolves ITaskMessaging from a scope to report progress
+        // and completion. A loose mock returns completed tasks for these calls.
+        container.RegisterInstance(new Mock<ITaskMessaging>().Object);
+        return container;
+    }
+
+    private static OperationTask<PrepareGeneCommand> CreateTask(
+        UniqueGeneIdentifier geneId,
+        GeneHash geneHash) =>
+        new(
+            new PrepareGeneCommand
+            {
+                Id = geneId,
+                Hash = geneHash,
+                AgentName = "test",
+            },
+            operationId: Guid.NewGuid(),
+            initiatingTaskId: Guid.NewGuid(),
+            taskId: Guid.NewGuid(),
+            created: DateTimeOffset.UtcNow);
+
+    /// <summary>
+    /// A fake gene provider whose downloads block until <see cref="ReleaseAll"/>
+    /// is called. It records the maximum number of downloads running at the same
+    /// time so the test can assert that requests are processed concurrently.
+    /// </summary>
+    private sealed class BlockingGeneProvider : IGeneProvider
+    {
+        private readonly ConcurrentDictionary<string, TaskCompletionSource> _started = new();
+        private readonly TaskCompletionSource _release = new();
+        private int _current;
+        private int _maxConcurrency;
+
+        public int MaxConcurrency => Volatile.Read(ref _maxConcurrency);
+
+        public void RegisterGene(UniqueGeneIdentifier geneId) =>
+            _started[geneId.Value] = new TaskCompletionSource();
+
+        public Task Started(UniqueGeneIdentifier geneId) => _started[geneId.Value].Task;
+
+        public void ReleaseAll() => _release.TrySetResult();
+
+        public Aff<CancelRt, PrepareGeneResponse> ProvideGene(
+            UniqueGeneIdentifier uniqueGeneId,
+            GeneHash geneHash,
+            Func<string, int, Task> reportProgress) =>
+            Aff<CancelRt, PrepareGeneResponse>(async _ =>
+            {
+                var current = Interlocked.Increment(ref _current);
+                UpdateMax(current);
+                _started[uniqueGeneId.Value].TrySetResult();
+                try
+                {
+                    await _release.Task.ConfigureAwait(false);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref _current);
+                }
+
+                return new PrepareGeneResponse { RequestedGene = uniqueGeneId };
+            });
+
+        private void UpdateMax(int current)
+        {
+            int observed;
+            while (current > (observed = Volatile.Read(ref _maxConcurrency)))
+            {
+                if (Interlocked.CompareExchange(ref _maxConcurrency, current, observed) == observed)
+                    return;
+            }
+        }
+
+        public Aff<CancelRt, string> GetGeneContent(
+            UniqueGeneIdentifier uniqueGeneId,
+            GeneHash geneHash) =>
+            throw new NotSupportedException();
+
+        public Aff<CancelRt, GenesetTagManifestData> GetGeneSetManifest(
+            GeneSetIdentifier geneSetId) =>
+            throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Fixes #367.

The gene request watcher (`GeneticsRequestWatcherService`) processed downloads one at a time via a single loop, so a slow volume download (e.g. win2022) blocked every other catlet's gene fetch.

It now runs `GenePoolConstants.MaxConcurrentGeneRequests` (3) parallel worker loops, so requests for *different* genes download in parallel. Requests for the *same* gene are still deduplicated into a single download by `GeneRequestRegistry`, which already supported concurrent consumers.

### Concurrency safety

`LocalGenePoolSource` already uses two levels of `FileDistributedLock`, and both are what make concurrent processing safe:

- **Per-tag (geneset) lock** (`geneset-tag.lock`) guards `geneset-tag.json` and the shared `genes.json` merged-genes list.
- **Per-gene lock** (`{geneName}.lock`) guards each gene's own files (download/merge/extract) and per-gene-hash temp dirs / per-part-hash temp files.

This was verified to compose correctly under the new concurrency, including for two genes of the *same* geneset:

- Lock ordering is always gene → geneset (no path takes the reverse), so no lock-ordering deadlock.
- The geneset lock is never re-acquired while already held (`FileDistributedLock` is not reentrant); within a merge it is taken/released sequentially for the remove and add steps.
- The `genes.json` read-modify-write happens entirely inside the geneset lock and commutes across different gene hashes, so concurrent merges cannot lose an update.
- No lock is held across the long network download.

**Caveat (out of scope here):** `FileDistributedLock` is per-host, so it does not coordinate across cluster nodes sharing a genepool, and writes still use `FileShare.None`. That robustness work is tracked separately in #140.

### Test

Adds a regression test that drives the watcher with two blocking fake downloads for different genes; it times out under serial processing and passes only when they run concurrently.