### PR TITLE
Fix duplicate gene-pool disk inventory entries

### DIFF
--- a/src/data/src/Eryph.StateDb/Specifications/VirtualDiskSpecs.cs
+++ b/src/data/src/Eryph.StateDb/Specifications/VirtualDiskSpecs.cs
@@ -12,7 +12,7 @@ public static class VirtualDiskSpecs
     public sealed class GetByLocation : Specification<VirtualDisk>
     {
         public GetByLocation(Guid projectId, string dataStore, string environment,
-            string storageIdentifier, string name, Guid diskIdentifier)
+            string? storageIdentifier, string name, Guid diskIdentifier)
         {
             Query.Where(x => x.Project.Id == projectId);
             Query.Where(x => x.DataStore == dataStore &&

--- a/src/data/test/Eryph.StateDb.Tests/VirtualDiskSpecsTests.cs
+++ b/src/data/test/Eryph.StateDb.Tests/VirtualDiskSpecsTests.cs
@@ -1,0 +1,97 @@
+using Eryph.Core;
+using Eryph.StateDb.Model;
+using Eryph.StateDb.Specifications;
+using Eryph.StateDb.TestBase;
+using Xunit.Abstractions;
+
+namespace Eryph.StateDb.Tests;
+
+[Trait("Category", "Docker")]
+[Collection(nameof(MySqlDatabaseCollection))]
+public class MySqlVirtualDiskSpecsTests(
+    MySqlFixture databaseFixture,
+    ITestOutputHelper outputHelper)
+    : VirtualDiskSpecsTests(databaseFixture, outputHelper);
+
+[Collection(nameof(SqliteDatabaseCollection))]
+public class SqliteVirtualDiskSpecsTests(
+    SqliteFixture databaseFixture,
+    ITestOutputHelper outputHelper)
+    : VirtualDiskSpecsTests(databaseFixture, outputHelper);
+
+public abstract class VirtualDiskSpecsTests(
+    IDatabaseFixture databaseFixture,
+    ITestOutputHelper outputHelper)
+    : StateDbTestBase(databaseFixture, outputHelper)
+{
+    private const string AgentName = "testhost";
+
+    // A gene-pool disk: it carries no storage identifier and is therefore
+    // persisted with StorageIdentifier == null.
+    private static readonly Guid GeneDiskId = new("3f6c1d2e-9a4b-4c8d-bf11-7e2a5d0c4b91");
+    private static readonly Guid GeneDiskIdentifier = new("c1a2b3c4-d5e6-47a8-9b0c-1d2e3f4a5b6c");
+
+    protected override async Task SeedAsync(IStateStore stateStore)
+    {
+        await SeedDefaultTenantAndProject();
+
+        await stateStore.For<VirtualDisk>().AddAsync(new VirtualDisk
+        {
+            Id = GeneDiskId,
+            Name = "sda",
+            DiskIdentifier = GeneDiskIdentifier,
+            StorageIdentifier = null,
+            LastSeenAgent = AgentName,
+            ProjectId = EryphConstants.DefaultProjectId,
+            Environment = EryphConstants.DefaultEnvironmentName,
+            DataStore = EryphConstants.DefaultDataStoreName,
+            GeneSet = "dbosoft/winsrv2025-standard/20260611",
+            GeneName = "sda",
+            GeneArchitecture = "hyperv/amd64",
+        });
+    }
+
+    [Fact]
+    public async Task GetByLocation_DiskHasNoStorageIdentifier_MatchesExistingDisk()
+    {
+        // Regression test for the gene-pool disk duplication bug: a disk that was
+        // persisted with StorageIdentifier == null must be found again during
+        // inventory. Passing the nullable value through lets EF emit "IS NULL" so
+        // the lookup matches; otherwise every inventory run inserts a duplicate.
+        await using var scope = CreateScope();
+        var stateStore = scope.GetInstance<IStateStore>();
+
+        var result = await stateStore.For<VirtualDisk>().ListAsync(
+            new VirtualDiskSpecs.GetByLocation(
+                EryphConstants.DefaultProjectId,
+                EryphConstants.DefaultDataStoreName,
+                EryphConstants.DefaultEnvironmentName,
+                storageIdentifier: null,
+                "sda",
+                GeneDiskIdentifier));
+
+        result.Should().ContainSingle()
+            .Which.Id.Should().Be(GeneDiskId);
+    }
+
+    [Fact]
+    public async Task GetByLocation_DiskHasNoStorageIdentifier_EmptyStringDoesNotMatch()
+    {
+        // Documents the original bug: querying a null-StorageIdentifier disk with an
+        // empty string (the previous "?? \"\"" behaviour) fails to match, which is what
+        // caused the duplicate inserts.
+        await using var scope = CreateScope();
+        var stateStore = scope.GetInstance<IStateStore>();
+
+        var result = await stateStore.For<VirtualDisk>().ListAsync(
+            new VirtualDiskSpecs.GetByLocation(
+                EryphConstants.DefaultProjectId,
+                EryphConstants.DefaultDataStoreName,
+                EryphConstants.DefaultEnvironmentName,
+                storageIdentifier: "",
+                "sda",
+                GeneDiskIdentifier));
+
+        result.Should().BeEmpty();
+    }
+}

--- a/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
@@ -461,7 +461,11 @@ internal class UpdateInventoryCommandHandlerBase
                 project.Id,
                 diskInfo.DataStore ?? "",
                 diskInfo.Environment ?? "",
-                diskInfo.StorageIdentifier ?? "",
+                // Gene-pool disks have no storage identifier and are persisted with
+                // StorageIdentifier == null. Pass the nullable value through (instead of
+                // coalescing to "") so EF emits "IS NULL" and matches the existing row;
+                // otherwise every inventory run fails the lookup and inserts a duplicate.
+                diskInfo.StorageIdentifier,
                 diskInfo.Name ?? "",
                 diskInfo.DiskIdentifier));
 


### PR DESCRIPTION
Gene-pool disks carry no storage identifier and are persisted with `StorageIdentifier == null`. The inventory lookup (`GetDisk` → `VirtualDiskSpecs.GetByLocation`) queried with `StorageIdentifier ?? ""`, producing `WHERE StorageIdentifier = ''`, which never matches a `NULL` column. As a result every inventory run failed to find the existing row and inserted a new `VirtualDisk`, so a single gene-pool disk accumulated dozens of duplicate rows.

The fix passes the nullable value straight through `GetByLocation` so EF emits `IS NULL` for gene-pool disks while keeping the normal equality match for disks that do have a storage identifier. Added SQLite + MySQL regression tests.

This regression was introduced when nullable was enabled (9b75de42); an audit of the other `StorageIdentifier` comparison/persistence sites (`CheckDisksExists`, `GetByName`, `DestroyCatletSaga`) found no further occurrences — they already bridge null correctly.