### PR TITLE
Expose resolved variables on catlet spec version variant

### DIFF
--- a/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/CatletSpecificationVersionVariant.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/CatletSpecificationVersionVariant.cs
@@ -9,5 +9,12 @@ public class CatletSpecificationVersionVariant
 
     public required JsonElement BuiltConfig { get; set; }
 
+    /// <summary>
+    /// The variable definitions of the built variant, resolved during the spec
+    /// build (i.e. bred from the parent chain). Exposed so deployment can collect
+    /// variable values without re-resolving the config.
+    /// </summary>
+    public required IReadOnlyList<CatletVariable> Variables { get; set; }
+
     public required IReadOnlyList<CatletSpecificationVersionVariantGene>? PinnedGenes { get; set; }
 }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/CatletVariable.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/CatletVariable.cs
@@ -1,0 +1,16 @@
+using Eryph.ConfigModel.Variables;
+
+namespace Eryph.Modules.ComputeApi.Model.V1;
+
+public class CatletVariable
+{
+    public required string Name { get; set; }
+
+    public VariableType Type { get; set; }
+
+    public string? Value { get; set; }
+
+    public bool Secret { get; set; }
+
+    public bool Required { get; set; }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/CatletVariable.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/CatletVariable.cs
@@ -2,15 +2,19 @@ using Eryph.ConfigModel.Variables;
 
 namespace Eryph.Modules.ComputeApi.Model.V1;
 
+// Mirrors the nullable shape of the source variable definition. This is an
+// external contract, so the properties stay nullable and no defaults are
+// invented here - the values are reported exactly as they are in the built
+// config, and consumers apply their own defaults.
 public class CatletVariable
 {
-    public required string Name { get; set; }
+    public string? Name { get; set; }
 
-    public VariableType Type { get; set; }
+    public VariableType? Type { get; set; }
 
     public string? Value { get; set; }
 
-    public bool Secret { get; set; }
+    public bool? Secret { get; set; }
 
-    public bool Required { get; set; }
+    public bool? Required { get; set; }
 }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/MapperProfile.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/MapperProfile.cs
@@ -1,7 +1,10 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using AutoMapper;
+using Eryph.ConfigModel.Json;
+using Eryph.ConfigModel.Variables;
 using Eryph.Core;
 using Eryph.Modules.AspNetCore.ApiProvider.Model;
 using Eryph.Modules.AspNetCore.ApiProvider.Model.V1;
@@ -148,7 +151,8 @@ public class MapperProfile : Profile
                     Content = s.Configuration,
                 }));
         CreateMap<StateDb.Model.CatletSpecificationVersionVariant, CatletSpecificationVersionVariant>()
-            .ForMember(v => v.BuiltConfig, o => o.MapFrom(s => MapToJsonElement(s.BuiltConfig)));
+            .ForMember(v => v.BuiltConfig, o => o.MapFrom(s => MapToJsonElement(s.BuiltConfig)))
+            .ForMember(v => v.Variables, o => o.MapFrom(s => MapVariables(s.BuiltConfig)));
         CreateMap<StateDb.Model.CatletSpecificationVersionVariantGene, CatletSpecificationVersionVariantGene>();
     }
 
@@ -156,5 +160,24 @@ public class MapperProfile : Profile
     {
         using var jsonDocument = JsonDocument.Parse(json);
         return jsonDocument.RootElement.Clone();
+    }
+
+    // Projects the variable definitions out of a variant's built config. The variables
+    // were already resolved (bred from the parent chain) when the spec was built, so they
+    // are surfaced as a typed field instead of forcing clients to re-resolve or to parse
+    // the built config blob.
+    private static IReadOnlyList<CatletVariable> MapVariables(string builtConfig)
+    {
+        var config = CatletConfigJsonSerializer.Deserialize(builtConfig);
+        return (config.Variables ?? [])
+            .Select(v => new CatletVariable
+            {
+                Name = v.Name ?? "",
+                Type = v.Type ?? VariableType.String,
+                Value = v.Value,
+                Secret = v.Secret ?? false,
+                Required = v.Required ?? true,
+            })
+            .ToList();
     }
 }

--- a/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/MapperProfile.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/MapperProfile.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text.Json;
 using AutoMapper;
 using Eryph.ConfigModel.Json;
-using Eryph.ConfigModel.Variables;
 using Eryph.Core;
 using Eryph.Modules.AspNetCore.ApiProvider.Model;
 using Eryph.Modules.AspNetCore.ApiProvider.Model.V1;
@@ -165,18 +164,19 @@ public class MapperProfile : Profile
     // Projects the variable definitions out of a variant's built config. The variables
     // were already resolved (bred from the parent chain) when the spec was built, so they
     // are surfaced as a typed field instead of forcing clients to re-resolve or to parse
