### PR TITLE
Fix catlet specification validation saga

### DIFF
--- a/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSaga.cs
@@ -32,9 +32,16 @@ internal class ValidateCatletSpecificationSaga(
         {
             var architecture = response.Architecture ?? throw new InvalidOperationException(
                 "The build response is missing the architecture.");
-            Data.Data.PendingArchitectures = toHashSet(Data.Data.PendingArchitectures)
+            // PendingArchitectures can deserialize as null for a saga instance persisted before it
+            // was set (guard as UpdateCatletSpecificationSaga does).
+            Data.Data.PendingArchitectures = toHashSet(Data.Data.PendingArchitectures ?? new HashSet<Architecture>())
                 .Remove(architecture)
                 .ToHashSet();
+
+            // Fall back to the first built architecture for a saga instance started before the
+            // primary was chosen up front (backward compatibility), so the config/genes are always
+            // captured for one architecture.
+            Data.Data.PrimaryArchitecture ??= architecture;
 
             // Return the built config/genes of the deterministic primary architecture only, so the
             // response is stable regardless of build completion order. BuiltConfig is required by
@@ -51,6 +58,14 @@ internal class ValidateCatletSpecificationSaga(
             // Wait until every requested architecture has built successfully.
             if (Data.Data.PendingArchitectures.Count > 0)
                 return;
+
+            // The primary architecture's result must have been captured; guard rather than complete
+            // a "valid" response with a null payload that the result mapping would then reject.
+            if (Data.Data.BuiltConfig is null || Data.Data.ResolvedGenes is null)
+            {
+                await Fail("The specification build did not produce a configuration.");
+                return;
+            }
 
             Data.Data.State = ValidateCatletSpecificationSagaState.SpecificationBuilt;
 

--- a/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSaga.cs
@@ -36,10 +36,17 @@ internal class ValidateCatletSpecificationSaga(
                 .Remove(architecture)
                 .ToHashSet();
 
-            // Validation only needs to know the spec builds; keep the last built config/genes as a
-            // representative result for the response.
-            Data.Data.BuiltConfig = response.BuiltConfig;
-            Data.Data.ResolvedGenes = response.ResolvedGenes;
+            // Return the built config/genes of the deterministic primary architecture only, so the
+            // response is stable regardless of build completion order. BuiltConfig is required by
+            // the API result mapping, so treat it as required here (matching create/update).
+            if (Data.Data.PrimaryArchitecture is { } primaryArchitecture
+                && architecture.Equals(primaryArchitecture))
+            {
+                Data.Data.BuiltConfig = response.BuiltConfig ?? throw new InvalidOperationException(
+                    "BuiltConfig is required");
+                Data.Data.ResolvedGenes = response.ResolvedGenes ?? throw new InvalidOperationException(
+                    "ResolvedGenes is required");
+            }
 
             // Wait until every requested architecture has built successfully.
             if (Data.Data.PendingArchitectures.Count > 0)
@@ -64,10 +71,17 @@ internal class ValidateCatletSpecificationSaga(
         // Validate every requested architecture (falling back to the default when none was given),
         // matching what create/update actually build — so an architecture-specific build failure is
         // caught by validation instead of surfacing only later on save.
+        var defaultArchitecture = Architecture.New(EryphConstants.DefaultArchitecture);
         var architectures = message.Architectures is { Count: > 0 }
             ? message.Architectures
-            : new HashSet<Architecture> { Architecture.New(EryphConstants.DefaultArchitecture) };
+            : new HashSet<Architecture> { defaultArchitecture };
         Data.Data.PendingArchitectures = architectures;
+
+        // The response can only carry one built config/genes; pick a deterministic architecture for
+        // it — the default when requested, otherwise the first by ordinal — so it is stable.
+        Data.Data.PrimaryArchitecture = architectures.Contains(defaultArchitecture)
+            ? defaultArchitecture
+            : architectures.OrderBy(a => a.Value, StringComparer.Ordinal).First();
 
         foreach (var architecture in architectures)
             await StartNewTask(new BuildCatletSpecificationCommand

--- a/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSaga.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Dbosoft.Rebus.Operations.Events;
 using Dbosoft.Rebus.Operations.Workflow;
@@ -10,6 +12,7 @@ using Eryph.ModuleCore;
 using JetBrains.Annotations;
 using Rebus.Handlers;
 using Rebus.Sagas;
+using static LanguageExt.Prelude;
 
 namespace Eryph.Modules.Controller.Compute;
 
@@ -27,15 +30,28 @@ internal class ValidateCatletSpecificationSaga(
 
         await FailOrRun(message, async (BuildCatletSpecificationCommandResponse response) =>
         {
-            Data.Data.State = ValidateCatletSpecificationSagaState.SpecificationBuilt;
+            var architecture = response.Architecture ?? throw new InvalidOperationException(
+                "The build response is missing the architecture.");
+            Data.Data.PendingArchitectures = toHashSet(Data.Data.PendingArchitectures)
+                .Remove(architecture)
+                .ToHashSet();
+
+            // Validation only needs to know the spec builds; keep the last built config/genes as a
+            // representative result for the response.
             Data.Data.BuiltConfig = response.BuiltConfig;
             Data.Data.ResolvedGenes = response.ResolvedGenes;
+
+            // Wait until every requested architecture has built successfully.
+            if (Data.Data.PendingArchitectures.Count > 0)
+                return;
+
+            Data.Data.State = ValidateCatletSpecificationSagaState.SpecificationBuilt;
 
             await Complete(new ValidateCatletSpecificationCommandResponse
             {
                 IsValid = true,
-                BuiltConfig = response.BuiltConfig,
-                ResolvedGenes = response.ResolvedGenes,
+                BuiltConfig = Data.Data.BuiltConfig,
+                ResolvedGenes = Data.Data.ResolvedGenes,
             });
         });
     }
@@ -45,12 +61,22 @@ internal class ValidateCatletSpecificationSaga(
         Data.Data.State = ValidateCatletSpecificationSagaState.Initiated;
         Data.Data.ConfigYaml = message.Configuration;
 
-        await StartNewTask(new BuildCatletSpecificationCommand
-        {
-            Configuration = message.Configuration,
-            Architecture = Architecture.New(EryphConstants.DefaultArchitecture),
-            AgentName = Environment.MachineName,
-        });
+        // Validate every requested architecture (falling back to the default when none was given),
+        // matching what create/update actually build — so an architecture-specific build failure is
+        // caught by validation instead of surfacing only later on save.
+        var architectures = message.Architectures is { Count: > 0 }
+            ? message.Architectures
+            : new HashSet<Architecture> { Architecture.New(EryphConstants.DefaultArchitecture) };
+        Data.Data.PendingArchitectures = architectures;
+
+        foreach (var architecture in architectures)
+            await StartNewTask(new BuildCatletSpecificationCommand
+            {
+                ContentType = message.ContentType,
+                Configuration = message.Configuration,
+                Architecture = architecture,
+                AgentName = Environment.MachineName,
+            });
     }
 
     protected override void CorrelateMessages(

--- a/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSagaData.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSagaData.cs
@@ -14,6 +14,11 @@ internal class ValidateCatletSpecificationSagaData
     // has built; a build failure fails the whole validation.
     public ISet<Architecture> PendingArchitectures { get; set; } = new HashSet<Architecture>();
 
+    // The single architecture whose built config/genes are returned in the response. Chosen
+    // deterministically up front (the default when requested, otherwise the first by ordinal) so
+    // the result never depends on which architecture's build happens to finish last.
+    public Architecture? PrimaryArchitecture { get; set; }
+
     public CatletConfig? BuiltConfig { get; set; }
 
     public IReadOnlyDictionary<UniqueGeneIdentifier, GeneHash>? ResolvedGenes { get; set; }

--- a/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSagaData.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSagaData.cs
@@ -10,6 +10,10 @@ internal class ValidateCatletSpecificationSagaData
 
     public string? ConfigYaml { get; set; }
 
+    // The architectures still being built. Validation succeeds once every requested architecture
+    // has built; a build failure fails the whole validation.
+    public ISet<Architecture> PendingArchitectures { get; set; } = new HashSet<Architecture>();
+
     public CatletConfig? BuiltConfig { get; set; }
 
     public IReadOnlyDictionary<UniqueGeneIdentifier, GeneHash>? ResolvedGenes { get; set; }


### PR DESCRIPTION
`ValidateCatletSpecificationSaga` had two bugs:

- It built the `BuildCatletSpecificationCommand` **without `ContentType`**, so validation failed in `BuildCatletSpecificationSaga` with `InvalidOperationException: ContentType is required`. The create and update sagas both pass it through.
- It only built the **default architecture**, ignoring the requested ones, so validation could not catch an architecture-specific build failure.

This passes `ContentType` through and validates **every requested architecture** (falling back to the default when none is given), completing only once all have built — matching `UpdateCatletSpecificationSaga`.