### PR TITLE
Fix 500 on identity client delete with relational store

### DIFF
--- a/src/modules/src/Eryph.ModuleCore/ChangeTracking/ChangeInterceptorBase.cs
+++ b/src/modules/src/Eryph.ModuleCore/ChangeTracking/ChangeInterceptorBase.cs
@@ -44,17 +44,7 @@ public abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor
         TransactionEventData eventData,
         CancellationToken cancellationToken = default)
     {
-        if (eventData.Context is null)
-        {
-            await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
-            return;
-        }
-
-        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
-            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
-
-        _changes = _changes.Union(currentChanges);
-
+        await DetectAndStoreChanges(eventData, cancellationToken);
         await base.CreatedSavepointAsync(transaction, eventData, cancellationToken);
     }
 
@@ -64,14 +54,7 @@ public abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor
         InterceptionResult result,
         CancellationToken cancellationToken = default)
     {
-        if (eventData.Context is null)
-            return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
-
-        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
-            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
-
-        _changes = _changes.Union(currentChanges);
-
+        await DetectAndStoreChanges(eventData, cancellationToken);
         return await base.TransactionCommittingAsync(transaction, eventData, result, cancellationToken);
     }
 
@@ -80,19 +63,21 @@ public abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor
         TransactionEndEventData eventData,
         CancellationToken cancellationToken = default)
     {
-        foreach (var item in _changes)
-        {
-            _logger.LogDebug("Detected relevant changes in transaction {TransactionId}: {Changes}",
-                item.TransactionId, item.Changes);
-            await _queue.EnqueueAsync(item, cancellationToken);
-        }
+        await EnqueueDetectedChanges(cancellationToken);
+        await base.TransactionCommittedAsync(transaction, eventData, cancellationToken);
     }
 
+    // OpenIddict's EF Core stores commit the delete path with a synchronous
+    // RelationalTransaction.Commit() (inside an execution strategy), so EF Core
+    // invokes the synchronous interceptor callbacks rather than the async ones.
+    // These must mirror the async work: throwing here aborts the commit (500),
+    // and skipping the enqueue would lose the deletion from the config mirror.
     public override void CreatedSavepoint(
         DbTransaction transaction,
         TransactionEventData eventData)
     {
-        throw new NotSupportedException();
+        DetectAndStoreChanges(eventData).GetAwaiter().GetResult();
+        base.CreatedSavepoint(transaction, eventData);
     }
 
     public override InterceptionResult TransactionCommitting(
@@ -100,13 +85,38 @@ public abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor
         TransactionEventData eventData,
         InterceptionResult result)
     {
-        throw new NotSupportedException();
+        DetectAndStoreChanges(eventData).GetAwaiter().GetResult();
+        return base.TransactionCommitting(transaction, eventData, result);
     }
 
     public override void TransactionCommitted(
         DbTransaction transaction,
         TransactionEndEventData eventData)
     {
-        throw new NotSupportedException();
+        EnqueueDetectedChanges().GetAwaiter().GetResult();
+        base.TransactionCommitted(transaction, eventData);
+    }
+
+    private async Task DetectAndStoreChanges(
+        TransactionEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventData.Context is null)
+            return;
+
+        var currentChanges = await DetectChanges(eventData.Context, cancellationToken)
+            .MapT(changes => new ChangeTrackingQueueItem<TChange>(eventData.TransactionId, changes));
+
+        _changes = _changes.Union(currentChanges);
+    }
+
+    private async Task EnqueueDetectedChanges(CancellationToken cancellationToken = default)
+    {
+        foreach (var item in _changes)
+        {
+            _logger.LogDebug("Detected relevant changes in transaction {TransactionId}: {Changes}",
+                item.TransactionId, item.Changes);
+            await _queue.EnqueueAsync(item, cancellationToken);
+        }
     }
 }

--- a/src/modules/src/Eryph.ModuleCore/ChangeTracking/ChangeInterceptorBase.cs
+++ b/src/modules/src/Eryph.ModuleCore/ChangeTracking/ChangeInterceptorBase.cs
@@ -69,9 +69,11 @@ public abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor
 
     // OpenIddict's EF Core stores commit the delete path with a synchronous
     // RelationalTransaction.Commit() (inside an execution strategy), so EF Core