-    // the built config blob.
+    // the built config blob. The values are passed through as-is (nullable) without
+    // inventing defaults - see CatletVariable.
     private static IReadOnlyList<CatletVariable> MapVariables(string builtConfig)
     {
         var config = CatletConfigJsonSerializer.Deserialize(builtConfig);
         return (config.Variables ?? [])
             .Select(v => new CatletVariable
             {
-                Name = v.Name ?? "",
-                Type = v.Type ?? VariableType.String,
+                Name = v.Name,
+                Type = v.Type,
                 Value = v.Value,
-                Secret = v.Secret ?? false,
-                Required = v.Required ?? true,
+                Secret = v.Secret,
+                Required = v.Required,
             })
             .ToList();
     }

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/MapperProfileTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/MapperProfileTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using AutoMapper;
+using Eryph.ConfigModel.Catlets;
+using Eryph.ConfigModel.Json;
+using Eryph.ConfigModel.Variables;
+using Eryph.Core;
+using Eryph.Core.Genetics;
+using Eryph.Modules.ComputeApi.Model.V1;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Eryph.Modules.ComputeApi.Tests;
+
+public class MapperProfileTests
+{
+    private static readonly IMapper Mapper = new MapperConfiguration(cfg =>
+    {
+        cfg.LicenseKey = AutoMapperLicense.Key;
+        cfg.AddProfile<MapperProfile>();
+    }, NullLoggerFactory.Instance).CreateMapper();
+
+    [Fact]
+    public void Variant_variables_are_projected_from_built_config()
+    {
+        var builtConfig = CatletConfigJsonSerializer.Serialize(new CatletConfig
+        {
+            Variables =
+            [
+                new VariableConfig
+                {
+                    Name = "size",
+                    Type = VariableType.Number,
+                    Value = "42",
+                    Required = false,
+                },
+                // Only a secret flag set: type and required must fall back to defaults.
+                new VariableConfig
+                {
+                    Name = "password",
+                    Secret = true,
+                },
+            ],
+        });
+
+        var source = new Eryph.StateDb.Model.CatletSpecificationVersionVariant
+        {
+            Id = Guid.NewGuid(),
+            SpecificationVersionId = Guid.NewGuid(),
+            Architecture = Architecture.New("hyperv/amd64"),
+            BuiltConfig = builtConfig,
+            PinnedGenes = new List<Eryph.StateDb.Model.CatletSpecificationVersionVariantGene>(),
+        };
+
+        var result = Mapper.Map<CatletSpecificationVersionVariant>(source);
+
+        result.Variables.Should().SatisfyRespectively(
+            v =>
+            {
+                v.Name.Should().Be("size");
+                v.Type.Should().Be(VariableType.Number);
+                v.Value.Should().Be("42");
+                v.Required.Should().BeFalse();
+                v.Secret.Should().BeFalse();
+            },
+            v =>
+            {
+                v.Name.Should().Be("password");
+                v.Type.Should().Be(VariableType.String);
+                v.Secret.Should().BeTrue();
+                v.Required.Should().BeTrue();
+                v.Value.Should().BeNull();
+            });
+    }
+
+    [Fact]
+    public void Variant_without_variables_maps_to_empty_list()
+    {
+        var builtConfig = CatletConfigJsonSerializer.Serialize(new CatletConfig
+        {
+            Name = "test",
+        });
+
+        var source = new Eryph.StateDb.Model.CatletSpecificationVersionVariant
+        {
+            Id = Guid.NewGuid(),
+            SpecificationVersionId = Guid.NewGuid(),
+            Architecture = Architecture.New("hyperv/amd64"),
+            BuiltConfig = builtConfig,
+            PinnedGenes = new List<Eryph.StateDb.Model.CatletSpecificationVersionVariantGene>(),
+        };
+
+        var result = Mapper.Map<CatletSpecificationVersionVariant>(source);
+
+        result.Variables.Should().BeEmpty();
+    }
+}

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/MapperProfileTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/MapperProfileTests.cs
@@ -62,14 +62,16 @@ public class MapperProfileTests
                 v.Type.Should().Be(VariableType.Number);
                 v.Value.Should().Be("42");
                 v.Required.Should().BeFalse();
-                v.Secret.Should().BeFalse();
+                v.Secret.Should().BeNull();
             },
+            // Only a secret flag was set. Unset properties are passed through as
+            // null instead of being defaulted - the API mirrors the built config.
             v =>
             {
                 v.Name.Should().Be("password");
-                v.Type.Should().Be(VariableType.String);
+                v.Type.Should().BeNull();
                 v.Secret.Should().BeTrue();
-                v.Required.Should().BeTrue();
+                v.Required.Should().BeNull();
                 v.Value.Should().BeNull();
             });
     }

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/MapperProfileTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/MapperProfileTests.cs
@@ -35,7 +35,7 @@ public class MapperProfileTests
                     Value = "42",
                     Required = false,
                 },
-                // Only a secret flag set: type and required must fall back to defaults.
+                // Only a secret flag is set; the other properties stay unset.
                 new VariableConfig
                 {
                     Name = "password",


### PR DESCRIPTION
Adds a typed `Variables` field to the catlet specification version variant API model, projected from the variant's already-resolved built config.

Deploying a spec previously re-resolved variables via `populate-variables` with a project-less spec config. That resolved to the default project and returned 403 for clients scoped to a non-default project. Reading the variables straight off the variant avoids the re-resolution entirely.

Includes mapper tests covering the projection and the empty-variables case.
