### PR TITLE
Resolve catlet genes for derived hypervisors (azure/ec2)

### DIFF
--- a/src/core/src/Eryph.Core/Genetics/Architecture.cs
+++ b/src/core/src/Eryph.Core/Genetics/Architecture.cs
@@ -58,15 +58,19 @@ public class Architecture : EryphName<Architecture>
             if (IsAny)
                 return Seq1(this);
 
-            var hypervisors = Hypervisor.Cons(Hypervisor.BaseHypervisors);
+            // Hypervisors from most to least specific: the requested one, the base
+            // hypervisors it derives from, then the 'any' wildcard.
+            var hypervisors = Hypervisor.Cons(Hypervisor.BaseHypervisors)
+                .Add(Hypervisor.New("any"));
+            // Processors: the requested one then the 'any' wildcard (or just 'any').
             var processors = ProcessorArchitecture.IsAny
                 ? Seq1(ProcessorArchitecture)
                 : Seq(ProcessorArchitecture, ProcessorArchitecture.New("any"));
 
-            return (from hypervisor in hypervisors
-                    from processor in processors
-                    select new Architecture(hypervisor, processor))
-                .Add(new Architecture("any"));
+            return toSeq(
+                from hypervisor in hypervisors
+                from processor in processors
+                select new Architecture(hypervisor, processor));
         }
     }
 

--- a/src/core/src/Eryph.Core/Genetics/Architecture.cs
+++ b/src/core/src/Eryph.Core/Genetics/Architecture.cs
@@ -43,6 +43,33 @@ public class Architecture : EryphName<Architecture>
         (Hypervisor.IsAny || Hypervisor == hostArchitecture.Hypervisor)
         && (ProcessorArchitecture.IsAny || ProcessorArchitecture == hostArchitecture.ProcessorArchitecture);
 
+    /// <summary>
+    /// The concrete gene architectures that can satisfy a catlet of this
+    /// architecture, ordered by specificity to the requested architecture. The
+    /// requested architecture itself is first, so an exact gene always wins; genes
+    /// for a base hypervisor (e.g. <c>hyperv</c> for <c>azure</c>) and the
+    /// <c>any</c> wildcards follow as fallbacks. The order is derived purely from
+    /// the requested architecture - there is no built-in hypervisor preference.
+    /// </summary>
+    public Seq<Architecture> GeneResolutionOrder
+    {
+        get
+        {
+            if (IsAny)
+                return Seq1(this);
+
+            var hypervisors = Hypervisor.Cons(Hypervisor.BaseHypervisors);
+            var processors = ProcessorArchitecture.IsAny
+                ? Seq1(ProcessorArchitecture)
+                : Seq(ProcessorArchitecture, ProcessorArchitecture.New("any"));
+
+            return (from hypervisor in hypervisors
+                    from processor in processors
+                    select new Architecture(hypervisor, processor))
+                .Add(new Architecture("any"));
+        }
+    }
+
     private static string Normalize(string value) =>
         string.Equals(value, "any/any", StringComparison.OrdinalIgnoreCase)
             ? "any"

--- a/src/core/src/Eryph.Core/Genetics/Architecture.cs
+++ b/src/core/src/Eryph.Core/Genetics/Architecture.cs
@@ -59,9 +59,11 @@ public class Architecture : EryphName<Architecture>
                 return Seq1(this);
 
             // Hypervisors from most to least specific: the requested one, the base
-            // hypervisors it derives from, then the 'any' wildcard.
+            // hypervisors it derives from, then the 'any' wildcard. Distinct guards
+            // the case where the requested hypervisor is already 'any'.
             var hypervisors = Hypervisor.Cons(Hypervisor.BaseHypervisors)
-                .Add(Hypervisor.New("any"));
+                .Add(Hypervisor.New("any"))
+                .Distinct();
             // Processors: the requested one then the 'any' wildcard (or just 'any').
             var processors = ProcessorArchitecture.IsAny
                 ? Seq1(ProcessorArchitecture)

