### PR TITLE
Add network adapters that are not attached to a network (#309)

### DIFF
--- a/src/core/src/Eryph.VmManagement.HyperV/Converging/ConvergeNetworkAdapters.cs
+++ b/src/core/src/Eryph.VmManagement.HyperV/Converging/ConvergeNetworkAdapters.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Eryph.ConfigModel;
 using Eryph.ConfigModel.Catlets;
 using Eryph.Core;
+using Eryph.Resources.Machines;
 using Eryph.VmManagement.Data;
 using Eryph.VmManagement.Data.Full;
 using Eryph.VmManagement.Networking;
@@ -31,17 +32,30 @@ public class ConvergeNetworkAdapters(ConvergeContext context)
         select unit;
 
     private Either<Error, Seq<PhysicalAdapterConfig>> PrepareAdapterConfigs() =>
-        from adapterConfigs in Context.Config.Networks.ToSeq()
+        // The adapters are driven by the union of the configured networks and
+        // the configured network adapters. Adapters which are not attached to
+        // any network are converged as disconnected Hyper-V adapters.
+        from adapterNames in (Context.Config.Networks.ToSeq().Map(n => n.AdapterName)
+                + Context.Config.NetworkAdapters.ToSeq().Map(a => a.Name))
+            .Map(CatletNetworkAdapterName.NewEither)
+            .Sequence()
+            .Map(names => names.Distinct())
+        from adapterConfigs in adapterNames
             .Map(PrepareAdapterConfig)
             .Sequence()
         select adapterConfigs;
 
     private Either<Error, PhysicalAdapterConfig> PrepareAdapterConfig(
-        CatletNetworkConfig networkConfig) =>
-        from adapterName in CatletNetworkAdapterName.NewEither(networkConfig.AdapterName)
-        from settings in Context.NetworkSettings.ToSeq()
+        CatletNetworkAdapterName adapterName) =>
+        Context.NetworkSettings.ToSeq()
             .Find(s => CatletNetworkAdapterName.NewOption(s.AdapterName) == adapterName)
-            .ToEither(Error.New($"Could not find network settings for adapter {networkConfig.AdapterName}"))
+            .Match(
+                Some: settings => PrepareConnectedAdapterConfig(adapterName, settings),
+                None: () => PrepareDisconnectedAdapterConfig(adapterName));
+
+    private Either<Error, PhysicalAdapterConfig> PrepareConnectedAdapterConfig(
+        CatletNetworkAdapterName adapterName,
+        MachineNetworkSettings settings) =>
         from switchName in Context.HostInfo.FindSwitchName(settings.NetworkProviderName)
             .ToEither(Error.New($"Could not find network provider '{settings.NetworkProviderName}' on host."))
         select new PhysicalAdapterConfig(
@@ -53,6 +67,28 @@ public class ConvergeNetworkAdapters(ConvergeContext context)
             settings.MacAddressSpoofing,
             settings.DhcpGuard,
             settings.RouterGuard);
+
+    // An adapter which is not attached to any network is converged as a
+    // disconnected Hyper-V adapter. It has no virtual switch and no OVS port.
+    // The MAC address is taken from the catlet config (it is generated during
+    // instantiation and persisted as part of the inventoried catlet config).
+    private Either<Error, PhysicalAdapterConfig> PrepareDisconnectedAdapterConfig(
+        CatletNetworkAdapterName adapterName) =>
+        from adapterConfig in Context.Config.NetworkAdapters.ToSeq()
+            .Find(a => CatletNetworkAdapterName.NewOption(a.Name) == adapterName)
+            .ToEither(Error.New($"Could not find the configuration for adapter '{adapterName}'."))
+        from macAddress in EryphMacAddress.NewEither(adapterConfig.MacAddress)
+            .MapLeft(e => Error.New(
+                $"The MAC address of the adapter '{adapterName}' which is not attached to any network is invalid.", e))
+        select new PhysicalAdapterConfig(
+            adapterName.Value,
+            None,
+            macAddress.Value,
+            None,
+            None,
+            None,
+            None,
+            None);
 
     private EitherAsync<Error, Seq<TypedPsObject<VMNetworkAdapter>>> GetVmAdapters(
         TypedPsObject<VirtualMachineInfo> vmInfo) =>
