### PR TITLE
Stabilize catlet specification architecture handling

### DIFF
--- a/src/apps/src/Eryph-zero/HostControllerModuleExtensions.cs
+++ b/src/apps/src/Eryph-zero/HostControllerModuleExtensions.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Dbosoft.Hosuto.Modules.Hosting;
 using Eryph.ModuleCore.Startup;
 using Eryph.Modules.Controller;
+using Eryph.Modules.HostAgent.Inventory;
 using Eryph.Runtime.Zero.Configuration;
 using Eryph.StateDb.Sqlite;
 using Medallion.Threading;
@@ -61,6 +62,12 @@ public static class HostControllerModuleExtensions
                 container.RegisterInstance<IDistributedLockProvider>(
                     new FileDistributedSynchronizationProvider(
                         new DirectoryInfo(ZeroConfig.GetLocksConfigPath())));
+
+                // The embedded runtime places every catlet on the local host agent and
+                // accepts only architectures that host can run. The host architecture is
+                // the same one the agent reports for inventory.
+                container.RegisterInstance<IHostArchitectureProvider>(new HostArchitectureProvider());
+                container.RegisterSingleton<IPlacementCalculator, SingleHostPlacementCalculator>();
 
                 next(context, container);
             };

--- a/src/apps/src/Eryph-zero/SingleHostPlacementCalculator.cs
+++ b/src/apps/src/Eryph-zero/SingleHostPlacementCalculator.cs
@@ -1,0 +1,34 @@
+using Eryph.ConfigModel.Catlets;
+using Eryph.Core.Genetics;
+using Eryph.Modules.Controller;
+using Eryph.Modules.HostAgent.Inventory;
+using LanguageExt;
+using LanguageExt.Common;
+using static LanguageExt.Prelude;
+
+namespace Eryph.Runtime.Zero;
+
+/// <summary>
+/// Placement for the embedded single-host runtime: the catlet always runs on the
+/// local host agent, but only if that host can run the requested architecture.
+/// </summary>
+internal sealed class SingleHostPlacementCalculator(
+    IComponentRegistry componentRegistry,
+    IHostArchitectureProvider hostArchitectureProvider)
+    : IPlacementCalculator
+{
+    public Either<Error, string> CalculateVMPlacement(
+        CatletConfig? dataConfig,
+        Architecture architecture)
+    {
+        var hostArchitecture = hostArchitectureProvider.Architecture;
+        if (!architecture.IsSatisfiedBy(hostArchitecture))
+            return Error.New(
+                $"The architecture '{architecture}' cannot be deployed on this host "
+                + $"(host architecture '{hostArchitecture}').");
+
+        return componentRegistry.GetHostAgents().HeadOrNone()
+            .Map(agent => agent.AgentName)
+            .ToEither(() => Error.New("No host agent is registered; cannot place the catlet."));
+    }
+}

--- a/src/apps/src/Eryph.Controller/ControllerPlacementCalculator.cs
+++ b/src/apps/src/Eryph.Controller/ControllerPlacementCalculator.cs
@@ -1,0 +1,27 @@
+using Eryph.ConfigModel.Catlets;
+using Eryph.Core.Genetics;
+using Eryph.Modules.Controller;
+using LanguageExt;
+using LanguageExt.Common;
+using static LanguageExt.Prelude;
+
+namespace Eryph.Controller;
+
+/// <summary>
+/// Placement for the standalone controller runtime.
+/// </summary>
+/// <remarks>
+/// TODO: select the host agent and validate the requested architecture against the
+/// capabilities the registered host agents report, instead of returning the first
+/// registered agent. Until that exists this returns the single registered host.
+/// </remarks>
+internal sealed class ControllerPlacementCalculator(IComponentRegistry componentRegistry)
+    : IPlacementCalculator
+{
+    public Either<Error, string> CalculateVMPlacement(
+        CatletConfig? dataConfig,
+        Architecture architecture) =>
+        componentRegistry.GetHostAgents().HeadOrNone()
+            .Map(agent => agent.AgentName)
+            .ToEither(() => Error.New("No host agent is registered; cannot place the catlet."));
+}

--- a/src/apps/src/Eryph.Controller/HostControllerModuleExtensions.cs
+++ b/src/apps/src/Eryph.Controller/HostControllerModuleExtensions.cs
@@ -92,6 +92,10 @@ internal static class HostControllerModuleExtensions
 
                 container.UseOvn();
 
