### PR TITLE
Run Eryph.Agent as a Windows service

### DIFF
--- a/src/apps/src/Eryph.Agent/AgentHostServices.cs
+++ b/src/apps/src/Eryph.Agent/AgentHostServices.cs
@@ -24,7 +24,7 @@ namespace Eryph.Agent
     {
         public AgentApplicationInfoProvider()
         {
-            Name = "eryph-agent";
+            Name = "eryph-hostagent";
             var entryAssembly = Assembly.GetEntryAssembly()!;
             var fileVersionInfo = FileVersionInfo.GetVersionInfo(entryAssembly.Location);
             ProductVersion = fileVersionInfo.ProductVersion ?? "unknown";

--- a/src/apps/src/Eryph.Agent/Eryph.Agent.csproj
+++ b/src/apps/src/Eryph.Agent/Eryph.Agent.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <!-- The agent is a WebModule host (Kestrel) for the EGS remote-channel listener. -->
     <PackageReference Include="Dbosoft.Hosuto.Hosting.AspNetCore" Version="1.2.0" />
+    <!-- Run as a Windows service on each Hyper-V host (like eryph-zero); no-op when run interactively. -->
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/apps/src/Eryph.Agent/Program.cs
+++ b/src/apps/src/Eryph.Agent/Program.cs
@@ -40,7 +40,7 @@ namespace Eryph.Agent
                     // console lifetime and break service mode, so build + RunAsync like eryph-zero.)
                     .ConfigureInternalHost(hb =>
                     {
-                        hb.UseWindowsService(cfg => cfg.ServiceName = "eryph-agent");
+                        hb.UseWindowsService(cfg => cfg.ServiceName = "eryph-hostagent");
                     })
                     .UseSimpleInjector(container)
                     // The agent is a WebModule: host Kestrel so it can serve the EGS remote-channel

--- a/src/apps/src/Eryph.Agent/Program.cs
+++ b/src/apps/src/Eryph.Agent/Program.cs
@@ -33,7 +33,9 @@ namespace Eryph.Agent
                 // eryph-zero). Hosuto otherwise defaults to Environment.CurrentDirectory.
                 builder.UseContentRoot(AppContext.BaseDirectory);
 
-                var host = builder
+                // Dispose the host after RunAsync returns so hosted services, Kestrel and other
+                // resources are stopped/disposed before the process exits (and before Serilog flushes).
+                using var host = builder
                     // Run as a Windows service on each Hyper-V host. UseWindowsService installs the
                     // service lifetime only when actually started as a service; interactively it is a
                     // no-op and the default console lifetime applies. (RunConsoleAsync would force the

--- a/src/apps/src/Eryph.Agent/Program.cs
+++ b/src/apps/src/Eryph.Agent/Program.cs
@@ -39,7 +39,9 @@ namespace Eryph.Agent
                     // no-op and the default console lifetime applies. (RunConsoleAsync would force the
                     // console lifetime and break service mode, so build + RunAsync like eryph-zero.)
                     .ConfigureInternalHost(hb =>
-                        hb.UseWindowsService(cfg => cfg.ServiceName = "eryph-agent"))
+                    {
+                        hb.UseWindowsService(cfg => cfg.ServiceName = "eryph-agent");
+                    })
                     .UseSimpleInjector(container)
                     // The agent is a WebModule: host Kestrel so it can serve the EGS remote-channel
                     // listener (/v1/channels/{token}). AgentChannelTls binds the mTLS endpoint (server

--- a/src/apps/src/Eryph.Agent/Program.cs
+++ b/src/apps/src/Eryph.Agent/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Dbosoft.Hosuto.Modules.Hosting;
 using Microsoft.Extensions.Hosting;
@@ -26,7 +27,19 @@ namespace Eryph.Agent
                 container.Options.EnableAutoVerification = false;
                 container.Bootstrap();
 
-                await ModulesHost.CreateDefaultBuilder(args)
+                var builder = ModulesHost.CreateDefaultBuilder(args);
+                // Windows services start with the system32 directory as their working directory;
+                // pin the content root to the app base directory so config/assets resolve (mirrors
+                // eryph-zero). Hosuto otherwise defaults to Environment.CurrentDirectory.
+                builder.UseContentRoot(AppContext.BaseDirectory);
+
+                var host = builder
+                    // Run as a Windows service on each Hyper-V host. UseWindowsService installs the
+                    // service lifetime only when actually started as a service; interactively it is a
+                    // no-op and the default console lifetime applies. (RunConsoleAsync would force the
+                    // console lifetime and break service mode, so build + RunAsync like eryph-zero.)
+                    .ConfigureInternalHost(hb =>
+                        hb.UseWindowsService(cfg => cfg.ServiceName = "eryph-agent"))
                     .UseSimpleInjector(container)
                     // The agent is a WebModule: host Kestrel so it can serve the EGS remote-channel
                     // listener (/v1/channels/{token}). AgentChannelTls binds the mTLS endpoint (server
@@ -35,7 +48,9 @@ namespace Eryph.Agent
                     .UseAspNetCoreWithDefaults((_, webHostBuilder) => AgentChannelTls.Configure(webHostBuilder))
                     .AddVmHostAgentModule()
                     .UseSerilog()
-                    .RunConsoleAsync().ConfigureAwait(false);
+                    .Build();
+
+                await host.RunAsync().ConfigureAwait(false);
             }
             finally
             {

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/VmHostAgentModule.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/VmHostAgentModule.cs
@@ -309,7 +309,7 @@ namespace Eryph.Modules.HostAgent
                 // Resolved inside the transport lambda (which runs at bus start) so it does not
                 // trigger premature container verification during ConfigureContainer.
                 .Transport(t =>
-                    container.GetService<IRebusTransportConfigurer>()
+                    container.GetInstance<IRebusTransportConfigurer>()
                         .Configure(t, container.GetInstance<ComponentIdentity>().InboundQueue))
                 .Options(x =>
                 {


### PR DESCRIPTION
The host agent runs as a Windows service on each Hyper-V host, but the standalone `Eryph.Agent` host only wired a console lifetime. This adds `UseWindowsService` (with the app base directory as the content root, since services start in system32) and switches to build + `RunAsync` instead of `RunConsoleAsync`, mirroring eryph-zero. `UseWindowsService` is a no-op when started interactively, so console runs are unaffected.