@@ -111,39 +147,66 @@ public class ConvergeNetworkAdapters(ConvergeContext context)
         PhysicalAdapterConfig adapterConfig,
         TypedPsObject<VirtualMachineInfo> vmInfo) =>
         from _1 in Context.ReportProgressAsync($"Add Network Adapter: {adapterConfig.AdapterName}")
-        let command = PsCommandBuilder.Create()
+        let baseCommand = PsCommandBuilder.Create()
             .AddCommand("Add-VMNetworkAdapter")
             .AddParameter("VM", vmInfo.PsObject)
             .AddParameter("Name", adapterConfig.AdapterName)
             .AddParameter("StaticMacAddress", adapterConfig.MacAddress)
-            .AddParameter("SwitchName", adapterConfig.SwitchName)
+        // When the adapter is not attached to any network, it is created as a
+        // disconnected adapter, i.e. without a virtual switch.
+        let command = adapterConfig.SwitchName
+            .Map(switchName => baseCommand.AddParameter("SwitchName", switchName))
+            .IfNone(baseCommand)
             .AddParameter("Passthru")
         from optionalCreatedAdapter in Context.Engine.GetObjectAsync<VMNetworkAdapter>(command)
         from createdAdapter in optionalCreatedAdapter.ToEitherAsync(
             Error.New("Failed to create network adapter"))
-        // Sometimes, it takes a moment until we can actually read the OVS port name
-        // from a newly created adapter. In the end, we need to access the
-        // Msvm_EthernetPortAllocationSettingData for that adapter via WMI.
-        from _2 in WaitForPortName(createdAdapter.Value.Id).Run().ToEitherAsync()
-        from _3 in Context.PortManager.SetPortName(createdAdapter.Value.Id, adapterConfig.PortName)
-        from _4 in ConvergeSecuritySettings(createdAdapter, adapterConfig)
+        // A disconnected adapter has no OVS port.
+        from _2 in adapterConfig.PortName.Match(
+            // Sometimes, it takes a moment until we can actually read the OVS port name
+            // from a newly created adapter. In the end, we need to access the
+            // Msvm_EthernetPortAllocationSettingData for that adapter via WMI.
+            Some: portName =>
+                from __ in WaitForPortName(createdAdapter.Value.Id).Run().ToEitherAsync()
+                from ___ in Context.PortManager.SetPortName(createdAdapter.Value.Id, portName)
+                select unit,
+            None: () => RightAsync<Error, Unit>(unit))
+        from _3 in ConvergeSecuritySettings(createdAdapter, adapterConfig)
         select unit;
 
     private EitherAsync<Error, Unit> UpdateAdapter(
         PhysicalAdapterConfig adapterConfig,
         TypedPsObject<VMNetworkAdapter> adapter) =>
-        from currentPortName in Context.PortManager.GetPortName(adapter.Value.Id)
-        from _1 in currentPortName == adapterConfig.PortName
-            ? RightAsync<Error, Unit>(unit)
-            : Context.PortManager.SetPortName(adapter.Value.Id, adapterConfig.PortName)
+        // A disconnected adapter has no OVS port. We leave any existing port name
+        // untouched as the port is gone once the adapter is disconnected.
+        from _1 in adapterConfig.PortName.Match(
+            Some: portName =>
+                from currentPortName in Context.PortManager.GetPortName(adapter.Value.Id)
+                from __ in currentPortName == portName
+                    ? RightAsync<Error, Unit>(unit)
+                    : Context.PortManager.SetPortName(adapter.Value.Id, portName)
+                select unit,
+            None: () => RightAsync<Error, Unit>(unit))
         from _2 in adapter.Value.MacAddress == adapterConfig.MacAddress
             ? RightAsync<Error, Unit>(unit)
             : UpdateMacAddress(adapter, adapterConfig.MacAddress)
         from _3 in ConvergeSecuritySettings(adapter, adapterConfig)