-    // invokes the synchronous interceptor callbacks rather than the async ones.
-    // These must mirror the async work: throwing here aborts the commit (500),
-    // and skipping the enqueue would lose the deletion from the config mirror.
+    // invokes these synchronous interceptor callbacks rather than the async ones.
+    // They must mirror the async work: throwing from the pre-commit callbacks
+    // (CreatedSavepoint/TransactionCommitting) aborts the commit and surfaces as a
+    // 500 - the original bug - while skipping the post-commit enqueue would silently
+    // lose the deletion from the on-disk config mirror.
     public override void CreatedSavepoint(
         DbTransaction transaction,
         TransactionEventData eventData)
@@ -118,5 +120,9 @@ public abstract class ChangeInterceptorBase<TChange> : DbTransactionInterceptor
                 item.TransactionId, item.Changes);
             await _queue.EnqueueAsync(item, cancellationToken);
         }
+
+        // Reset after a committed transaction so a DbContext that is reused for a
+        // second transaction does not re-enqueue the already-exported changes.
+        _changes = HashSet<ChangeTrackingQueueItem<TChange>>.Empty;
     }
 }

--- a/src/modules/test/Eryph.Modules.Identity.Test/ChangeTracking/SynchronousCommitChangeTrackingTests.cs
+++ b/src/modules/test/Eryph.Modules.Identity.Test/ChangeTracking/SynchronousCommitChangeTrackingTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Eryph.IdentityDb;
+using Eryph.IdentityDb.Entities;
+using Eryph.ModuleCore.ChangeTracking;
+using Eryph.Modules.Identity.ChangeTracking.RedeemedTokens;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Eryph.Modules.Identity.Test.ChangeTracking;
+
+/// <summary>
+/// Regression guard for the change-tracking interceptor on a <em>relational</em> identity store.
+/// OpenIddict's EF Core application store commits its delete transaction synchronously
+/// (<c>RelationalTransaction.Commit</c>), so EF Core invokes the interceptor's <em>synchronous</em>
+/// callbacks rather than the async ones. Those used to throw <see cref="NotSupportedException"/>,
+/// which turned every client delete on the persistent identity DB (MariaDB/SQLite) into a 500 — the
+/// in-memory provider never exercised the path because it has no relational transactions.
+/// </summary>
+public class SynchronousCommitChangeTrackingTests
+{
+    [Fact]
+    public async Task Synchronously_committed_delete_is_tracked_and_enqueued()
+    {
+        // A single open connection keeps the in-memory SQLite schema alive across both contexts.
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        // The queue is a singleton in production; the interceptor is scoped (one per DbContext).
+        var queue = new ChangeTrackingQueue<RedeemedTokenChange>();
+
+        DbContextOptions<IdentityDbContext> NewOptions()
+        {
+            var builder = new DbContextOptionsBuilder<IdentityDbContext>()
+                .UseSqlite(connection)
+                .AddInterceptors(new RedeemedTokenChangeInterceptor(queue, NullLogger.Instance));
+            IdentityDbModel.ApplyOpenIddict(builder);
+            return builder.Options;
+        }
+
+        await using (var context = new IdentityDbContext(NewOptions()))
+        {
+            await context.Database.EnsureCreatedAsync();
+            context.RedeemedEnrollmentTokens.Add(new RedeemedEnrollmentToken
+            {
+                Jti = "jti-sync",
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Start capturing only now, so the assertion sees the delete and not the seed insert.
+        queue.Enable();
+
+        await using (var context = new IdentityDbContext(NewOptions()))
+        {
+            var entity = await context.RedeemedEnrollmentTokens.SingleAsync(t => t.Jti == "jti-sync");
+            await using var transaction = await context.Database.BeginTransactionAsync();
+            context.RedeemedEnrollmentTokens.Remove(entity);
+            await context.SaveChangesAsync();
+
+            // The synchronous commit is the exact call OpenIddict makes on its delete path; before the
+            // fix this threw NotSupportedException from the interceptor and rolled the delete back.
+            var commit = () => transaction.Commit();
+            commit.Should().NotThrow();
+        }
+
+        queue.GetCount().Should().Be(1, "the synchronously committed deletion must still be enqueued for export");
+        var item = await queue.DequeueAsync();
+        item.Changes.Jti.Should().Be("jti-sync");
+    }
+}

--- a/src/modules/test/Eryph.Modules.Identity.Test/ChangeTracking/SynchronousCommitChangeTrackingTests.cs
+++ b/src/modules/test/Eryph.Modules.Identity.Test/ChangeTracking/SynchronousCommitChangeTrackingTests.cs
@@ -73,4 +73,71 @@ public class SynchronousCommitChangeTrackingTests
         var item = await queue.DequeueAsync();
         item.Changes.Jti.Should().Be("jti-sync");
     }
+
+    /// <summary>
+    /// The interceptor accumulates detected changes in a field and clears it once a transaction
+    /// commits. A DbContext (and therefore its interceptor instance) that is reused for a second
+    /// transaction must export only that transaction's changes — not re-enqueue the first one's.
+    /// </summary>
+    [Fact]
+    public async Task Reused_context_does_not_re_enqueue_prior_transaction_changes()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var queue = new ChangeTrackingQueue<RedeemedTokenChange>();
+
+        DbContextOptions<IdentityDbContext> NewOptions()
+        {
+            var builder = new DbContextOptionsBuilder<IdentityDbContext>()
+                .UseSqlite(connection)
+                .AddInterceptors(new RedeemedTokenChangeInterceptor(queue, NullLogger.Instance));
+            IdentityDbModel.ApplyOpenIddict(builder);
+            return builder.Options;
+        }
+
+        await using (var context = new IdentityDbContext(NewOptions()))
+        {
+            await context.Database.EnsureCreatedAsync();
+            context.RedeemedEnrollmentTokens.Add(new RedeemedEnrollmentToken
+            {
+                Jti = "jti-1",
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            });
+            context.RedeemedEnrollmentTokens.Add(new RedeemedEnrollmentToken
+            {
+                Jti = "jti-2",
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(1),
+            });
+            await context.SaveChangesAsync();
+        }
+
+        queue.Enable();
+
+        // A single context runs two sequential transactions through the same interceptor instance.
+        await using (var context = new IdentityDbContext(NewOptions()))
+        {
+            var first = await context.RedeemedEnrollmentTokens.SingleAsync(t => t.Jti == "jti-1");
+            await using (var transaction = await context.Database.BeginTransactionAsync())
+            {
+                context.RedeemedEnrollmentTokens.Remove(first);
+                await context.SaveChangesAsync();
+                transaction.Commit();
+            }
+
+            var second = await context.RedeemedEnrollmentTokens.SingleAsync(t => t.Jti == "jti-2");
+            await using (var transaction = await context.Database.BeginTransactionAsync())
+            {
+                context.RedeemedEnrollmentTokens.Remove(second);
+                await context.SaveChangesAsync();
+                transaction.Commit();
+            }
+        }
+
+        // Without the post-commit reset the first deletion would ride along on the second commit,
+        // yielding three enqueued items instead of one per transaction.
+        queue.GetCount().Should().Be(2, "each transaction must enqueue only its own changes");
+        (await queue.DequeueAsync()).Changes.Jti.Should().Be("jti-1");
+        (await queue.DequeueAsync()).Changes.Jti.Should().Be("jti-2");
+    }
 }


### PR DESCRIPTION
After #384 moved the Identity DB from EF Core InMemory to a relational provider (MariaDB for the server, SQLite for eryph-zero), `Remove-EryphClient` started returning HTTP 500.

`ChangeInterceptorBase` only implemented the async EF transaction-interceptor callbacks; the synchronous overrides threw `NotSupportedException`. OpenIddicts EF Core application store commits its delete transaction synchronously (`RelationalTransaction.Commit`), so on a relational store every client delete hit the sync callback and failed. The in-memory provider never exercised the path because it has no relational transactions.

- Implement the synchronous `CreatedSavepoint`/`TransactionCommitting`/`TransactionCommitted` callbacks to mirror the async ones, so synchronously committed changes are detected and enqueued for config export.
- Reset the change accumulator after each committed transaction, so a DbContext reused for a second transaction no longer re-enqueues the first transactions already-exported changes.
- Add regression tests on a real SQLite identity context covering both the synchronous commit and the reused-context cases.