### PR TITLE
Fix SQLitePCLRaw native SQLite vulnerability (CVE-2025-6965)

### DIFF
--- a/src/data/src/Eryph.IdentityDb.Sqlite/Eryph.IdentityDb.Sqlite.csproj
+++ b/src/data/src/Eryph.IdentityDb.Sqlite/Eryph.IdentityDb.Sqlite.csproj
@@ -8,6 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
+    <!-- EF Core 10.0.x still pins SQLitePCLRaw 2.1.11, whose native e_sqlite3 is
+         vulnerable (CVE-2025-6965, GHSA-2m69-gcr7-jv3q). Override the bundle to the
+         patched 3.0.x line (ships SQLite >= 3.50.2). Remove once EF Core bumps it. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/data/src/Eryph.StateDb.Sqlite/Eryph.StateDb.Sqlite.csproj
+++ b/src/data/src/Eryph.StateDb.Sqlite/Eryph.StateDb.Sqlite.csproj
@@ -8,6 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
+    <!-- EF Core 10.0.x still pins SQLitePCLRaw 2.1.11, whose native e_sqlite3 is
+         vulnerable (CVE-2025-6965, GHSA-2m69-gcr7-jv3q). Override the bundle to the
+         patched 3.0.x line (ships SQLite >= 3.50.2). Remove once EF Core bumps it. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
EF Core 10.0.x (including the latest 10.0.9) still pins `SQLitePCLRaw` to 2.1.11, whose bundled native `e_sqlite3` is affected by **CVE-2025-6965** (GHSA-2m69-gcr7-jv3q, High — memory corruption in SQLite < 3.50.2). Restore reports this as **NU1903**.

Since no released EF Core bumps the dependency, this overrides the transitive package with a direct reference to `SQLitePCLRaw.bundle_e_sqlite3` 3.0.3 (ships native SQLite 3.50.4) in the two EF Core SQLite source projects (`Eryph.StateDb.Sqlite`, `Eryph.IdentityDb.Sqlite`). The override flows transitively to all consumers, so no other project needs changes.

Verified: restore is clean (no NU1903), and `Eryph.StateDb.Tests` passes 28/28 against a real SQLite database, confirming SQLitePCLRaw 3.0.x is runtime-compatible with EF Core 10.