-        from _4 in adapter.Value.Connected && adapter.Value.SwitchName == adapterConfig.SwitchName
-            ? RightAsync<Error, Unit>(unit)
-            : ConnectAdapter(adapter, adapterConfig)
+        from _4 in ConvergeConnection(adapter, adapterConfig)
         select unit;
+
+    private EitherAsync<Error, Unit> ConvergeConnection(
+        TypedPsObject<VMNetworkAdapter> adapter,
+        PhysicalAdapterConfig adapterConfig) =>
+        adapterConfig.SwitchName.Match(
+            Some: switchName =>
+                adapter.Value.Connected && adapter.Value.SwitchName == switchName
+                    ? RightAsync<Error, Unit>(unit)
+                    : ConnectAdapter(adapter, switchName, adapterConfig.NetworkName),
+            // The adapter is not attached to any network. Disconnect it from
+            // its virtual switch if necessary.
+            None: () => adapter.Value.Connected
+                ? DisconnectAdapter(adapter)
+                : RightAsync<Error, Unit>(unit));
 
     private EitherAsync<Error, Unit> UpdateMacAddress(
         TypedPsObject<VMNetworkAdapter> adapter,
@@ -163,11 +226,11 @@ public class ConvergeNetworkAdapters(ConvergeContext context)
         let currentMacAddressSpoofing = adapter.Value.MacAddressSpoofing == OnOffState.On
         let currentRouterGuard = adapter.Value.RouterGuard == OnOffState.On
         let currentDhcpGuard = adapter.Value.DhcpGuard == OnOffState.On
-        let changedMacAddressSpoofing = Optional(adapterConfig.MacAddressSpoofing)
+        let changedMacAddressSpoofing = adapterConfig.MacAddressSpoofing
             .Filter(v => v != currentMacAddressSpoofing)
-        let changedDhcpGuard = Optional(adapterConfig.DhcpGuard)
+        let changedDhcpGuard = adapterConfig.DhcpGuard
             .Filter(v => v != currentDhcpGuard)
-        let changedRouterGuard = Optional(adapterConfig.RouterGuard)
+        let changedRouterGuard = adapterConfig.RouterGuard
             .Filter(v => v != currentRouterGuard)
         from __ in changedMacAddressSpoofing.IsSome || changedDhcpGuard.IsSome || changedRouterGuard.IsSome
             ? UpdateSecuritySettings(
@@ -204,13 +267,24 @@ public class ConvergeNetworkAdapters(ConvergeContext context)
 
     private EitherAsync<Error, Unit> ConnectAdapter(
         TypedPsObject<VMNetworkAdapter> adapter,
-        PhysicalAdapterConfig adapterConfig) =>
+        string switchName,
+        Option<string> networkName) =>
         from _ in Context.ReportProgressAsync(
-            $"Connected Network Adapter {adapter.Value.Name} to network {adapterConfig.NetworkName}")
+            $"Connected Network Adapter {adapter.Value.Name} to network {networkName.IfNone("")}")
         let command = PsCommandBuilder.Create()
             .AddCommand("Connect-VMNetworkAdapter")
             .AddParameter("VMNetworkAdapter", adapter.PsObject)
-            .AddParameter("SwitchName", adapterConfig.SwitchName)
+            .AddParameter("SwitchName", switchName)
+        from __ in Context.Engine.RunAsync(command)
+        select unit;
+
+    private EitherAsync<Error, Unit> DisconnectAdapter(
+        TypedPsObject<VMNetworkAdapter> adapter) =>
+        from _ in Context.ReportProgressAsync(
+            $"Disconnected Network Adapter {adapter.Value.Name}")
+        let command = PsCommandBuilder.Create()
+            .AddCommand("Disconnect-VMNetworkAdapter")
+            .AddParameter("VMNetworkAdapter", adapter.PsObject)
         from __ in Context.Engine.RunAsync(command)
         select unit;
 