--- a/src/core/src/Eryph.Core/Genetics/CatletGeneResolving.cs
+++ b/src/core/src/Eryph.Core/Genetics/CatletGeneResolving.cs
@@ -101,8 +101,7 @@ public static class CatletGeneResolving
             .Filter(i => i.GeneType == geneIdWithType.GeneType && i.Id == geneIdWithType.GeneIdentifier)
         from _2 in guard(filteredGenes.Count > 0, Error.New($"The gene {geneIdWithType} does not exist."))
         let hypervisorCompatibleGenes = filteredGenes
-            .Filter(g => g.Architecture.Hypervisor == catletArchitecture.Hypervisor
-                         || g.Architecture.Hypervisor.IsAny)
+            .Filter(g => catletArchitecture.Hypervisor.AcceptsGenesFrom(g.Architecture.Hypervisor))
         from _3 in guard(
             hypervisorCompatibleGenes.Count > 0,
             Error.New(
@@ -114,10 +113,13 @@ public static class CatletGeneResolving
             processorCompatibleGenes.Count > 0,
             Error.New(
                 $"The gene {geneIdWithType} is not compatible with the processor architecture {catletArchitecture.ProcessorArchitecture}."))
-        let bestMatch = processorCompatibleGenes.Find(g => g.Architecture == catletArchitecture)
-                        | processorCompatibleGenes.Find(g => g.Architecture.Hypervisor == catletArchitecture.Hypervisor
-                                                             && g.Architecture.ProcessorArchitecture.IsAny)
-                        | processorCompatibleGenes.Find(g => g.Architecture.IsAny)
+        // Pick the gene that matches the requested architecture most closely. The
+        // order is driven solely by the requested architecture (see
+        // Architecture.GeneResolutionOrder): the exact architecture first, then a
+        // base-hypervisor gene (e.g. hyperv for azure), then the wildcards.
+        let bestMatch = catletArchitecture.GeneResolutionOrder
+            .Choose(arch => processorCompatibleGenes.Find(g => g.Architecture == arch))
+            .HeadOrNone()
         from result in bestMatch.ToValidation(
             Error.New($"BUG! Could not find best match for gene '{geneIdWithType}'."))
         select result;

--- a/src/core/src/Eryph.Core/Genetics/Hypervisor.cs
+++ b/src/core/src/Eryph.Core/Genetics/Hypervisor.cs
@@ -10,6 +10,16 @@ namespace Eryph.Core.Genetics;
 
 public class Hypervisor : EryphName<Hypervisor>
 {
+    // Some hypervisors are derived from a base hypervisor: their VMs use the same
+    // platform and disk format, so a gene built for the base hypervisor can be used
+    // by a catlet of the derived hypervisor (Azure runs on Hyper-V, EC2/Nitro on
+    // KVM). The relation is one-directional and is plain data - add an entry to
+    // enable a further derived hypervisor. The map must stay acyclic: BaseHypervisors
+    // walks it recursively, so a cycle would not terminate.
+    private static readonly HashMap<string, string> BaseHypervisorMap = HashMap(
+        (Hypervisors.Azure, Hypervisors.HyperV),
+        (Hypervisors.EC2, Hypervisors.Kvm));
+
     public Hypervisor(string value) : base(value)
     {
         ValidOrThrow(
@@ -24,4 +34,24 @@ public class Hypervisor : EryphName<Hypervisor>
     }
 
     public bool IsAny => Value == "any";
+
+    /// <summary>
+    /// The hypervisors this one is derived from, nearest first (e.g. <c>hyperv</c>
+    /// for <c>azure</c>). Empty for base hypervisors and <c>any</c>.
+    /// </summary>
+    public Seq<Hypervisor> BaseHypervisors =>
+        BaseHypervisorMap.Find(Value)
+            .Map(New)
+            .Map(b => b.Cons(b.BaseHypervisors))
+            .IfNone(Seq<Hypervisor>());
+
+    /// <summary>
+    /// Whether a gene built for the <paramref name="geneHypervisor"/> can be used
+    /// by a catlet of this hypervisor: the gene is built for the same hypervisor,
+    /// the wildcard <c>any</c>, or a base hypervisor that this one is derived from.
+    /// </summary>
+    public bool AcceptsGenesFrom(Hypervisor geneHypervisor) =>
+        geneHypervisor.IsAny
+        || geneHypervisor == this
+        || BaseHypervisors.Contains(geneHypervisor);
 }

--- a/src/core/test/Eryph.Core.Tests/Genetics/ArchitectureTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/ArchitectureTests.cs
@@ -1,9 +1,28 @@
-﻿using Eryph.Core.Genetics;
+﻿using System.Linq;
+using Eryph.Core.Genetics;
 
 namespace Eryph.Core.Tests.Genetics;
 
 public class ArchitectureTests
 {
+    [Theory]
+    [InlineData("any", "any")]
+    [InlineData("hyperv/amd64", "hyperv/amd64, hyperv/any, any")]
+    [InlineData("kvm/amd64", "kvm/amd64, kvm/any, any")]
+    [InlineData("hyperv/any", "hyperv/any, any")]
+    // A derived hypervisor falls back to its base after its own architectures.
+    [InlineData("azure/amd64", "azure/amd64, azure/any, hyperv/amd64, hyperv/any, any")]
+    [InlineData("ec2/amd64", "ec2/amd64, ec2/any, kvm/amd64, kvm/any, any")]
+    [InlineData("azure/any", "azure/any, hyperv/any, any")]
+    public void GeneResolutionOrder_ReturnsCandidatesInOrder(
+        string architecture,
+        string expectedOrder)
+    {
+        var order = Architecture.New(architecture).GeneResolutionOrder.Map(a => a.Value);
+
+        string.Join(", ", order).Should().Be(expectedOrder);
+    }
+
     [Theory]
     [InlineData("any", true)]
     [InlineData("hyperv/any", false)]

--- a/src/core/test/Eryph.Core.Tests/Genetics/ArchitectureTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/ArchitectureTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Eryph.Core.Genetics;
+﻿using Eryph.Core.Genetics;
 
 namespace Eryph.Core.Tests.Genetics;
 
@@ -7,12 +6,12 @@ public class ArchitectureTests
 {
     [Theory]
     [InlineData("any", "any")]
-    [InlineData("hyperv/amd64", "hyperv/amd64, hyperv/any, any")]
-    [InlineData("kvm/amd64", "kvm/amd64, kvm/any, any")]
+    [InlineData("hyperv/amd64", "hyperv/amd64, hyperv/any, any/amd64, any")]
+    [InlineData("kvm/amd64", "kvm/amd64, kvm/any, any/amd64, any")]
     [InlineData("hyperv/any", "hyperv/any, any")]
     // A derived hypervisor falls back to its base after its own architectures.
-    [InlineData("azure/amd64", "azure/amd64, azure/any, hyperv/amd64, hyperv/any, any")]
-    [InlineData("ec2/amd64", "ec2/amd64, ec2/any, kvm/amd64, kvm/any, any")]
+    [InlineData("azure/amd64", "azure/amd64, azure/any, hyperv/amd64, hyperv/any, any/amd64, any")]
+    [InlineData("ec2/amd64", "ec2/amd64, ec2/any, kvm/amd64, kvm/any, any/amd64, any")]
     [InlineData("azure/any", "azure/any, hyperv/any, any")]
     public void GeneResolutionOrder_ReturnsCandidatesInOrder(
         string architecture,

--- a/src/core/test/Eryph.Core.Tests/Genetics/ArchitectureTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/ArchitectureTests.cs
@@ -9,6 +9,8 @@ public class ArchitectureTests
     [InlineData("hyperv/amd64", "hyperv/amd64, hyperv/any, any/amd64, any")]
     [InlineData("kvm/amd64", "kvm/amd64, kvm/any, any/amd64, any")]
     [InlineData("hyperv/any", "hyperv/any, any")]
+    // A wildcard hypervisor with a concrete processor must not repeat the 'any' tier.
+    [InlineData("any/amd64", "any/amd64, any")]
     // A derived hypervisor falls back to its base after its own architectures.
     [InlineData("azure/amd64", "azure/amd64, azure/any, hyperv/amd64, hyperv/any, any/amd64, any")]
     [InlineData("ec2/amd64", "ec2/amd64, ec2/any, kvm/amd64, kvm/any, any/amd64, any")]

--- a/src/core/test/Eryph.Core.Tests/Genetics/CatletGeneResolvingTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/CatletGeneResolvingTests.cs
@@ -42,7 +42,18 @@ public class CatletGeneResolvingTests
         (UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sdd[hyperv/any]"),
             GeneHash.New(ComputeHash("sdd-hyperv-any"))),
         (UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sde[hyperv/amd64]"),
-            GeneHash.New(ComputeHash("sde-hyperv-amd64"))));
+            GeneHash.New(ComputeHash("sde-hyperv-amd64"))),
+        // Genes for derived hypervisors (azure derives from hyperv, ec2 from kvm).
+        (UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sdf[kvm/amd64]"),
+            GeneHash.New(ComputeHash("sdf-kvm-amd64"))),
+        (UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sdg[hyperv/amd64]"),
+            GeneHash.New(ComputeHash("sdg-hyperv-amd64"))),
+        (UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sdg[azure/amd64]"),
+            GeneHash.New(ComputeHash("sdg-azure-amd64"))),
+        (UniqueGeneIdentifier.New("fodder::gene:acme/acme-os/1.0:kvm-food[kvm/amd64]"),
+            GeneHash.New(ComputeHash("kvm-food-kvm-amd64"))),
+        (UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sdh[azure/amd64]"),
+            GeneHash.New(ComputeHash("sdh-azure-amd64"))));
 
 
     [Theory]
@@ -116,6 +127,57 @@ public class CatletGeneResolvingTests
         result.Should().HaveCount(1);
         result.Should().ContainKey(expectedUniqueId)
             .WhoseValue.Should().Be(expectedGeneHash);
+    }
+
+    [Theory]
+    // A derived hypervisor falls back to a gene built for its base hypervisor when
+    // no gene for the derived hypervisor itself exists.
+    [InlineData(GeneType.Volume, "sde", "azure/amd64", "hyperv/amd64", "sde-hyperv-amd64")]
+    [InlineData(GeneType.Volume, "sdf", "ec2/amd64", "kvm/amd64", "sdf-kvm-amd64")]
+    [InlineData(GeneType.Fodder, "kvm-food", "ec2/amd64", "kvm/amd64", "kvm-food-kvm-amd64")]
+    // An exact gene for the derived hypervisor wins over the base-hypervisor gene.
+    [InlineData(GeneType.Volume, "sdg", "azure/amd64", "azure/amd64", "sdg-azure-amd64")]
+    public void ResolveGenes_DerivedHypervisor_ResolvesToBestGene(
+        GeneType geneType, string geneName, string requestedArchitecture,
+        string expectedArchitecture, string expectedContent)
+    {
+        var geneSetId = GeneSetIdentifier.New("acme/acme-os/1.0");
+        var geneId = new GeneIdentifier(geneSetId, GeneName.New(geneName));
+        var geneIdAndType = new GeneIdentifierWithType(geneType, geneId);
+
+        var expectedUniqueId = new UniqueGeneIdentifier(geneType, geneId, Architecture.New(expectedArchitecture));
+        var expectedGeneHash = GeneHash.New(ComputeHash(expectedContent));
+
+        var either = CatletGeneResolving.ResolveGenes(
+            Seq1(geneIdAndType), Architecture.New(requestedArchitecture), _genes);
+
+        var result = either.Should().BeRight().Subject.ToDictionary();
+        result.Should().HaveCount(1);
+        result.Should().ContainKey(expectedUniqueId)
+            .WhoseValue.Should().Be(expectedGeneHash);
+    }
+
+    [Theory]
+    // Compatibility is one-directional and only between a hypervisor and its base.
+    [InlineData(GeneType.Volume, "sdf", "azure/amd64")] // kvm gene, azure target
+    [InlineData(GeneType.Volume, "sde", "ec2/amd64")] // hyperv gene, ec2 target
+    [InlineData(GeneType.Volume, "sde", "kvm/amd64")] // hyperv gene, kvm target
+    [InlineData(GeneType.Volume, "sdh", "hyperv/amd64")] // azure gene, hyperv target (derived does not satisfy base)
+    public void ResolveGene_GeneIsNotCompatibleWithDerivedHypervisor_ReturnsError(
+        GeneType geneType, string geneName, string architecture)
+    {
+        var geneSetId = GeneSetIdentifier.New("acme/acme-os/1.0");
+        var geneId = new GeneIdentifier(geneSetId, GeneName.New(geneName));
+        var geneIdAndType = new GeneIdentifierWithType(geneType, geneId);
+
+        var either = CatletGeneResolving.ResolveGenes(
+            Seq1(geneIdAndType), Architecture.New(architecture), _genes);
+
+        var error = either.Should().BeLeft().Subject;
+        error.Message.Should().Be("Could not resolve some genes.");
+        error.Inner.Should().BeSome().Which.Message
+            .Should().Match(
+                $"The gene {geneType.ToString().ToLowerInvariant()}::{geneId} is not compatible with the hypervisor {Architecture.New(architecture).Hypervisor}.");
     }
 
     [Theory]

--- a/src/core/test/Eryph.Core.Tests/Genetics/CatletGeneResolvingTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/CatletGeneResolvingTests.cs
@@ -53,7 +53,9 @@ public class CatletGeneResolvingTests
         (UniqueGeneIdentifier.New("fodder::gene:acme/acme-os/1.0:kvm-food[kvm/amd64]"),
             GeneHash.New(ComputeHash("kvm-food-kvm-amd64"))),
         (UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sdh[azure/amd64]"),
-            GeneHash.New(ComputeHash("sdh-azure-amd64"))));
+            GeneHash.New(ComputeHash("sdh-azure-amd64"))),
+        (UniqueGeneIdentifier.New("volume::gene:acme/acme-os/1.0:sdi[any/amd64]"),
+            GeneHash.New(ComputeHash("sdi-any-amd64"))));
 
 
     [Theory]