+                // VM placement is host-provided; the standalone controller selects from the
+                // registered host agents (see ControllerPlacementCalculator for the open work).
+                container.RegisterSingleton<IPlacementCalculator, ControllerPlacementCalculator>();
+
                 // The split runtime manages a real broker, so the controller can delete a
                 // component's RabbitMQ user when it is decommissioned (the revocation cutoff);
                 // eryph-zero appends none and decommission only removes the registration.

--- a/src/core/src/Eryph.Core/Eryph.Core.csproj
+++ b/src/core/src/Eryph.Core/Eryph.Core.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Eryph.ConfigModel.Core.Validation" Version="0.9.1-ci.3" />
     <PackageReference Include="Eryph.ConfigModel.Networks" Version="0.9.1-ci.3" />
     <PackageReference Include="Eryph.ConfigModel.Yaml" Version="0.9.1-ci.3" />
+    <PackageReference Include="Eryph.GenePool.Model" Version="0.6.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/src/Eryph.Core/Genetics/Architecture.cs
+++ b/src/core/src/Eryph.Core/Genetics/Architecture.cs
@@ -34,6 +34,15 @@ public class Architecture : EryphName<Architecture>
 
     public bool IsAny => Value.Equals("any", StringComparison.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Whether a catlet of this architecture can be deployed on a host that has
+    /// the given <paramref name="hostArchitecture"/>. A wildcard (<c>any</c>)
+    /// hypervisor or processor part matches the host's concrete part.
+    /// </summary>
+    public bool IsSatisfiedBy(Architecture hostArchitecture) =>
+        (Hypervisor.IsAny || Hypervisor == hostArchitecture.Hypervisor)
+        && (ProcessorArchitecture.IsAny || ProcessorArchitecture == hostArchitecture.ProcessorArchitecture);
+
     private static string Normalize(string value) =>
         string.Equals(value, "any/any", StringComparison.OrdinalIgnoreCase)
             ? "any"

--- a/src/core/src/Eryph.Core/Genetics/Hypervisor.cs
+++ b/src/core/src/Eryph.Core/Genetics/Hypervisor.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using Eryph.ConfigModel;
+using Eryph.GenePool.Model;
 using LanguageExt;
 using LanguageExt.Common;
 using static LanguageExt.Prelude;
@@ -12,7 +14,9 @@ public class Hypervisor : EryphName<Hypervisor>
     {
         ValidOrThrow(
             from _ in guard(
-                string.Equals(value, "hyperv", StringComparison.OrdinalIgnoreCase)
+                // The known hypervisors are sourced from the gene pool model so that
+                // eryph stays in sync with the gene pool instead of duplicating the list.
+                Hypervisors.KnownNames.Contains(value, StringComparer.OrdinalIgnoreCase)
                 || string.Equals(value, "any", StringComparison.OrdinalIgnoreCase),
                 Error.New("The hypervisor is invalid.")
             ).ToValidation()

--- a/src/core/src/Eryph.Core/Genetics/ProcessorArchitecture.cs
+++ b/src/core/src/Eryph.Core/Genetics/ProcessorArchitecture.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using Eryph.ConfigModel;
+using Eryph.GenePool.Model;
 using LanguageExt;
 using LanguageExt.Common;
 using static LanguageExt.Prelude;
@@ -12,7 +14,9 @@ public class ProcessorArchitecture : EryphName<ProcessorArchitecture>
     {
         ValidOrThrow(
             from _ in guard(
-                string.Equals(value, "amd64", StringComparison.OrdinalIgnoreCase)
+                // The known processor types are sourced from the gene pool model so that
+                // eryph stays in sync with the gene pool instead of duplicating the list.
+                ProcessorTypes.KnownNames.Contains(value, StringComparer.OrdinalIgnoreCase)
                 || string.Equals(value, "any", StringComparison.OrdinalIgnoreCase),
                 Error.New("The processor architecture is invalid.")
             ).ToValidation()

--- a/src/core/src/Eryph.VmConfig.Primitives/Eryph.Primitives.csproj
+++ b/src/core/src/Eryph.VmConfig.Primitives/Eryph.Primitives.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dbosoft.Functional.Json" Version="3.2.0" />
-    <PackageReference Include="Eryph.GenePool.Model" Version="0.5.1-ci.5" />
+    <PackageReference Include="Eryph.GenePool.Model" Version="0.6.0" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/test/Eryph.Core.Tests/Genetics/ArchitectureTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/ArchitectureTests.cs
@@ -37,6 +37,25 @@ public class ArchitectureTests
     }
 
     [Theory]
+    // Concrete host hyperv/amd64: exact and wildcard requests are satisfied.
+    [InlineData("hyperv/amd64", "hyperv/amd64", true)]
+    [InlineData("hyperv/any", "hyperv/amd64", true)]
+    [InlineData("any", "hyperv/amd64", true)]
+    // Mismatched hypervisor or processor cannot be placed on the host.
+    [InlineData("azure/amd64", "hyperv/amd64", false)]
+    [InlineData("kvm/amd64", "hyperv/amd64", false)]
+    [InlineData("azure/any", "hyperv/amd64", false)]
+    public void IsSatisfiedBy_ReturnsCorrectResult(
+        string architecture,
+        string hostArchitecture,
+        bool expected)
+    {
+        Architecture.New(architecture)
+            .IsSatisfiedBy(Architecture.New(hostArchitecture))
+            .Should().Be(expected);
+    }
+
+    [Theory]
     [InlineData(null!, "The value cannot be null.")]
     [InlineData("", "The architecture cannot be empty.")]
     [InlineData("a", "The architecture is invalid.")]

--- a/src/core/test/Eryph.Core.Tests/Genetics/ArchitectureTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/ArchitectureTests.cs
@@ -24,6 +24,9 @@ public class ArchitectureTests
     [InlineData("HYPERV/ANY", "hyperv/any")]
     [InlineData("hyperv/amd64", "hyperv/amd64")]
     [InlineData("HYPERV/AMD64", "hyperv/amd64")]
+    [InlineData("azure/amd64", "azure/amd64")]
+    [InlineData("AZURE/AMD64", "azure/amd64")]
+    [InlineData("azure/any", "azure/any")]
     public void NewValidation_ValidData_ReturnsResult(
         string hypervisor,
         string expected)

--- a/src/core/test/Eryph.Core.Tests/Genetics/HypervisorTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/HypervisorTests.cs
@@ -19,6 +19,10 @@ public class HypervisorTests
     [InlineData("ANY", "any")]
     [InlineData("hyperv", "hyperv")]
     [InlineData("HYPERV", "hyperv")]
+    [InlineData("azure", "azure")]
+    [InlineData("AZURE", "azure")]
+    [InlineData("kvm", "kvm")]
+    [InlineData("ec2", "ec2")]
     public void NewValidation_ValidData_ReturnsResult(
         string hypervisor,
         string expected)

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/CatletSpecifications/Create.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/CatletSpecifications/Create.cs
@@ -63,6 +63,11 @@ public class Create(
                 modelStateDictionary: validation.ToModelStateDictionary(
                     nameof(NewCatletSpecificationRequest.Configuration)));
 
+        var architecturesValidation = RequestValidations.ValidateArchitectures(
+            request.Architectures, nameof(NewCatletSpecificationRequest.Architectures));
+        if (architecturesValidation.IsFail)
+            return ValidationProblem(architecturesValidation.ToModelStateDictionary());
+
         var config = validation.ToOption().ValueUnsafe();
 
         var project = await projectRepository.GetByIdAsync(request.ProjectId, cancellationToken);

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/CatletSpecifications/Update.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/CatletSpecifications/Update.cs
@@ -60,6 +60,10 @@ public class Update(
                 modelStateDictionary: validation.ToModelStateDictionary(
                     nameof(UpdateCatletSpecificationRequestBody.Configuration)));
 
+        var architecturesValidation = RequestValidations.ValidateArchitectures(
+            request.Body.Architectures, nameof(UpdateCatletSpecificationRequestBody.Architectures));
+        if (architecturesValidation.IsFail)
+            return ValidationProblem(architecturesValidation.ToModelStateDictionary());
 
         return await base.HandleAsync(request, cancellationToken);
     }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/CatletSpecifications/Validate.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/CatletSpecifications/Validate.cs
@@ -14,7 +14,6 @@ using LanguageExt;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
-using static Dbosoft.Functional.Validations.ComplexValidations;
 using static LanguageExt.Prelude;
 
 namespace Eryph.Modules.ComputeApi.Endpoints.V1.CatletSpecifications;
@@ -64,15 +63,8 @@ public class Validate(
                        .Map(_ => unit)
                        .AddJsonPathPrefix(
                            nameof(ValidateSpecificationRequest.Configuration).ToJsonPath(apiNamingPolicy))
-                   | ValidateList(request, r => r.Architectures, ValidateArchitecture,
+                   | RequestValidations.ValidateArchitectures(
+                           request.Architectures,
                            nameof(ValidateSpecificationRequest.Architectures))
-                       .ToJsonPath(apiNamingPolicy)
-        select unit;
-
-    private static Validation<ValidationIssue, Unit> ValidateArchitecture(
-        string architecture,
-        string path) =>
-        from _ in Architecture.NewValidation(architecture)
-            .MapFail(e => new ValidationIssue(path, e.Message))
         select unit;
 }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/CatletSpecification.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/CatletSpecification.cs
@@ -8,8 +8,6 @@ public class CatletSpecification
 
     public required string Name { get; set; }
 
-    public required string Architecture { get; set; }
-
     public required Project Project { get; set; }
 
     public required CatletSpecificationVersionInfo Latest { get; set; }

--- a/src/modules/src/Eryph.Modules.ComputeApi/RequestValidations.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/RequestValidations.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using Dbosoft.Functional.Validations;
 using Eryph.ConfigModel;
@@ -7,6 +9,7 @@ using Eryph.ConfigModel.Json;
 using Eryph.ConfigModel.Networks;
 using Eryph.ConfigModel.Yaml;
 using Eryph.Core;
+using Eryph.Core.Genetics;
 using Eryph.Modules.AspNetCore.ApiProvider;
 using Eryph.Modules.ComputeApi.Model.V1;
 using LanguageExt;
@@ -47,6 +50,30 @@ public static class RequestValidations
             .MapFail(vi => vi.ToJsonPath(configNamingPolicy))
             .AddJsonPathPrefix(nameof(CatletSpecificationConfig.Content).ToJsonPath(apiNamingPolicy))
         select config;
+
+    /// <summary>
+    /// Validates the requested architecture strings. This must run before the
+    /// architectures are passed to the throwing <c>Architecture.New</c>, so that
+    /// an invalid architecture results in a validation problem (400) instead of
+    /// an unhandled exception (500).
+    /// </summary>
+    public static Validation<ValidationIssue, Unit> ValidateArchitectures(
+        IEnumerable<string>? architectures,
+        string propertyName) =>
+        architectures.ToSeq()
+            .Select((architecture, index) =>
+                ValidateArchitecture(architecture, $"{propertyName}[{index}]"))
+            .ToSeq()
+            .Sequence()
+            .Map(_ => unit)
+            .ToJsonPath(Optional(ApiJsonSerializerOptions.Options.PropertyNamingPolicy));
+
+    private static Validation<ValidationIssue, Unit> ValidateArchitecture(
+        string architecture,
+        string path) =>
+        from _ in Architecture.NewValidation(architecture)
+            .MapFail(e => new ValidationIssue(path, e.Message))
+        select unit;
 
     public static Validation<ValidationIssue, ProjectNetworksConfig> ValidateProjectNetworkConfig(
         JsonElement jsonElement) =>

--- a/src/modules/src/Eryph.Modules.Controller/ComponentRegistryAgentLocator.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ComponentRegistryAgentLocator.cs
@@ -1,21 +1,16 @@
 using System;
-using Eryph.ConfigModel.Catlets;
 
 namespace Eryph.Modules.Controller;
 
 /// <summary>
-/// Resolves the responsible host agent from <see cref="IComponentRegistry"/>.
-/// Replaces the host-provided single-machine locator; for a single-host
-/// deployment it returns the one registered host, preserving prior behavior.
-/// Cluster-aware placement (using <see cref="CatletConfig"/> and host capabilities)
-/// arrives in a later phase.
+/// Resolves the responsible storage-management host agent from
+/// <see cref="IComponentRegistry"/>. For a single-host deployment it returns
+/// the one registered host. VM placement is provided separately by the runtime
+/// host via <see cref="IPlacementCalculator"/>.
 /// </summary>
 internal sealed class ComponentRegistryAgentLocator(IComponentRegistry componentRegistry)
-    : IPlacementCalculator, IStorageManagementAgentLocator
+    : IStorageManagementAgentLocator
 {
-    public string CalculateVMPlacement(CatletConfig? dataConfig) =>
-        SingleHostAgent().AgentName;
-
     public string FindAgentForDataStore(string dataStore, string environment) =>
         SingleHostAgent().AgentName;
 

--- a/src/modules/src/Eryph.Modules.Controller/Compute/CreateCatletSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/CreateCatletSaga.cs
@@ -12,6 +12,7 @@ using Eryph.StateDb;
 using Eryph.StateDb.Model;
 using Eryph.StateDb.Specifications;
 using JetBrains.Annotations;
+using LanguageExt;
 using Rebus.Handlers;
 using Rebus.Sagas;
 using static LanguageExt.Prelude;
@@ -22,6 +23,7 @@ namespace Eryph.Modules.Controller.Compute;
 internal class CreateCatletSaga(
     IStorageIdentifierGenerator storageIdentifierGenerator,
     IStateStore stateStore,
+    IPlacementCalculator placementCalculator,
     IWorkflow workflow)
     : OperationTaskWorkflowSaga<CreateCatletCommand, EryphSagaData<CreateCatletSagaData>>(workflow),
         IHandleMessages<OperationTaskStatusEvent<BuildCatletSpecificationCommand>>,
@@ -95,10 +97,19 @@ internal class CreateCatletSaga(
     {
         Data.Data.State = CreateCatletSagaState.Initiated;
         Data.Data.TenantId = message.TenantId;
-        Data.Data.AgentName = Environment.MachineName;
         Data.Data.Architecture = Architecture.New(EryphConstants.DefaultArchitecture);
 
         var config = message.Config ?? throw new InvalidOperationException("Config from CreateCatletCommand must not be null.");
+
+        var placement = placementCalculator.CalculateVMPlacement(config, Data.Data.Architecture);
+        if (placement.IsLeft)
+        {
+            await Fail(placement.LeftToSeq().Head.Message);
+            return;
+        }
+
+        Data.Data.AgentName = placement.RightToSeq().Head;
+
         Data.Data.ProjectName = Optional(config.Project).Filter(notEmpty).Match(
             n => ProjectName.New(n),
             () => ProjectName.New(EryphConstants.DefaultProjectName));

--- a/src/modules/src/Eryph.Modules.Controller/Compute/DeployCatletSpecificationSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/DeployCatletSpecificationSaga.cs
@@ -15,6 +15,7 @@ using Eryph.StateDb;
 using Eryph.StateDb.Model;
 using Eryph.StateDb.Specifications;
 using JetBrains.Annotations;
+using LanguageExt;
 using LanguageExt.Common;
 using LanguageExt.UnsafeValueAccess;
 using Rebus.Handlers;
@@ -28,6 +29,7 @@ internal class DeployCatletSpecificationSaga(
     IReadonlyStateStoreRepository<CatletSpecification> specificationRepository,
     IReadonlyStateStoreRepository<CatletSpecificationVersion> specificationVersionRepository,
     IStorageIdentifierGenerator storageIdentifierGenerator,
+    IPlacementCalculator placementCalculator,
     IWorkflow workflow)
     : OperationTaskWorkflowSaga<DeployCatletSpecificationCommand, EryphSagaData<DeployCatletSpecificationSagaData>>(
             workflow),
@@ -119,7 +121,6 @@ internal class DeployCatletSpecificationSaga(
         Data.Data.SpecificationId = specification.Id;
         Data.Data.SpecificationVersionId = specificationVersion.Id;
         Data.Data.ProjectId = specification.ProjectId;
-        Data.Data.AgentName = Environment.MachineName;
         Data.Data.Redeploy = message.Redeploy;
         Data.Data.ContentType = specificationVersion.ContentType;
         Data.Data.Configuration = specificationVersion.Configuration;
@@ -151,6 +152,16 @@ internal class DeployCatletSpecificationSaga(
         }
 
         Data.Data.BuiltConfig = builtConfig.CloneWith(c => { c.Variables = updatedVariables.ValueUnsafe().ToArray(); });
+
+        var placement = placementCalculator.CalculateVMPlacement(
+            Data.Data.BuiltConfig, specificationVersionVariant.Architecture);
+        if (placement.IsLeft)
+        {
+            await Fail(placement.LeftToSeq().Head.Message);
+            return;
+        }
+
+        Data.Data.AgentName = placement.RightToSeq().Head;
 
         var existingCatlet = await catletRepository.GetBySpecAsync(
             new CatletSpecs.GetBySpecificationId(specification.Id));

--- a/src/modules/src/Eryph.Modules.Controller/ControllerModule.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ControllerModule.cs
@@ -132,11 +132,10 @@ public class ControllerModule
         container.RegisterSingleton<IIdGenerator<long>>(IdGeneratorFactory.CreateIdGenerator);
         container.RegisterSingleton<IStorageIdentifierGenerator, StorageIdentifierGenerator>();
 
-        // Placement and storage-agent location resolve through the component registry
-        // (single instance shared across both interfaces).
-        var agentLocator = Lifestyle.Singleton.CreateRegistration<ComponentRegistryAgentLocator>(container);
-        container.AddRegistration(typeof(IPlacementCalculator), agentLocator);
-        container.AddRegistration(typeof(IStorageManagementAgentLocator), agentLocator);
+        // Storage-agent location resolves through the component registry. VM placement
+        // (IPlacementCalculator) is registered by the runtime host, which knows how the
+        // deployment selects hosts and which architectures they can run.
+        container.RegisterSingleton<IStorageManagementAgentLocator, ComponentRegistryAgentLocator>();
 
         // Component registration + configuration distribution (controller is the authority).
         container.Register<IComponentRegistryService, ComponentRegistryService>(Lifestyle.Scoped);

--- a/src/modules/src/Eryph.Modules.Controller/IPlacementCalculator.cs
+++ b/src/modules/src/Eryph.Modules.Controller/IPlacementCalculator.cs
@@ -1,8 +1,16 @@
 ﻿using Eryph.ConfigModel.Catlets;
+using Eryph.Core.Genetics;
+using LanguageExt;
+using LanguageExt.Common;
 
 namespace Eryph.Modules.Controller;
 
 public interface IPlacementCalculator
 {
-    string CalculateVMPlacement(CatletConfig? dataConfig);
+    /// <summary>
+    /// Selects the host agent that should run the catlet, or an error when the
+    /// requested <paramref name="architecture"/> cannot be placed on any
+    /// available host. The implementation is provided by the runtime host.
+    /// </summary>
+    Either<Error, string> CalculateVMPlacement(CatletConfig? dataConfig, Architecture architecture);
 }

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/RequestValidationsTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/RequestValidationsTests.cs
@@ -70,6 +70,17 @@ public class RequestValidationsTests
     }
 
     [Fact]
+    public void ValidateArchitectures_MultipleInvalid_ReturnsIssuePerItem()
+    {
+        var result = RequestValidations.ValidateArchitectures(
+            ["bogus/amd64", "hyperv/amd64", "garbage"], "Architectures");
+
+        result.Should().BeFail().Which.Should().SatisfyRespectively(
+            first => first.Member.Should().Be("$.architectures[0]"),
+            second => second.Member.Should().Be("$.architectures[2]"));
+    }
+
+    [Fact]
     public void ValidateArchitectures_ValidArchitectures_ReturnsSuccess()
     {
         var result = RequestValidations.ValidateArchitectures(

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/RequestValidationsTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/RequestValidationsTests.cs
@@ -55,6 +55,38 @@ public class RequestValidationsTests
     }
 
     [Fact]
+    public void ValidateArchitectures_InvalidArchitecture_ReturnsIssueWithJsonPath()
+    {
+        // A bad architecture must surface as a validation issue rather than the
+        // throwing Architecture.New escaping as an unhandled exception (500).
+        var result = RequestValidations.ValidateArchitectures(
+            ["amd64/any"], "Architectures");
+
+        result.Should().BeFail().Which.Should().SatisfyRespectively(issue =>
+        {
+            issue.Member.Should().Be("$.architectures[0]");
+            issue.Message.Should().Contain("hypervisor");
+        });
+    }
+
+    [Fact]
+    public void ValidateArchitectures_ValidArchitectures_ReturnsSuccess()
+    {
+        var result = RequestValidations.ValidateArchitectures(
+            ["hyperv/amd64", "hyperv/any", "any"], "Architectures");
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ValidateArchitectures_NoArchitectures_ReturnsSuccess()
+    {
+        var result = RequestValidations.ValidateArchitectures(null, "Architectures");
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
     public void ValidateProjectNetworkConfig_InvalidValue_ReturnsIssueWithJsonPath()
     {
         using var document = JsonDocument.Parse("""

--- a/src/modules/test/Eryph.Modules.GenePoolModule.Test/Genetics/GeneSetTagManifestUtilsTests.cs
+++ b/src/modules/test/Eryph.Modules.GenePoolModule.Test/Genetics/GeneSetTagManifestUtilsTests.cs
@@ -89,13 +89,19 @@ public class GeneSetTagManifestUtilsTests
                 Architecture = "any",
                 Hash = ComputeHash("sdc-any"),
             },
-            // Gene for a hypervisor which this version of eryph does not understand.
-            // It must be ignored to allow future extensions of the gene pool.
             new GeneReferenceData
             {
                 Name = "sda",
                 Architecture = "kvm/amd64",
                 Hash = ComputeHash("sda-kvm-amd64"),
+            },
+            // Gene for a hypervisor which this version of eryph does not understand.
+            // It must be ignored to allow future extensions of the gene pool.
+            new GeneReferenceData
+            {
+                Name = "sda",
+                Architecture = "vmware/amd64",
+                Hash = ComputeHash("sda-vmware-amd64"),
             },
         ],
     };
@@ -106,7 +112,7 @@ public class GeneSetTagManifestUtilsTests
         var result = GeneSetTagManifestUtils.GetGenes(_manifest).Should().BeRight().Subject;
 
         var dictionary = result.ToDictionary();
-        dictionary.Should().HaveCount(13);
+        dictionary.Should().HaveCount(14);
 
         dictionary.Should().ContainKey(UniqueGeneIdentifier.New("catlet::gene:acme/acme-os/1.0:catlet[any]"))
             .WhoseValue.Should().Be(GeneHash.New(ComputeHash("catlet")));
@@ -138,9 +144,11 @@ public class GeneSetTagManifestUtilsTests
             .WhoseValue.Should().Be(GeneHash.New(ComputeHash("sdb-hyperv-any")));
         dictionary.Should().ContainKey(UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sdc[any]"))
             .WhoseValue.Should().Be(GeneHash.New(ComputeHash("sdc-any")));
+        dictionary.Should().ContainKey(UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sda[kvm/amd64]"))
+            .WhoseValue.Should().Be(GeneHash.New(ComputeHash("sda-kvm-amd64")));
 
-        // The gene for the unsupported 'kvm' hypervisor must be ignored.
-        dictionary.Keys.Should().NotContain(k => k.Architecture.Hypervisor.Value == "kvm");
+        // The gene for the unknown 'vmware' hypervisor must be ignored.
+        dictionary.Keys.Should().NotContain(k => k.Architecture.Hypervisor.Value == "vmware");
     }
 
     [Theory]


### PR DESCRIPTION
Stabilizes how catlet specifications handle architectures.

- Remove the singular `Architecture` field from the `CatletSpecification` API DTO: it had no AutoMapper binding and was never read. A specification is inherently multi-architecture; the per-architecture data lives on the version variants.
- Validate requested architectures at the API boundary. `Create`/`Update` previously mapped them with the throwing `Architecture.New` after only the config was validated, so an invalid architecture escaped as a 500. They now return a 400 via a shared `RequestValidations.ValidateArchitectures` (reused by `Validate`).
- Source the known hypervisors/processors from `Eryph.GenePool.Model` (bumped to 0.6.0) instead of a hardcoded, drifted list, so architectures such as `azure/amd64` validate.
- Restore the VM placement step that was disconnected when catlet preparation and host deployment were split (#353). The deploy sagas resolve an agent through `IPlacementCalculator` instead of hard-coding the machine name, and placement fails fast when the requested architecture cannot run on the target host. Placement is host-provided: eryph-zero validates against the local host's `IHostArchitectureProvider`; the standalone controller registers its own calculator. Adds `Architecture.IsSatisfiedBy`.

Out of scope: `ValidateCatletSpecificationSaga` still validates against the default architecture only; tracked separately.