### PR TITLE
Reconcile system-client certificate between filesystem and identity DB

### DIFF
--- a/src/modules/src/Eryph.Modules.Identity/Seeding/ClientSeeder.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Seeding/ClientSeeder.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Eryph.Configuration;
 using Eryph.Configuration.Model;
+using Eryph.Core;
 using Eryph.Modules.Identity.ChangeTracking;
 using Eryph.Modules.Identity.Services;
 
@@ -16,7 +17,9 @@ namespace Eryph.Modules.Identity.Seeding;
 /// <c>IdentityClientSeeder</c>). Reads the <see cref="ClientConfigModel"/> files — including the
 /// system client's bootstrap file written by the system client generator — and adds any that are not
 /// already present. Secrets in the files are already hashed, so they are added with
-/// <c>hashedSecret: true</c>.
+/// <c>hashedSecret: true</c>. An already-present row is left untouched, except for the system client
+/// whose certificate is reconciled with the on-disk one (see
+/// <see cref="ReconcileSystemClientCertificate"/>).
 /// </summary>
 internal class ClientSeeder(
     IdentityChangeTrackingConfig config,
@@ -43,7 +46,16 @@ internal class ClientSeeder(
 
                 var existing = await clientService.Get(model.ClientId, model.TenantId, stoppingToken);
                 if (existing is not null)
+                {
+                    // Add-only seeding is correct for every client except the system client: a regular
+                    // client's file is always an export of its database row (identity change tracking),
+                    // so a present row already matches the file. The system client is the exception —
+                    // eryph-zero's system client generator writes and can regenerate it directly on
+                    // disk, so its stored certificate must be reconciled with the on-disk one.
+                    if (model.ClientId == EryphConstants.SystemClientId)
+                        await ReconcileSystemClientCertificate(existing, model, stoppingToken);
                     continue;
+                }
 
                 await clientService.Add(model.ToDescriptor(), true, stoppingToken);
             }
@@ -52,5 +64,33 @@ internal class ClientSeeder(
                 throw new InvalidOperationException(
                     $"Failed to seed identity client from file '{file}'.", ex);
             }
+    }
+
+    /// <summary>
+    /// Reconciles the persisted system-client certificate with the one on disk. eryph-zero's system
+    /// client generator can regenerate the on-disk certificate and private key (e.g. after the key
+    /// file became unreadable) while a persisted database row keeps the previous certificate. The
+    /// client then signs its assertions with the new on-disk private key while the server still
+    /// validates against the stale certificate, so every request fails with <c>401 Unauthorized</c>.
+    /// When the certificates differ, the row is updated from the file, which also re-syncs the derived
+    /// JSON Web Key Set the server validates against. Comparing only the certificate is sufficient: the
+    /// generator only ever rewrites the certificate together with the scopes and roles it also
+    /// validates, so a certificate match implies the rest of the row already matches, and a mismatch
+    /// re-seeds the full descriptor (scopes and roles included) anyway.
+    /// </summary>
+    private async Task ReconcileSystemClientCertificate(
+        ClientApplicationDescriptor existing,
+        ClientConfigModel model,
+        CancellationToken cancellationToken)
+    {
+        // A missing or empty on-disk certificate (e.g. a torn write) must never overwrite a valid
+        // stored one — that would wipe the server's validation key and lock the system client out.
+        if (string.IsNullOrWhiteSpace(model.X509CertificateBase64))
+            return;
+
+        if (string.Equals(existing.Certificate, model.X509CertificateBase64, StringComparison.Ordinal))
+            return;
+
+        await clientService.Update(model.ToDescriptor(), cancellationToken);
     }
 }