@@ -228,11 +302,15 @@ public class ConvergeNetworkAdapters(ConvergeContext context)
 
     private sealed record PhysicalAdapterConfig(
         string AdapterName,
-        string SwitchName,
+        // The switch, port name and network name are not set for adapters
+        // which are not attached to any network (disconnected adapters).
+        Option<string> SwitchName,
         string MacAddress,
-        string PortName,
-        string NetworkName,
-        bool MacAddressSpoofing,
-        bool DhcpGuard,
-        bool RouterGuard);
+        Option<string> PortName,
+        Option<string> NetworkName,
+        // The security settings are only managed for adapters which are
+        // attached to a network. For disconnected adapters they are None.
+        Option<bool> MacAddressSpoofing,
+        Option<bool> DhcpGuard,
+        Option<bool> RouterGuard);
 }

--- a/src/core/src/Eryph.VmManagement.HyperV/Converging/ConvergeNetworkAdapters.cs
+++ b/src/core/src/Eryph.VmManagement.HyperV/Converging/ConvergeNetworkAdapters.cs
@@ -77,7 +77,14 @@ public class ConvergeNetworkAdapters(ConvergeContext context)
         from adapterConfig in Context.Config.NetworkAdapters.ToSeq()
             .Find(a => CatletNetworkAdapterName.NewOption(a.Name) == adapterName)
             .ToEither(Error.New($"Could not find the configuration for adapter '{adapterName}'."))