@@ -110,6 +112,8 @@ public class CatletGeneResolvingTests
     [InlineData(GeneType.Volume, "sda", "hyperv/amd64", "sda-hyperv-amd64")]
     [InlineData(GeneType.Volume, "sdb", "hyperv/any", "sdb-hyperv-any")]
     [InlineData(GeneType.Volume, "sdc", "any", "sdc-any")]
+    // A wildcard-hypervisor gene with a matching processor is usable as a fallback.
+    [InlineData(GeneType.Volume, "sdi", "any/amd64", "sdi-any-amd64")]
     public void ResolveGenes_UsableGeneExists_ReturnsArchitecture(
         GeneType geneType, string geneName, string expectedArchitecture, string expectedContent)
     {

--- a/src/core/test/Eryph.Core.Tests/Genetics/CatletGeneResolvingTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/CatletGeneResolvingTests.cs
@@ -167,7 +167,7 @@ public class CatletGeneResolvingTests
     [InlineData(GeneType.Volume, "sde", "ec2/amd64")] // hyperv gene, ec2 target
     [InlineData(GeneType.Volume, "sde", "kvm/amd64")] // hyperv gene, kvm target
     [InlineData(GeneType.Volume, "sdh", "hyperv/amd64")] // azure gene, hyperv target (derived does not satisfy base)
-    public void ResolveGene_GeneIsNotCompatibleWithDerivedHypervisor_ReturnsError(
+    public void ResolveGenes_GeneIsNotCompatibleWithHypervisorLineage_ReturnsError(
         GeneType geneType, string geneName, string architecture)
     {
         var geneSetId = GeneSetIdentifier.New("acme/acme-os/1.0");

--- a/src/core/test/Eryph.Core.Tests/Genetics/HypervisorTests.cs
+++ b/src/core/test/Eryph.Core.Tests/Genetics/HypervisorTests.cs
@@ -40,4 +40,43 @@ public class HypervisorTests
         result.Should().BeFail().Which.Should()
             .SatisfyRespectively(error => error.Message.Should().Be("The hypervisor is invalid."));
     }
+
+    [Theory]
+    [InlineData("azure", "hyperv")]
+    [InlineData("ec2", "kvm")]
+    public void BaseHypervisors_DerivedHypervisor_ReturnsBase(
+        string hypervisor, string expectedBase)
+    {
+        Hypervisor.New(hypervisor).BaseHypervisors
+            .Should().SatisfyRespectively(b => b.Value.Should().Be(expectedBase));
+    }
+
+    [Theory]
+    [InlineData("hyperv")]
+    [InlineData("kvm")]
+    [InlineData("any")]
+    public void BaseHypervisors_BaseHypervisor_ReturnsEmpty(string hypervisor)
+    {
+        Hypervisor.New(hypervisor).BaseHypervisors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("hyperv", "hyperv", true)] // same hypervisor
+    [InlineData("hyperv", "any", true)] // wildcard gene
+    [InlineData("azure", "hyperv", true)] // gene for the base hypervisor
+    [InlineData("ec2", "kvm", true)] // gene for the base hypervisor
+    [InlineData("azure", "azure", true)]
+    [InlineData("hyperv", "azure", false)] // derived gene does not satisfy the base
+    [InlineData("kvm", "ec2", false)] // derived gene does not satisfy the base
+    [InlineData("azure", "kvm", false)] // unrelated hypervisor
+    [InlineData("ec2", "hyperv", false)] // unrelated lineage (ec2 derives from kvm)
+    [InlineData("kvm", "azure", false)] // unrelated lineage
+    [InlineData("any", "hyperv", false)] // a wildcard catlet is not satisfied by a concrete gene
+    public void AcceptsGenesFrom_ReturnsCorrectResult(
+        string catletHypervisor, string geneHypervisor, bool expected)
+    {
+        Hypervisor.New(catletHypervisor)
+            .AcceptsGenesFrom(Hypervisor.New(geneHypervisor))
+            .Should().Be(expected);
+    }
 }


### PR DESCRIPTION
## What

Gene resolution now lets a gene built for a **base hypervisor** satisfy a catlet of a **derived hypervisor**: `azure` derives from `hyperv`, `ec2` derives from `kvm`. Building an `azure/amd64` catlet-specification variant previously failed when only a `hyperv/amd64` OS-disk gene existed, because resolution demanded an exact hypervisor match (or `any`).

## How

- `Hypervisor`: a small base/derived data map plus `BaseHypervisors` and `AcceptsGenesFrom`.
- `Architecture.GeneResolutionOrder`: the candidate gene architectures ordered purely from the requested architecture (exact → base-hypervisor fallback → wildcards) — no built-in "own hypervisor wins" rule.
- `CatletGeneResolving` uses both for eligibility and selection.

Resolution stays independent of the host the resolving module runs on. The relation is one-directional (a derived gene does not satisfy a base catlet) and unrelated hypervisors (e.g. `azure`/`kvm`) never match. Host placement (`Architecture.IsSatisfiedBy`) is deliberately unchanged.

Covered by unit tests for `AcceptsGenesFrom`, `GeneResolutionOrder`, and `ResolveGenes` (fallback, exact-wins, and one-directional incompatibility).