--- a/src/modules/src/Eryph.Modules.Identity/Seeding/ClientSeeder.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Seeding/ClientSeeder.cs
@@ -72,11 +72,11 @@ internal class ClientSeeder(
     /// file became unreadable) while a persisted database row keeps the previous certificate. The
     /// client then signs its assertions with the new on-disk private key while the server still
     /// validates against the stale certificate, so every request fails with <c>401 Unauthorized</c>.
-    /// When the certificates differ, the row is updated from the file, which also re-syncs the derived
-    /// JSON Web Key Set the server validates against. Comparing only the certificate is sufficient: the
-    /// generator only ever rewrites the certificate together with the scopes and roles it also
-    /// validates, so a certificate match implies the rest of the row already matches, and a mismatch
-    /// re-seeds the full descriptor (scopes and roles included) anyway.
+    /// When the certificates differ, the generator-owned fields are reapplied onto the stored row,
+    /// which also re-syncs the derived JSON Web Key Set the server validates against. Comparing only
+    /// the certificate is sufficient: the generator only ever rewrites the certificate together with
+    /// the scopes and roles it also validates, so a certificate match implies the rest already matches,
+    /// and a mismatch reapplies the scopes and roles from the file anyway.
     /// </summary>
     private async Task ReconcileSystemClientCertificate(
         ClientApplicationDescriptor existing,
@@ -91,6 +91,17 @@ internal class ClientSeeder(
         if (string.Equals(existing.Certificate, model.X509CertificateBase64, StringComparison.Ordinal))
             return;
 
-        await clientService.Update(model.ToDescriptor(), cancellationToken);
+        // Reapply only the fields the system client generator owns onto the existing row so no other
+        // stored property (e.g. display name) is disturbed. Keep the secret null so Update() leaves the
+        // stored client secret untouched — the system client authenticates with its certificate, not a
+        // shared secret.
+        existing.Certificate = model.X509CertificateBase64;
+        existing.Scopes.Clear();
+        existing.Scopes.UnionWith(model.AllowedScopes ?? []);
+        existing.AppRoles.Clear();
+        existing.AppRoles.UnionWith(model.Roles ?? []);
+        existing.ClientSecret = null;
+
+        await clientService.Update(existing, cancellationToken);
     }
 }

--- a/src/modules/src/Eryph.Modules.Identity/Seeding/ClientSeeder.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Seeding/ClientSeeder.cs
@@ -72,11 +72,13 @@ internal class ClientSeeder(
     /// file became unreadable) while a persisted database row keeps the previous certificate. The
     /// client then signs its assertions with the new on-disk private key while the server still
     /// validates against the stale certificate, so every request fails with <c>401 Unauthorized</c>.
-    /// When the certificates differ, the generator-owned fields are reapplied onto the stored row,
-    /// which also re-syncs the derived JSON Web Key Set the server validates against. Comparing only
-    /// the certificate is sufficient: the generator only ever rewrites the certificate together with
-    /// the scopes and roles it also validates, so a certificate match implies the rest already matches,
-    /// and a mismatch reapplies the scopes and roles from the file anyway.
+    /// When the certificates differ, the generator-owned fields (certificate, scopes and roles) are
+    /// reapplied onto the stored row, which also re-syncs the derived JSON Web Key Set the server
+    /// validates against. Comparing only the certificate is sufficient in practice: the certificate is
+    /// the only field whose drift breaks authentication, and the generator regenerates it whenever the
+    /// required scopes or the key pair no longer match (see <c>SystemClientGenerator.IsValid</c>). The
+    /// roles are a fixed constant for the system client, so they do not drift on their own; a mismatch
+    /// reapplies them together with the scopes anyway.
     /// </summary>
     private async Task ReconcileSystemClientCertificate(
         ClientApplicationDescriptor existing,

--- a/src/modules/src/Eryph.Modules.Identity/Services/BaseApplicationService.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Services/BaseApplicationService.cs
@@ -45,9 +45,12 @@ public abstract class BaseApplicationService<TEntity, TDescriptor>(
 
     public async ValueTask<TDescriptor> Update(TDescriptor descriptor, CancellationToken cancellationToken)
     {
-        if (descriptor.ClientId == EryphConstants.SystemClientId)
-            throw new Exception("System client can't be updated");
-
+        // Modifying the system client is blocked at the public API (Clients/Update, Clients/NewKey), so
+        // callers exposed to users must keep that check themselves. It is intentionally allowed here —
+        // unlike Delete, which keeps its guard because there is no legitimate internal deletion path —
+        // so the client seeder can reconcile the stored system-client certificate with the one
+        // eryph-zero's system client generator regenerated on disk. Without this the database keeps a
+        // stale certificate and rejects the client's assertions.
         ArgumentNullException.ThrowIfNull(descriptor.ClientId);
         var currentApplication = await repository.GetBySpecAsync(
                                      GetSingleEntitySpec(descriptor.ClientId, descriptor.TenantId), cancellationToken)

--- a/src/modules/src/Eryph.Modules.Identity/Services/IClientService.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Services/IClientService.cs
@@ -10,6 +10,11 @@ public interface IClientService
     ValueTask<IReadOnlyList<ClientApplicationDescriptor>> List(Guid tenantId, CancellationToken cancellationToken);
     ValueTask<ClientApplicationDescriptor?> Get(string clientId, Guid tenantId, CancellationToken cancellationToken);
 
+    /// <remarks>
+    /// Mutating the system client is intentionally permitted here (the startup seeder uses it to
+    /// reconcile the system client's certificate). Callers exposed to users must block the system
+    /// client themselves, as the client endpoints do.
+    /// </remarks>
     ValueTask<ClientApplicationDescriptor> Update(ClientApplicationDescriptor descriptor,
         CancellationToken cancellationToken);
 

--- a/src/modules/test/Eryph.Modules.Identity.Test/Seeding/ClientSeederTests.cs
+++ b/src/modules/test/Eryph.Modules.Identity.Test/Seeding/ClientSeederTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Eryph.Configuration.Model;
+using Eryph.Core;
+using Eryph.Modules.Identity.ChangeTracking;
+using Eryph.Modules.Identity.Seeding;
+using Eryph.Modules.Identity.Services;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Eryph.Modules.Identity.Test.Seeding;
+
+/// <summary>
+/// Covers the system-client reconciliation the seeder performs on top of add-only seeding: when the
+/// eryph-zero system client generator regenerates the on-disk certificate, the persisted database row
+/// must be updated to match, otherwise the client's assertions are validated against a stale
+/// certificate and every request fails with 401. Regular clients stay add-only.
+/// </summary>
+public class ClientSeederTests : IDisposable
+{
+    private static readonly Guid TenantId = EryphConstants.DefaultTenantId;
+
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "eryph-id-client-seed-" + Guid.NewGuid().ToString("N"));
+
+    private readonly IFileSystem _fileSystem = new FileSystem();
+    private readonly IdentityChangeTrackingConfig _config;
+
+    public ClientSeederTests()
+    {
+        _config = new IdentityChangeTrackingConfig
+        {
+            SeedDatabase = true,
+            ClientsConfigPath = Path.Combine(_dir, "clients"),
+        };
+    }
+
+    public void Dispose()
+    {
+        if (_fileSystem.Directory.Exists(_dir))
+            _fileSystem.Directory.Delete(_dir, true);
+    }
+
+    [Fact]
+    public async Task System_client_certificate_is_reconciled_when_the_stored_one_differs()
+    {
+        WriteClientFile(EryphConstants.SystemClientId, "new-cert");
+
+        var stored = SystemClientDescriptor("old-cert");
+        ClientApplicationDescriptor? updated = null;
+        var service = new Mock<IClientService>();
+        service
+            .Setup(s => s.Get(EryphConstants.SystemClientId, TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stored);
+        service
+            .Setup(s => s.Update(It.IsAny<ClientApplicationDescriptor>(), It.IsAny<CancellationToken>()))
+            .Callback<ClientApplicationDescriptor, CancellationToken>((d, _) => updated = d)
+            .ReturnsAsync((ClientApplicationDescriptor d, CancellationToken _) => d);
+
+        var seeder = new ClientSeeder(_config, _fileSystem, service.Object);
+        await seeder.Execute(CancellationToken.None);
+
+        updated.Should().NotBeNull("the stale system-client certificate must be reconciled");
+        updated!.ClientId.Should().Be(EryphConstants.SystemClientId);
+        updated.Certificate.Should().Be("new-cert", "the database must follow the on-disk certificate");
+        updated.Scopes.Should().BeEquivalentTo(new[] { "compute:write", "identity:write" },
+            "the reconciled row must carry the scopes from the file");
+        updated.AppRoles.Should().Contain(EryphConstants.SuperAdminRole,
+            "the reconciled row must carry the roles from the file");
+        service.Verify(s => s.Add(It.IsAny<ClientApplicationDescriptor>(), It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task System_client_is_not_reconciled_when_the_on_disk_certificate_is_missing()
+    {
+        // A torn/partial write must not wipe the server's validation key.
+        WriteClientFile(EryphConstants.SystemClientId, certificate: "");
+
+        var service = new Mock<IClientService>();
+        service
+            .Setup(s => s.Get(EryphConstants.SystemClientId, TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SystemClientDescriptor("stored-cert"));
+
+        var seeder = new ClientSeeder(_config, _fileSystem, service.Object);
+        await seeder.Execute(CancellationToken.None);
+
+        service.Verify(s => s.Update(It.IsAny<ClientApplicationDescriptor>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task System_client_is_not_touched_when_the_certificate_matches()
+    {
+        WriteClientFile(EryphConstants.SystemClientId, "same-cert");
+
+        var service = new Mock<IClientService>();
+        service
+            .Setup(s => s.Get(EryphConstants.SystemClientId, TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SystemClientDescriptor("same-cert"));
+
+        var seeder = new ClientSeeder(_config, _fileSystem, service.Object);
+        await seeder.Execute(CancellationToken.None);
+
+        service.Verify(s => s.Update(It.IsAny<ClientApplicationDescriptor>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        service.Verify(s => s.Add(It.IsAny<ClientApplicationDescriptor>(), It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Existing_regular_client_is_left_untouched_even_when_its_certificate_differs()
+    {
+        WriteClientFile("regular-client", "file-cert");
+
+        var stored = new ClientApplicationDescriptor
+        {
+            ClientId = "regular-client",
+            TenantId = TenantId,
+            Certificate = "stored-cert",
+        };
+        var service = new Mock<IClientService>();
+        service
+            .Setup(s => s.Get("regular-client", TenantId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(stored);
+
+        var seeder = new ClientSeeder(_config, _fileSystem, service.Object);
+        await seeder.Execute(CancellationToken.None);
+
+        service.Verify(s => s.Update(It.IsAny<ClientApplicationDescriptor>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        service.Verify(s => s.Add(It.IsAny<ClientApplicationDescriptor>(), It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static ClientApplicationDescriptor SystemClientDescriptor(string certificate) => new()
+    {
+        ClientId = EryphConstants.SystemClientId,
+        TenantId = TenantId,
+        Certificate = certificate,
+    };
+
+    private void WriteClientFile(string clientId, string certificate)
+    {
+        _fileSystem.Directory.CreateDirectory(_config.ClientsConfigPath);
+        var model = new ClientConfigModel
+        {
+            ClientId = clientId,
+            TenantId = TenantId,
+            X509CertificateBase64 = certificate,
+            AllowedScopes = ["compute:write", "identity:write"],
+            Roles = [EryphConstants.SuperAdminRole],
+        };
+        _fileSystem.File.WriteAllText(
+            Path.Combine(_config.ClientsConfigPath, $"{clientId}.json"),
+            JsonSerializer.Serialize(model));
+    }
+}

--- a/src/modules/test/Eryph.Modules.Identity.Test/Seeding/ClientSeederTests.cs
+++ b/src/modules/test/Eryph.Modules.Identity.Test/Seeding/ClientSeederTests.cs
@@ -52,6 +52,7 @@ public class ClientSeederTests : IDisposable
         WriteClientFile(EryphConstants.SystemClientId, "new-cert");
 
         var stored = SystemClientDescriptor("old-cert");
+        stored.DisplayName = "preserved-name";
         ClientApplicationDescriptor? updated = null;
         var service = new Mock<IClientService>();
         service
@@ -72,6 +73,10 @@ public class ClientSeederTests : IDisposable
             "the reconciled row must carry the scopes from the file");
         updated.AppRoles.Should().Contain(EryphConstants.SuperAdminRole,
             "the reconciled row must carry the roles from the file");
+        updated.DisplayName.Should().Be("preserved-name",
+            "fields not owned by the generator must be preserved on the existing row");
+        updated.ClientSecret.Should().BeNull(
+            "the stored client secret must not be rotated by the reconciliation");
         service.Verify(s => s.Add(It.IsAny<ClientApplicationDescriptor>(), It.IsAny<bool>(),
             It.IsAny<CancellationToken>()), Times.Never);
     }


### PR DESCRIPTION
## Problem

`Get-EryphClientCredentials -SystemClient` followed by any authenticated call fails with `401 Unauthorized`. The system client exists in two places that can drift apart now that the identity database is persistent:

- **Filesystem** — `system-client.json` (certificate) + `system-client.key` (private key), written by eryph-zero's `SystemClientGenerator`.
- **Identity DB** — an OpenIddict application row whose stored certificate drives the JSON Web Key Set used to validate the client's `private_key_jwt` assertions.

`SystemClientGenerator` regenerates the on-disk certificate/key whenever its filesystem pair is invalid, but `ClientSeeder` was **add-only** (it skipped existing rows) and `BaseApplicationService.Update`/`Delete` hard-blocked the system client. So once the on-disk certificate was regenerated while the DB row survived, the DB kept a stale certificate: the client signed with the new key, the server validated against the old one → 401.

Confirmed against a live `identity.db`: on-disk certificate modulus `3u7mnhIu…` vs the DB row's certificate/JWKS modulus `8ZXAtKNa…` (different key pairs). Before the DB became persistent this was invisible, because the DB was rebuilt from the filesystem mirror on every start.

## Fix

- `ClientSeeder` now reconciles the **system client** on startup: when the stored certificate differs from the on-disk one, it updates the row, which also rebuilds the JWKS the server validates against. All other clients stay add-only — their config files are always exports of their DB row (via change tracking), so a present row already matches.
- An empty/torn-write on-disk certificate is ignored, so it can never wipe the validation key.
- The redundant service-level `system client can't be updated` guard is removed so the internal reconcile can run; the client endpoints (`Clients/Update`, `Clients/NewKey`, `Clients/Delete`) still block system-client mutation for API callers.

Healing note: the seeder and the generator run in separate module containers with no guaranteed order, so a *future* regeneration heals on the next restart at worst. An already-broken install (like the one that prompted this) heals on the first restart, since the generator won't touch a valid on-disk pair.

## Tests

New `ClientSeederTests` cover: reconcile on cert mismatch (carrying scopes/roles), no-op on match, no update for a regular client with a differing cert, and no update when the on-disk certificate is missing. Full identity suite: 120 passing.

## Out of scope

`BaseApplicationService.Update` replaces the stored `ClientSecret` with a fresh unhashed value on every update — pre-existing behaviour that also affects `Clients/Update`. It is inert here (eryph clients authenticate via `private_key_jwt`; the shared secret is never checked), so it is left for a separate change rather than reworking the shared update path.