-        from macAddress in EryphMacAddress.NewEither(adapterConfig.MacAddress)
+        // The MAC address is assigned when the catlet config is instantiated. It
+        // should always be present here. We guard explicitly so a missing MAC does
+        // not surface as a confusing 'invalid MAC address' error.
+        from rawMacAddress in Optional(adapterConfig.MacAddress).Filter(notEmpty)
+            .ToEither(() => Error.New(
+                $"The adapter '{adapterName}' is not attached to any network and has no MAC address. "
+                + "The catlet configuration might not have been instantiated correctly."))
+        from macAddress in EryphMacAddress.NewEither(rawMacAddress)
             .MapLeft(e => Error.New(
                 $"The MAC address of the adapter '{adapterName}' which is not attached to any network is invalid.", e))
         select new PhysicalAdapterConfig(
@@ -177,8 +184,11 @@ public class ConvergeNetworkAdapters(ConvergeContext context)
     private EitherAsync<Error, Unit> UpdateAdapter(
         PhysicalAdapterConfig adapterConfig,
         TypedPsObject<VMNetworkAdapter> adapter) =>
-        // A disconnected adapter has no OVS port. We leave any existing port name
-        // untouched as the port is gone once the adapter is disconnected.
+        // A disconnected adapter has no OVS port. Any stale OVS port name (WMI
+        // metadata) is left in place: it is deterministic per adapter
+        // (ovs_<catletId>_<adapter>), so the same name is reapplied when a network
+        // is attached again. While disconnected the adapter is on no switch, hence
+        // the leftover name is inert.
         from _1 in adapterConfig.PortName.Match(
             Some: portName =>
                 from currentPortName in Context.PortManager.GetPortName(adapter.Value.Id)

--- a/src/core/src/Eryph.VmManagement.HyperV/Converging/ConvergeNetworkAdapters.cs
+++ b/src/core/src/Eryph.VmManagement.HyperV/Converging/ConvergeNetworkAdapters.cs
@@ -51,7 +51,18 @@ public class ConvergeNetworkAdapters(ConvergeContext context)
             .Find(s => CatletNetworkAdapterName.NewOption(s.AdapterName) == adapterName)
             .Match(
                 Some: settings => PrepareConnectedAdapterConfig(adapterName, settings),
-                None: () => PrepareDisconnectedAdapterConfig(adapterName));
+                // An adapter is only converged as disconnected when it is not attached
+                // to any network. When it is attached to a network but has no network
+                // settings, the settings generation is incomplete. We fail instead of
+                // silently disconnecting the adapter.
+                None: () => IsAttachedToNetwork(adapterName)
+                    ? Left<Error, PhysicalAdapterConfig>(Error.New(
+                        $"Could not find the network settings for adapter '{adapterName}' which is attached to a network."))
+                    : PrepareDisconnectedAdapterConfig(adapterName));
+
+    private bool IsAttachedToNetwork(CatletNetworkAdapterName adapterName) =>
+        Context.Config.Networks.ToSeq()
+            .Exists(n => CatletNetworkAdapterName.NewOption(n.AdapterName) == adapterName);
 
     private Either<Error, PhysicalAdapterConfig> PrepareConnectedAdapterConfig(
         CatletNetworkAdapterName adapterName,

--- a/src/core/test/Eryph.VMManagement.HyperV.Test/ConvergeNetworkAdaptersTests.cs
+++ b/src/core/test/Eryph.VMManagement.HyperV.Test/ConvergeNetworkAdaptersTests.cs
@@ -352,6 +352,9 @@ public class ConvergeNetworkAdaptersTests
 
         result.Should().BeRight();
         adapterAdded.Should().BeTrue();
+        // The existing connected adapter eth0 already has the correct port, so its
+        // OVS port name must not be rewritten.
+        _portManagerMock.Verify(m => m.SetPortName("eth0Id", It.IsAny<string>()), Times.Never);
     }
 
     [Fact]
@@ -533,6 +536,96 @@ public class ConvergeNetworkAdaptersTests
 
         result.Should().BeRight();
         adapterDisconnected.Should().BeTrue();
+        // A disconnected adapter has no OVS port, so the port manager must not be touched.
+        _portManagerMock.Verify(m => m.GetPortName(It.IsAny<string>()), Times.Never);
+        _portManagerMock.Verify(m => m.SetPortName(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Converge_NetworkAddedToDisconnectedAdapter_ConnectsAdapter()
+    {
+        var macAddress = EryphMacAddress.New("00:02:04:06:08:10").Value;
+
+        // The adapter currently exists in Hyper-V but is not connected to any switch.
+        var disconnectedAdapter = _fixture.Engine.ToPsObject(new VMNetworkAdapter
+        {
+            Id = "eth0Id",
+            Name = "eth0",
+            MacAddress = macAddress,
+            SwitchName = "",
+            Connected = false,
+            DhcpGuard = OnOffState.Off,
+            RouterGuard = OnOffState.Off,
+            MacAddressSpoofing = OnOffState.Off,
+        });
+
+        _fixture.Config.Networks =
+        [
+            new CatletNetworkConfig
+            {
+                AdapterName = "eth0",
+            },
+        ];
+        _fixture.Config.NetworkAdapters =
+        [
+            new CatletNetworkAdapterConfig { Name = "eth0" },
+        ];
+        _fixture.NetworkSettings =
+        [
+            new MachineNetworkSettings
+            {
+                AdapterName = "eth0",
+                // The MAC address is preserved when the adapter is attached to a network.
+                MacAddress = macAddress,
+                PortName = "port0",
+                NetworkProviderName = "default",
+            },
+        ];
+
+        _fixture.Engine.GetObjectCallback = (_, command) =>
+        {
+            if (command.ToString().StartsWith("Get-VMNetworkAdapter"))
+            {
+                return Seq1(_fixture.Engine.ConvertPsObject(disconnectedAdapter));
+            }
+
+            if (command.ToString().StartsWith("Get-VM"))
+            {
+                return Seq1(_fixture.Engine.ConvertPsObject(_vmInfo));
+            }
+
+            return Error.New($"Unexpected command: {command}.");
+        };
+
+        var adapterConnected = false;
+        _fixture.Engine.RunCallback = command =>
+        {
+            if (command.ToString().StartsWith("Connect-VMNetworkAdapter"))
+            {
+                command.ShouldBeCommand("Connect-VMNetworkAdapter")
+                    .ShouldBeParam("VMNetworkAdapter", disconnectedAdapter.PsObject)
+                    .ShouldBeParam("SwitchName", EryphConstants.OverlaySwitchName)
+                    .ShouldBeComplete();
+                adapterConnected = true;
+                return unit;
+            }
+
+            return Error.New($"Unexpected command {command}");
+        };
+
+        // The adapter has no OVS port yet.
+        _portManagerMock.Setup(m => m.GetPortName("eth0Id"))
+            .Returns(RightAsync<Error, Option<string>>(Some("")));
+        _portManagerMock.Setup(m => m.SetPortName("eth0Id", "port0"))
+            .Returns(RightAsync<Error, Unit>(unit))
+            .Verifiable();
+
+        var convergeTask = new ConvergeNetworkAdapters(_fixture.Context);
+        var result = await convergeTask.Converge(_vmInfo);
+
+        result.Should().BeRight();
+        adapterConnected.Should().BeTrue();
+        _portManagerMock.Verify();
     }
 
     [Fact]

--- a/src/core/test/Eryph.VMManagement.HyperV.Test/ConvergeNetworkAdaptersTests.cs
+++ b/src/core/test/Eryph.VMManagement.HyperV.Test/ConvergeNetworkAdaptersTests.cs
@@ -629,6 +629,30 @@ public class ConvergeNetworkAdaptersTests
     }
 
     [Fact]
+    public async Task Converge_AdapterAttachedToNetworkButSettingsMissing_Fails()
+    {
+        // eth0 is attached to a network but no network settings were generated for it.
+        // This must fail rather than silently converging eth0 as a disconnected adapter.
+        _fixture.Config.Networks =
+        [
+            new CatletNetworkConfig
+            {
+                AdapterName = "eth0",
+            },
+        ];
+        _fixture.Config.NetworkAdapters =
+        [
+            new CatletNetworkAdapterConfig { Name = "eth0" },
+        ];
+        _fixture.NetworkSettings = [];
+
+        var convergeTask = new ConvergeNetworkAdapters(_fixture.Context);
+        var result = await convergeTask.Converge(_vmInfo);
+
+        result.Should().BeLeft().Which.Message.Should().Contain("eth0");
+    }
+
+    [Fact]
     public async Task Converge_AdapterNotConfigured_RemovesAdapter()
     {
         bool adapterRemoved = false;

--- a/src/core/test/Eryph.VMManagement.HyperV.Test/ConvergeNetworkAdaptersTests.cs
+++ b/src/core/test/Eryph.VMManagement.HyperV.Test/ConvergeNetworkAdaptersTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Dbosoft.OVN.Windows;
+using Eryph.ConfigModel;
 using Eryph.ConfigModel.Catlets;
 using Eryph.Core;
 using Eryph.Core.Network;
@@ -277,6 +278,261 @@ public class ConvergeNetworkAdaptersTests
         adapterSettingsUpdated.Should().BeTrue();
         adapterConnected.Should().BeTrue();
         _portManagerMock.Verify();
+    }
+
+    [Fact]
+    public async Task Converge_AdapterWithoutNetwork_AddsDisconnectedAdapter()
+    {
+        var eth1MacAddress = EryphMacAddress.New("00:12:14:16:18:20").Value;
+
+        _fixture.Config.Networks =
+        [
+            new CatletNetworkConfig
+            {
+                AdapterName = "eth0",
+            },
+        ];
+        _fixture.Config.NetworkAdapters =
+        [
+            new CatletNetworkAdapterConfig { Name = "eth0" },
+            new CatletNetworkAdapterConfig { Name = "eth1", MacAddress = "00:12:14:16:18:20" },
+        ];
+        _fixture.NetworkSettings =
+        [
+            new MachineNetworkSettings
+            {
+                AdapterName = "eth0",
+                MacAddress = "00:02:04:06:08:10",
+                PortName = "port0",
+                NetworkProviderName = "default",
+            },
+        ];
+
+        var adapterAdded = false;
+
+        var newAdapter = _fixture.Engine.ToPsObject<object>(new VMNetworkAdapter
+        {
+            Id = "eth1Id",
+            Name = "eth1",
+            MacAddressSpoofing = OnOffState.Off,
+            RouterGuard = OnOffState.Off,
+            DhcpGuard = OnOffState.Off,
+        });
+
+        _fixture.Engine.GetObjectCallback = (_, command) =>
+        {
+            if (command.ToString().StartsWith("Get-VMNetworkAdapter"))
+            {
+                return Seq1(_fixture.Engine.ConvertPsObject(_existingAdapter));
+            }
+
+            if (command.ToString().StartsWith("Get-VM"))
+            {
+                return Seq1(_fixture.Engine.ConvertPsObject(_vmInfo));
+            }
+
+            if (command.ToString().StartsWith("Add-VMNetworkAdapter"))
+            {
+                // A disconnected adapter is added without a virtual switch.
+                command.ShouldBeCommand("Add-VMNetworkAdapter")
+                    .ShouldBeParam("VM", _vmInfo.PsObject)
+                    .ShouldBeParam("Name", "eth1")
+                    .ShouldBeParam("StaticMacAddress", eth1MacAddress)
+                    .ShouldBeFlag("Passthru")
+                    .ShouldBeComplete();
+                adapterAdded = true;
+                return Seq1(newAdapter);
+            }
+
+            return Error.New($"Unexpected command: {command}.");
+        };
+
+        var convergeTask = new ConvergeNetworkAdapters(_fixture.Context);
+        var result = await convergeTask.Converge(_vmInfo);
+
+        result.Should().BeRight();
+        adapterAdded.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Converge_FlatNetworkAndAdapterWithoutNetwork_ConvergesBoth()
+    {
+        var eth1MacAddress = EryphMacAddress.New("00:22:24:26:28:30").Value;
+
+        // eth0 is attached to a flat network, eth1 is not attached to any network.
+        _fixture.Config.Networks =
+        [
+            new CatletNetworkConfig
+            {
+                AdapterName = "eth0",
+            },
+        ];
+        _fixture.Config.NetworkAdapters =
+        [
+            new CatletNetworkAdapterConfig { Name = "eth0" },
+            new CatletNetworkAdapterConfig { Name = "eth1", MacAddress = "00:22:24:26:28:30" },
+        ];
+        _fixture.NetworkSettings =
+        [
+            new MachineNetworkSettings
+            {
+                AdapterName = "eth0",
+                MacAddress = "00:12:14:16:18:20",
+                PortName = "port1",
+                NetworkProviderName = "flat",
+                MacAddressSpoofing = true,
+                DhcpGuard = true,
+                RouterGuard = true,
+            },
+        ];
+
+        var disconnectedAdapterAdded = false;
+        var flatAdapterConnected = false;
+
+        var newAdapter = _fixture.Engine.ToPsObject<object>(new VMNetworkAdapter
+        {
+            Id = "eth1Id",
+            Name = "eth1",
+            MacAddressSpoofing = OnOffState.Off,
+            RouterGuard = OnOffState.Off,
+            DhcpGuard = OnOffState.Off,
+        });
+
+        _fixture.Engine.GetObjectCallback = (_, command) =>
+        {
+            if (command.ToString().StartsWith("Get-VMNetworkAdapter"))
+            {
+                return Seq1(_fixture.Engine.ConvertPsObject(_existingAdapter));
+            }
+
+            if (command.ToString().StartsWith("Get-VM"))
+            {
+                return Seq1(_fixture.Engine.ConvertPsObject(_vmInfo));
+            }
+
+            if (command.ToString().StartsWith("Add-VMNetworkAdapter"))
+            {
+                // The disconnected adapter is added without a virtual switch.
+                command.ShouldBeCommand("Add-VMNetworkAdapter")
+                    .ShouldBeParam("VM", _vmInfo.PsObject)
+                    .ShouldBeParam("Name", "eth1")
+                    .ShouldBeParam("StaticMacAddress", eth1MacAddress)
+                    .ShouldBeFlag("Passthru")
+                    .ShouldBeComplete();
+                disconnectedAdapterAdded = true;
+                return Seq1(newAdapter);
+            }
+
+            return Error.New($"Unexpected command: {command}.");
+        };
+
+        _fixture.Engine.RunCallback = command =>
+        {
+            if (command.ToString().Contains("StaticMacAddress"))
+            {
+                command.ShouldBeCommand("Set-VMNetworkAdapter")
+                    .ShouldBeParam("VMNetworkAdapter", _existingAdapter.PsObject)
+                    .ShouldBeParam("StaticMacAddress", "00:12:14:16:18:20")
+                    .ShouldBeComplete();
+                return unit;
+            }
+
+            if (command.ToString().Contains("MacAddressSpoofing"))
+            {
+                command.ShouldBeCommand("Set-VMNetworkAdapter")
+                    .ShouldBeParam("VMNetworkAdapter", _existingAdapter.PsObject)
+                    .ShouldBeParam("MacAddressSpoofing", OnOffState.On)
+                    .ShouldBeParam("DhcpGuard", OnOffState.On)
+                    .ShouldBeParam("RouterGuard", OnOffState.On)
+                    .ShouldBeComplete();
+                return unit;
+            }
+
+            if (command.ToString().StartsWith("Connect-VMNetworkAdapter"))
+            {
+                command.ShouldBeCommand("Connect-VMNetworkAdapter")
+                    .ShouldBeParam("VMNetworkAdapter", _existingAdapter.PsObject)
+                    .ShouldBeParam("SwitchName", "test-switch")
+                    .ShouldBeComplete();
+                flatAdapterConnected = true;
+                return unit;
+            }
+
+            return Error.New($"Unexpected command {command}");
+        };
+
+        _portManagerMock.Setup(m => m.SetPortName("eth0Id", "port1"))
+            .Returns(RightAsync<Error, Unit>(unit))
+            .Verifiable();
+
+        var convergeTask = new ConvergeNetworkAdapters(_fixture.Context);
+        var result = await convergeTask.Converge(_vmInfo);
+
+        result.Should().BeRight();
+        disconnectedAdapterAdded.Should().BeTrue();
+        flatAdapterConnected.Should().BeTrue();
+        _portManagerMock.Verify();
+    }
+
+    [Fact]
+    public async Task Converge_NetworkRemovedFromAdapter_DisconnectsAdapter()
+    {
+        var macAddress = EryphMacAddress.New("00:02:04:06:08:10").Value;
+        var connectedAdapter = _fixture.Engine.ToPsObject(new VMNetworkAdapter
+        {
+            Id = "eth0Id",
+            Name = "eth0",
+            MacAddress = macAddress,
+            SwitchName = EryphConstants.OverlaySwitchName,
+            Connected = true,
+            DhcpGuard = OnOffState.Off,
+            RouterGuard = OnOffState.Off,
+            MacAddressSpoofing = OnOffState.Off,
+        });
+
+        // The adapter is still configured but is no longer attached to any network.
+        _fixture.Config.Networks = [];
+        _fixture.Config.NetworkAdapters =
+        [
+            new CatletNetworkAdapterConfig { Name = "eth0", MacAddress = "00:02:04:06:08:10" },
+        ];
+        _fixture.NetworkSettings = [];
+
+        _fixture.Engine.GetObjectCallback = (_, command) =>
+        {
+            if (command.ToString().StartsWith("Get-VMNetworkAdapter"))
+            {
+                return Seq1(_fixture.Engine.ConvertPsObject(connectedAdapter));
+            }
+
+            if (command.ToString().StartsWith("Get-VM"))
+            {
+                return Seq1(_fixture.Engine.ConvertPsObject(_vmInfo));
+            }
+
+            return Error.New($"Unexpected command: {command}.");
+        };
+
+        var adapterDisconnected = false;
+        _fixture.Engine.RunCallback = command =>
+        {
+            if (command.ToString().StartsWith("Disconnect-VMNetworkAdapter"))
+            {
+                command.ShouldBeCommand("Disconnect-VMNetworkAdapter")
+                    .ShouldBeParam("VMNetworkAdapter", connectedAdapter.PsObject)
+                    .ShouldBeComplete();
+                adapterDisconnected = true;
+                return unit;
+            }
+
+            return Error.New($"Unexpected command {command}");
+        };
+
+        var convergeTask = new ConvergeNetworkAdapters(_fixture.Context);
+        var result = await convergeTask.Converge(_vmInfo);
+
+        result.Should().BeRight();
+        adapterDisconnected.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #309.

A `network_adapters` entry without a matching `networks` entry was silently dropped, so the adapter never appeared on the VM. Adapter convergence was driven solely by the configured networks, and any VM adapter not backed by a network was removed.

`ConvergeNetworkAdapters` now converges the union of the configured networks and network adapters. Adapters without a network are created as disconnected Hyper-V adapters (no virtual switch, no OVS port, no security settings) using the MAC address from the catlet config. The MAC is generated at instantiation and persisted via the inventoried config, so it stays stable across updates and is reused when a network is attached later. Adapters whose network is removed are now disconnected instead of being torn down.