### PR TITLE
Dial the OVN southbound DB from a remote chassis over SSL

### DIFF
--- a/docker/cluster/provision-entrypoint.sh
+++ b/docker/cluster/provision-entrypoint.sh
@@ -21,6 +21,12 @@ echo "== 1. CA + broker TLS material (CN=$BROKER_DNS) =="
 dotnet /app/provision/eryph-cluster-provision.dll provision-broker "$BROKER_DNS" "$BROKER"
 # rabbitmq.conf points cacertfile at ca.crt; the broker trust bundle is the full CA bundle.
 cp "$BROKER/ca-bundle.pem" "$BROKER/ca.crt"
+# The broker runs as uid 999, but rootless podman maps THIS provision container's root to a different
+# subuid than the broker container's 999, so `chown 999` here would not grant the broker read access —
+# only the other bit reliably does across the two userns mappings. Hence 0644 rather than 0640+chown.
+# Dev harness only: an ephemeral key on a private local volume, regenerated on each bring-up. Production
+# key material is delivered with proper per-service ownership, not provisioned by this script.
+chmod 0644 "$BROKER/server.key"
 
 echo "== 2. Root trust anchor for the component OS trust stores =="
 # The first certificate block in the bundle is the self-signed root; the broker presents its

--- a/src/apps/src/Eryph.Network/OvnRemoteEndpointService.cs
+++ b/src/apps/src/Eryph.Network/OvnRemoteEndpointService.cs
@@ -36,13 +36,18 @@ internal sealed class OvnRemoteEndpointService(
         // anyway (e.g. a crash left only the PFX), fail fast rather than running on without listeners:
         // the module still advertises the SSL endpoints, so a silent "no listeners" state would leave
         // the controller/agents dialling a dead port.
-        var pem = certificateStore.ReadClientCertificatePem();
+        // These are TLS *server* listeners, so present the server certificate (serverAuth EKU): a client
+        // (ovn-controller / the controller's ovn-nbctl) validating the peer rejects the client
+        // certificate, which carries only clientAuth. The client leaf the components present on their own
+        // outgoing connections stays the client certificate.
+        var pem = certificateStore.ReadServerCertificatePem();
         if (pem is null)
         {
             FailFast(
-                "The component certificate (PEM) is not available, so the OVN databases cannot be "
+                "The component server certificate (PEM) is not available, so the OVN databases cannot be "
                 + "exposed over SSL. Stopping so the service manager restarts the process and re-runs "
-                + "enrollment; check the component enrollment if this persists.");
+                + "enrollment; check the component enrollment (a server certificate is required) if this "
+                + "persists.");
             return;
         }
 
@@ -63,9 +68,8 @@ internal sealed class OvnRemoteEndpointService(
 
         // Listen on all interfaces (null address) so the controller and agents can dial from other
         // hosts; clients are authenticated by certificate against the component CA.
-        // The controller consumes the northbound listener today. The southbound listener is opened and
-        // advertised so the agents' ovn-controller can connect to it remotely; wiring the agents to
-        // dial it (instead of the local pipe) is a separate slice and is not consumed yet.
+        // The controller consumes the northbound listener; the agents' ovn-controller dials the
+        // southbound listener remotely over SSL (see OVNChassisService's remote-chassis path).
         var clusterPlan = new ClusterPlan()
             .SetNorthboundSsl(pem.PrivateKeyPem, pem.CertificatePem, pem.CaBundlePem)
             .AddNorthboundConnection(OvnRemoteEndpoints.NorthboundPort, true)

--- a/src/core/src/Eryph.Core/OvnRemoteEndpoints.cs
+++ b/src/core/src/Eryph.Core/OvnRemoteEndpoints.cs
@@ -1,11 +1,18 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+
 namespace Eryph.Core;
 
 /// <summary>
 /// The well-known names and ports under which the standalone network process exposes the OVN
 /// databases to remote clients over SSL. Shared across the components so they agree on a single
 /// source: the network process advertises these endpoints on registration and opens the listeners;
-/// the controller resolves <see cref="NorthboundName"/> to reach the northbound database when the
-/// network process runs on a different host (co-located it uses the local pipe instead).
+/// the controller resolves <see cref="NorthboundName"/> to reach the northbound database and the
+/// agents' ovn-controller resolves <see cref="SouthboundName"/> to reach the southbound database
+/// when the network process runs on a different host (co-located each uses the local pipe instead).
 /// </summary>
 public static class OvnRemoteEndpoints
 {
@@ -16,4 +23,46 @@ public static class OvnRemoteEndpoints
     public const string NorthboundName = "ovn-northbound";
 
     public const string SouthboundName = "ovn-southbound";
+
+    /// <summary>
+    /// Parses an advertised OVN database endpoint of the form <c>ssl:host:port</c> into its host and
+    /// port. Shared by the controller (northbound dial) and the agents (southbound dial) so both apply
+    /// the same rules. The host may itself contain ':' (an IPv6 literal), so the port is taken from the
+    /// last ':' rather than splitting on every ':'.
+    /// </summary>
+    public static (string Host, int Port) ParseSslEndpoint(string endpoint)
+    {
+        const string prefix = "ssl:";
+        // Tolerate surrounding whitespace on the whole value (e.g. a stray trailing newline from
+        // config), but reject a missing/whitespace host, whitespace around the port, and an
+        // out-of-range port so a malformed endpoint fails here with a clear message rather than
+        // producing an OvsDbConnection that fails obscurely on connect (NumberStyles.None rejects the
+        // leading/trailing whitespace and sign that int.TryParse would otherwise accept).
+        var trimmed = (endpoint ?? "").Trim();
+        var hostPort = trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? trimmed[prefix.Length..]
+            : throw new InvalidOperationException(
+                $"The advertised OVN endpoint '{endpoint}' must be of the form 'ssl:host:port'.");
+        var lastColon = hostPort.LastIndexOf(':');
+        var host = lastColon > 0 ? hostPort[..lastColon] : "";
+        // Brackets denote an IPv6 literal ("ssl:[fe80::1]:6641"); their contents must actually be a
+        // valid IPv6 address, so reject "ssl:[]:6641" / "ssl:[not-an-ip]:6641" / a bracketed IPv4 rather
+        // than passing a host that only fails later on connect. A bare host still containing ':' is an
+        // unbracketed IPv6 literal, ambiguous with the port separator, so reject that too.
+        var isBracketed = host.StartsWith('[') && host.EndsWith(']');
+        var bracketedNotIpv6 = isBracketed
+            && !(IPAddress.TryParse(host[1..^1], out var ipv6)
+                 && ipv6.AddressFamily == AddressFamily.InterNetworkV6);
+        var unbracketedIpv6 = !isBracketed && host.Contains(':');
+        if (lastColon <= 0
+            || host.Any(char.IsWhiteSpace)
+            || unbracketedIpv6
+            || bracketedNotIpv6
+            || !int.TryParse(hostPort[(lastColon + 1)..], NumberStyles.None, CultureInfo.InvariantCulture, out var port)
+            || port is < 1 or > 65535)
+            throw new InvalidOperationException(
+                $"The advertised OVN endpoint '{endpoint}' is not of the form 'ssl:host:port' "
+                + "(an IPv6 host must be bracketed and a valid IPv6 literal, e.g. 'ssl:[fe80::1]:6641').");
+        return (host, port);
+    }
 }

--- a/src/core/src/Eryph.Core/VmAgent/VmHostAgentConfiguration.cs
+++ b/src/core/src/Eryph.Core/VmAgent/VmHostAgentConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace Eryph.Core.VmAgent;
+﻿using YamlDotNet.Serialization;
+
+namespace Eryph.Core.VmAgent;
 
 public class VmHostAgentConfiguration
 {
@@ -7,4 +9,9 @@ public class VmHostAgentConfiguration
     public VmHostAgentDataStoreConfiguration[]? Datastores { get; init; }
 
     public VmHostAgentEnvironmentConfiguration[]? Environments { get; init; }
+
+    // Optional advanced section — unlike datastores/environments this serializer emits null members,
+    // but ovn is omitted when unset so existing agent configs are not rewritten with an empty 'ovn:'.
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public VmHostAgentOvnConfiguration? Ovn { get; init; }
 }

--- a/src/core/src/Eryph.Core/VmAgent/VmHostAgentConfigurationValidations.cs
+++ b/src/core/src/Eryph.Core/VmAgent/VmHostAgentConfigurationValidations.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Net;
 using Dbosoft.Functional.Validations;
 using Eryph.ConfigModel;
 using LanguageExt;
@@ -17,6 +18,7 @@ public static class VmHostAgentConfigurationValidations
         from _ in ValidateProperty(configuration, c => c.Defaults, ValidateDefaultsConfig, path)
                   | ValidateList(configuration, c => c.Datastores, ValidateDataStoreConfig, path)
                   | ValidateList(configuration, c => c.Environments, ValidateEnvironmentConfig, path)
+                  | ValidateProperty(configuration, c => c.Ovn, ValidateOvnConfig, path)
         from __ in ValidateNoDuplicatePaths(configuration)
                    | ValidateProperty(configuration, c => c.Datastores, ValidateNoDuplicateDataStores, path)
                    | ValidateProperty(configuration, c => c.Environments, ValidateNoDuplicateEnvironments, path)
@@ -50,6 +52,17 @@ public static class VmHostAgentConfigurationValidations
         string path) =>
         ValidateProperty(toValidate, c => c.Vms, ValidatePath, path, true)
         | ValidateProperty(toValidate, c => c.Volumes, ValidatePath, path, true);
+
+    private static Validation<ValidationIssue, Unit> ValidateOvnConfig(
+        VmHostAgentOvnConfiguration toValidate,
+        string path) =>
+        ValidateProperty(toValidate, c => c.OverlayTransportIp, ValidateIpAddress, path);
+
+    private static Validation<Error, string> ValidateIpAddress(string value) =>
+        IPAddress.TryParse(value, out _)
+            ? Success<Error, string>(value)
+            : Fail<Error, string>(Error.New(
+                $"The value '{value}' is not a valid IP address."));
 
     private static Validation<Error, string> ValidatePath(string path) =>
         from _ in Validations.ValidateWindowsPath(path, "value")

--- a/src/core/src/Eryph.Core/VmAgent/VmHostAgentOvnConfiguration.cs
+++ b/src/core/src/Eryph.Core/VmAgent/VmHostAgentOvnConfiguration.cs
@@ -1,0 +1,13 @@
+namespace Eryph.Core.VmAgent;
+
+public class VmHostAgentOvnConfiguration
+{
+    /// <summary>
+    /// The host's IP address used as the local endpoint of the OVN Geneve overlay tunnels
+    /// (<c>ovn-encap-ip</c>). It must be an address reachable by the other chassis on the
+    /// overlay transport network. Host-local and authoritative — the controller never
+    /// distributes it. When unset the chassis falls back to the loopback address, which only
+    /// works for a single-host (co-located) deployment; a multi-host deployment must set it.
+    /// </summary>
+    public string? OverlayTransportIp { get; init; }
+}

--- a/src/core/test/Eryph.Core.Tests/OvnRemoteEndpointsTests.cs
+++ b/src/core/test/Eryph.Core.Tests/OvnRemoteEndpointsTests.cs
@@ -1,0 +1,41 @@
+namespace Eryph.Core.Tests;
+
+public class OvnRemoteEndpointsTests
+{
+    [Theory]
+    [InlineData("ssl:host:6641", "host", 6641)]
+    [InlineData("ssl:192.0.2.10:6641", "192.0.2.10", 6641)]
+    [InlineData("SSL:host:16641", "host", 16641)]
+    [InlineData("ssl:[fe80::1]:6641", "[fe80::1]", 6641)] // bracketed IPv6
+    [InlineData("  ssl:host:6641\t", "host", 6641)] // surrounding whitespace is trimmed
+    public void ParseSslEndpoint_Valid_ReturnsHostAndPort(string endpoint, string host, int port)
+    {
+        var result = OvnRemoteEndpoints.ParseSslEndpoint(endpoint);
+
+        result.Host.Should().Be(host);
+        result.Port.Should().Be(port);
+    }
+
+    [Theory]
+    [InlineData("tcp:host:6641")] // wrong scheme
+    [InlineData("ssl:host")] // no port
+    [InlineData("ssl:host:port")] // non-numeric port
+    [InlineData("ssl::6641")] // empty host
+    [InlineData("ssl:   :6641")] // whitespace-only host
+    [InlineData("ssl:ho st:6641")] // whitespace inside the host
+    [InlineData("ssl:host: 6641")] // whitespace around the port
+    [InlineData("ssl:fe80::1:6641")] // bare (unbracketed) IPv6 host
+    [InlineData("ssl:[]:6641")] // empty brackets
+    [InlineData("ssl:[not-an-ip]:6641")] // brackets around a non-IPv6 host
+    [InlineData("ssl:[10.0.0.1]:6641")] // brackets around an IPv4 literal (brackets are IPv6-only)
+    [InlineData("ssl:host:0")] // port below range
+    [InlineData("ssl:host:99999")] // port above range
+    [InlineData("ssl:host:-5")] // negative port
+    [InlineData("host:6641")] // no scheme
+    public void ParseSslEndpoint_Invalid_Throws(string endpoint)
+    {
+        var act = () => OvnRemoteEndpoints.ParseSslEndpoint(endpoint);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+}

--- a/src/core/test/Eryph.Core.Tests/VmAgent/VmHostAgentConfigurationValidationsTests.cs
+++ b/src/core/test/Eryph.Core.Tests/VmAgent/VmHostAgentConfigurationValidationsTests.cs
@@ -354,6 +354,54 @@ public class VmHostAgentConfigurationValidationsTests
         });
     }
 
+    [Theory]
+    [InlineData("10.0.0.21")]
+    [InlineData("fe80::1")]
+    public void ValidateVmHostAgentConfig_ValidOverlayTransportIp_ReturnsSuccess(string ip)
+    {
+        var config = new VmHostAgentConfiguration
+        {
+            Ovn = new VmHostAgentOvnConfiguration { OverlayTransportIp = ip },
+        };
+
+        var result = ValidateVmHostAgentConfig(config);
+
+        result.Should().BeSuccess();
+    }
+
+    [Fact]
+    public void ValidateVmHostAgentConfig_InvalidOverlayTransportIp_ReturnsFail()
+    {
+        var config = new VmHostAgentConfiguration
+        {
+            Ovn = new VmHostAgentOvnConfiguration { OverlayTransportIp = "not-an-ip" },
+        };
+
+        var result = ValidateVmHostAgentConfig(config);
+
+        result.Should().BeFail().Which.Should().SatisfyRespectively(issue =>
+        {
+            issue.Member.Should().Be("Ovn.OverlayTransportIp");
+            issue.Message.Should().Be("The value 'not-an-ip' is not a valid IP address.");
+        });
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateVmHostAgentConfig_BlankOverlayTransportIp_TreatedAsUnset_ReturnsSuccess(string ip)
+    {
+        // A blank value is treated as "unset" (like null): it passes validation and the chassis falls
+        // back to the loopback tunnel endpoint (single-host only). Only a non-blank, non-parseable value
+        // is a validation error, so an operator who leaves it blank is not blocked here.
+        var config = new VmHostAgentConfiguration
+        {
+            Ovn = new VmHostAgentOvnConfiguration { OverlayTransportIp = ip },
+        };
+
+        ValidateVmHostAgentConfig(config).Should().BeSuccess();
+    }
+
     [Fact]
     public void ValidateVmHostAgentConfig_EnvironmentWithEmptyDefaults_ReturnsFail()
     {

--- a/src/modules/src/Eryph.ModuleCore/Components/ComponentEnrollmentResult.cs
+++ b/src/modules/src/Eryph.ModuleCore/Components/ComponentEnrollmentResult.cs
@@ -27,8 +27,10 @@ public sealed class ComponentEnrollmentResult
     /// <summary>The server certificate's issuing intermediate CA certificate(s), each DER-encoded.</summary>
     public IReadOnlyList<byte[]> ServerIssuingChain { get; init; } = [];
 
-    /// <summary>The CA trust bundle: the currently trusted root CA certificate(s), each
-    /// DER-encoded. A bundle rather than a single anchor so a CA rollover can keep old and new
-    /// roots trusted at once.</summary>
+    /// <summary>The CA trust bundle: the currently trusted root CA certificate(s) plus the issuing
+    /// intermediate CA(s), each DER-encoded. The intermediates are included so a relying party can
+    /// still build a chain to a trusted root when a peer presents only its leaf without its issuing
+    /// chain (as OVS/ovn-controller does over SSL). A bundle rather than a single anchor so a CA
+    /// rollover can keep old and new generations trusted at once.</summary>
     public IReadOnlyList<byte[]> CaTrustBundle { get; init; } = [];
 }

--- a/src/modules/src/Eryph.ModuleCore/Components/FileComponentCertificateStore.cs
+++ b/src/modules/src/Eryph.ModuleCore/Components/FileComponentCertificateStore.cs
@@ -142,21 +142,36 @@ public sealed class FileComponentCertificateStore(string directory, TimeSpan ren
     /// bundle is not carried by the PFX, so it cannot be reconstructed from it; recovery is a re-enrollment
     /// (which rewrites the full PEM set). Callers must treat null as "not currently usable for SSL".
     /// </remarks>
-    public ComponentCertificatePem? ReadClientCertificatePem()
+    public ComponentCertificatePem? ReadClientCertificatePem() =>
+        ReadPem(KeyPath, LeafPath, ChainPath);
+
+    /// <summary>
+    /// Reads the enrolled <b>server</b>-TLS PEM material (private key, leaf-with-issuing-chain
+    /// certificate and CA trust bundle), or <see langword="null"/> when no server certificate is
+    /// enrolled or its PEM copies are incomplete. The certificate is the leaf followed by its issuing
+    /// chain so a listener presents the full path a peer pinning only the root can validate.
+    /// </summary>
+    public ComponentCertificatePem? ReadServerCertificatePem() =>
+        ReadPem(ServerKeyPath, ServerLeafPath, ServerChainPath);
+
+    // Reads a (key, leaf[, chain]) PEM triple plus the shared CA trust bundle. Returns null when the
+    // key, leaf or bundle is missing — notably the rare crash-between-writes case that left only the
+    // PFX. Callers treat null as "not currently usable for SSL".
+    private ComponentCertificatePem? ReadPem(string keyPath, string leafPath, string chainPath)
     {
-        if (!File.Exists(KeyPath) || !File.Exists(LeafPath) || !File.Exists(BundlePath))
+        if (!File.Exists(keyPath) || !File.Exists(leafPath) || !File.Exists(BundlePath))
             return null;
 
-        var certificate = File.ReadAllText(LeafPath);
-        if (File.Exists(ChainPath))
+        var certificate = File.ReadAllText(leafPath);
+        if (File.Exists(chainPath))
         {
-            var chain = File.ReadAllText(ChainPath);
+            var chain = File.ReadAllText(chainPath);
             if (!string.IsNullOrWhiteSpace(chain))
                 certificate = certificate.TrimEnd() + "\n" + chain.TrimStart();
         }
 
         return new ComponentCertificatePem(
-            File.ReadAllText(KeyPath),
+            File.ReadAllText(keyPath),
             certificate,
             File.ReadAllText(BundlePath));
     }

--- a/src/modules/src/Eryph.ModuleCore/Components/IComponentCertificateStore.cs
+++ b/src/modules/src/Eryph.ModuleCore/Components/IComponentCertificateStore.cs
@@ -57,4 +57,13 @@ public interface IComponentCertificateStore
     /// PEM-based TLS directly (e.g. OVN's <c>set-ssl</c>, which takes PEM strings, not a PKCS#12 file).
     /// </summary>
     ComponentCertificatePem? ReadClientCertificatePem();
+
+    /// <summary>
+    /// The enrolled <b>server</b>-TLS PEM material (private key, leaf-with-issuing-chain certificate and
+    /// CA trust bundle) as strings, or <see langword="null"/> when no server certificate is enrolled. A
+    /// TLS listener (e.g. the OVN southbound/northbound SSL databases) must present the server
+    /// certificate — it carries the <c>serverAuth</c> EKU — not the client certificate, which peers
+    /// reject for server authentication.
+    /// </summary>
+    ComponentCertificatePem? ReadServerCertificatePem();
 }

--- a/src/modules/src/Eryph.ModuleCore/DistributedEndpointResolver.cs
+++ b/src/modules/src/Eryph.ModuleCore/DistributedEndpointResolver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Eryph.ModuleCore;
 
@@ -47,7 +48,49 @@ public sealed class DistributedEndpointResolver : IEndpointResolver
         return new Uri(new Uri(defaultBase), endpoint);
     }
 
+    /// <summary>
+    /// Reads the raw distributed value for <paramref name="name"/> without the URI coercion
+    /// <see cref="GetEndpoint"/> applies — for consumers whose endpoint is not an HTTP(S) URL, such
+    /// as the OVN <c>ssl:host:port</c> database endpoints. Returns <see langword="false"/> when the
+    /// name has not been distributed (or was distributed empty).
+    /// </summary>
+    public bool TryGetRawEndpoint(string name, [NotNullWhen(true)] out string? value) =>
+        _endpoints.TryGetValue(name, out value) && !string.IsNullOrWhiteSpace(value);
+
+    /// <summary>
+    /// Raised after <see cref="Update"/> swaps in a new endpoint map, so a consumer that realizes an
+    /// endpoint into live system state (e.g. the OVN chassis southbound dial) can re-apply when the
+    /// controller distributes a change after the consumer already ran once at startup.
+    /// </summary>
+    public event EventHandler? Changed;
+
     /// <summary>Replaces the endpoint map with the controller-distributed set.</summary>
-    public void Update(IReadOnlyDictionary<string, string> endpoints) =>
-        _endpoints = new Dictionary<string, string>(endpoints, StringComparer.OrdinalIgnoreCase);
+    public void Update(IReadOnlyDictionary<string, string> endpoints)
+    {
+        var updated = new Dictionary<string, string>(endpoints, StringComparer.OrdinalIgnoreCase);
+        var previous = _endpoints;
+        _endpoints = updated;
+
+        // Only signal consumers when the set actually changed. Realizing an endpoint into live system
+        // state (DNS resolution, a certificate read, an OVS chassis-plan round-trip) is expensive, and
+        // the controller may republish an unchanged map under a new config version.
+        if (!SameEndpoints(previous, updated))
+            Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static bool SameEndpoints(
+        IReadOnlyDictionary<string, string> a, IReadOnlyDictionary<string, string> b)
+    {
+        if (a.Count != b.Count)
+            return false;
+
+        foreach (var (key, value) in a)
+        {
+            if (!b.TryGetValue(key, out var other)
+                || !string.Equals(value, other, StringComparison.Ordinal))
+                return false;
+        }
+
+        return true;
+    }
 }

--- a/src/modules/src/Eryph.Modules.AspNetCore/Components/ComponentClientCertificateValidator.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/Components/ComponentClientCertificateValidator.cs
@@ -26,9 +26,9 @@ public static class ComponentClientCertificateValidator
         X509Certificate2Collection trustedRoots)
     {
         // The peer presents leaf + client intermediate in the handshake; Kestrel surfaces only the
-        // leaf to this callback, so the intermediate must come from the presented chain. The trust
-        // bundle holds the root anchor only, so without the presented intermediates the fresh chain
-        // has no source to build leaf -> intermediate -> root.
+        // leaf to this callback, so the intermediate is taken from the presented chain. (The trust
+        // bundle may itself now carry the issuing intermediates, but the presented chain is the
+        // reliable per-connection source to build leaf -> intermediate -> root here.)
         var intermediates = new X509Certificate2Collection();
         if (presentedChain is not null)
             foreach (var element in presentedChain.ChainElements)

--- a/src/modules/src/Eryph.Modules.Controller/Networks/OvnNorthboundConnectionProvider.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Networks/OvnNorthboundConnectionProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -82,41 +81,9 @@ internal class OvnNorthboundConnectionProvider(
     internal static bool IsColocated(string componentMachineName, string localHostId) =>
         string.Equals(componentMachineName, localHostId, StringComparison.OrdinalIgnoreCase);
 
-    // The advertised endpoint has the form "ssl:<host>:<port>". The host may itself contain ':'
-    // (an IPv6 literal), so the port is taken from the last ':' rather than splitting on every ':'.
-    internal static (string Host, int Port) ParseSslEndpoint(string endpoint)
-    {
-        const string prefix = "ssl:";
-        // Tolerate surrounding whitespace on the whole value (e.g. a stray trailing newline from
-        // config), but reject a missing/whitespace host, whitespace around the port, and an
-        // out-of-range port so a malformed endpoint fails here with a clear message rather than
-        // producing an OvsDbConnection that fails obscurely on connect (NumberStyles.None rejects the
-        // leading/trailing whitespace and sign that int.TryParse would otherwise accept).
-        var trimmed = (endpoint ?? "").Trim();
-        var hostPort = trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-            ? trimmed[prefix.Length..]
-            : throw new InvalidOperationException(
-                $"The advertised northbound endpoint '{endpoint}' must be of the form 'ssl:host:port'.");
-        var lastColon = hostPort.LastIndexOf(':');
-        var host = lastColon > 0 ? hostPort[..lastColon] : "";
-        // An IPv6 literal must be bracketed ("ssl:[fe80::1]:6641"); a bare IPv6 host is ambiguous and
-        // OVN rejects it, so reject an unbracketed host that still contains ':' rather than passing it
-        // through to build a connection that fails obscurely.
-        var unbracketedIpv6 = host.Contains(':') && !(host.StartsWith('[') && host.EndsWith(']'));
-        if (lastColon <= 0
-            || host.Any(char.IsWhiteSpace)
-            || unbracketedIpv6
-            || !int.TryParse(hostPort[(lastColon + 1)..], NumberStyles.None, CultureInfo.InvariantCulture, out var port)
-            || port is < 1 or > 65535)
-            throw new InvalidOperationException(
-                $"The advertised northbound endpoint '{endpoint}' is not of the form 'ssl:host:port' "
-                + "(an IPv6 host must be bracketed, e.g. 'ssl:[fe80::1]:6641').");
-        return (host, port);
-    }
-
     private async Task<OvsDbConnection> BuildSslConnection(string endpoint)
     {
-        var (host, port) = ParseSslEndpoint(endpoint);
+        var (host, port) = OvnRemoteEndpoints.ParseSslEndpoint(endpoint);
 
         // Resolve the store safely so an un-enrolled controller gets the actionable message below rather
         // than a raw container ActivationException.

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Configuration/VmHostAgentConfiguration.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Configuration/VmHostAgentConfiguration.cs
@@ -87,6 +87,8 @@ public static class VmHostAgentConfiguration<RT> where RT : struct,
             Defaults = simplifyDefaults(normalizePaths(config.Defaults), hostSettings),
             Datastores = config.Datastores?.Select(normalizePaths).ToArray(),
             Environments = config.Environments?.Select(normalizePaths).ToArray(),
+            // Ovn carries no paths to normalize, but must be preserved or it is lost on save.
+            Ovn = config.Ovn,
         };
 
     private static VmHostAgentDefaultsConfiguration normalizePaths(
@@ -145,6 +147,9 @@ public static class VmHostAgentConfiguration<RT> where RT : struct,
             Datastores = config.Datastores,
             Defaults = applyHostDefaults(config.Defaults, hostSettings),
             Environments = config.Environments,
+            // Ovn carries no host defaults, but must be preserved or the running agent (and get→import)
+            // never sees the configured overlay transport IP.
+            Ovn = config.Ovn,
         };
 
     private static VmHostAgentDefaultsConfiguration applyHostDefaults(

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/OVNChassisService.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/OVNChassisService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Dbosoft.OVN;
@@ -7,6 +8,9 @@ using Dbosoft.OVN.Nodes;
 using Dbosoft.OVN.OSCommands.OVS;
 using Eryph.Core;
 using Eryph.Core.Network;
+using Eryph.Core.VmAgent;
+using Eryph.ModuleCore;
+using Eryph.ModuleCore.Components;
 using Eryph.ModuleCore.Networks;
 using Eryph.Modules.HostAgent.Networks;
 using LanguageExt;
@@ -28,10 +32,18 @@ public class OVNChassisService(
     IOVSService<OVNChassisNode> ovnChassisNode,
     IOVSService<OVSDbNode> ovsDbNode,
     IOVSService<OVSSwitchNode> ovsVSwitchNode,
+    DistributedEndpointResolver endpointResolver,
     IServiceProvider serviceProvider)
     : IHostedService
 {
     private readonly ILogger _logger = logger;
+
+    // Serializes the startup apply against re-applies triggered by a distributed endpoint change, so a
+    // change arriving mid-apply cannot interleave two chassis plans against OVS.
+    private readonly SemaphoreSlim _applyLock = new(1, 1);
+
+    // Lifetime token for background re-applies (endpoint-change driven), cancelled on stop.
+    private readonly CancellationTokenSource _stopping = new();
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
@@ -40,18 +52,69 @@ public class OVNChassisService(
 
         StartOnOwnThread();
         await UpdateNetworkProviders();
+
+        // Subscribe before the first apply so a change distributed while it runs is not lost — the
+        // re-apply serializes behind the startup apply on _applyLock. The southbound endpoint is
+        // distributed over the Endpoints config domain and may only arrive after startup.
+        endpointResolver.Changed += OnEndpointsChanged;
         await ApplyChassisPlan(cancellationToken);
     }
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
+        // Stop new re-applies (unsubscribe) and cancel any running one.
+        endpointResolver.Changed -= OnEndpointsChanged;
+        await _stopping.CancelAsync();
         controlService.UnRegister(this);
+
+        // Drain an in-flight re-apply BEFORE tearing down the OVS nodes, so an apply cannot reconfigure
+        // OVS while it is being stopped. The cancelled token makes any in-flight apply finish promptly.
+        // Bound the wait by the shutdown token: if it trips first, skip the drain and disposal (a
+        // harmless leak at process exit) rather than hang host shutdown on a stuck apply.
+        var drained = false;
+        try
+        {
+            await _applyLock.WaitAsync(cancellationToken);
+            drained = true;
+        }
+        catch (OperationCanceledException)
+        {
+            // fall through to teardown without the lock
+        }
 
         await Task.WhenAll(
             StopWitchCatch(ovnChassisNode, true, "Failed to stop OVN chassis node.", cancellationToken),
             DisconnectWitchCatch(ovsVSwitchNode, "Failed to stop vswitch node."),
             DisconnectWitchCatch(ovsDbNode, "Failed to stop chassis db node.")
         );
+
+        // Hold the lock through disposal (never release it first) so no re-apply can slip in between a
+        // release and the dispose. Only dispose if we actually acquired it.
+        if (drained)
+        {
+            _stopping.Dispose();
+            _applyLock.Dispose();
+        }
+    }
+
+    // A distributed endpoint change may add/replace the OVN southbound endpoint after the startup
+    // apply already ran (on the local pipe). Re-apply in the background; failures are logged, not
+    // propagated to the bus/config-apply path that raised the event.
+    private void OnEndpointsChanged(object? sender, EventArgs e) => _ = ReapplyChassisPlan();
+
+    private async Task ReapplyChassisPlan()
+    {
+        try
+        {
+            await ApplyChassisPlan(_stopping.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to re-apply OVN chassis plan after an endpoint change.");
+        }
     }
 
     private async Task<bool> OnControlEvent(AgentControlEvent e, CancellationToken cancellationToken)
@@ -160,6 +223,19 @@ public class OVNChassisService(
 
     private async Task ApplyChassisPlan(CancellationToken cancellationToken)
     {
+        await _applyLock.WaitAsync(cancellationToken);
+        try
+        {
+            await ApplyChassisPlanCore(cancellationToken);
+        }
+        finally
+        {
+            _applyLock.Release();
+        }
+    }
+
+    private async Task ApplyChassisPlanCore(CancellationToken cancellationToken)
+    {
         // The local chassis must register itself in the OVS database
         // (system-id, ovn-remote, ovn-encap-*, ovn-bridge-mappings) so that
         // ovn-controller can connect to the southbound DB and so that the
@@ -183,13 +259,31 @@ public class OVNChassisService(
                 });
             if (config is null) return;
 
+            // When a standalone network process runs on a different host it advertises its southbound
+            // database over the Endpoints config domain; ovn-controller must dial that endpoint over SSL
+            // instead of the local pipe. Absent (co-located / eryph-zero), the chassis keeps the local
+            // pipe and the loopback tunnel endpoint.
+            var southbound = await ResolveSouthbound(container, cancellationToken);
+            var encapIp = await ResolveEncapIp(scope);
+
+            if (southbound is not null && IPAddress.IsLoopback(encapIp))
+                _logger.LogWarning(
+                    "The OVN southbound database is remote but no overlay transport IP is configured "
+                    + "(agentsettings 'ovn.overlay_transport_ip'); Geneve tunnels use the loopback address "
+                    + "and will not reach other hosts. Set 'ovn.overlay_transport_ip' to this host's "
+                    + "overlay IP address.");
+
             var ovsTool = new OVSControlTool(systemEnvironment, LocalConnections.Switch);
             var realizer = new ChassisPlanRealizer(systemEnvironment, ovsTool);
-            var plan = BuildChassisPlan(config);
+            var plan = BuildChassisPlan(config, encapIp, southbound);
 
             var result = await realizer.ApplyChassisPlan(plan, cancellationToken).ToEither();
             result.IfLeft(e =>
                 _logger.LogWarning("Failed to apply OVN chassis plan: {Error}", e.Message));
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown / cancelled re-apply — stop quietly rather than logging a warning.
         }
         catch (Exception ex)
         {
@@ -197,15 +291,147 @@ public class OVNChassisService(
         }
     }
 
+    // Resolves the remote southbound endpoint to dial, or null to keep the local pipe. Null when no
+    // southbound endpoint is advertised (co-located), when it is malformed, when the agent is not
+    // enrolled (no client certificate for SSL yet), or when the host does not resolve — the failures
+    // log and the chassis re-applies on the next endpoint change or restart.
+    private async Task<ChassisSouthbound?> ResolveSouthbound(
+        Container container, CancellationToken cancellationToken)
+    {
+        if (!endpointResolver.TryGetRawEndpoint(OvnRemoteEndpoints.SouthboundName, out var endpoint))
+            return null;
+
+        (string Host, int Port) parsed;
+        try
+        {
+            parsed = OvnRemoteEndpoints.ParseSslEndpoint(endpoint);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex, "Ignoring malformed OVN southbound endpoint '{Endpoint}'.", endpoint);
+            return null;
+        }
+
+        var certStore = container.GetRegistration(typeof(IComponentCertificateStore))?.GetInstance()
+            as IComponentCertificateStore;
+        var pem = certStore?.ReadClientCertificatePem();
+        if (pem is null)
+        {
+            _logger.LogWarning(
+                "The OVN southbound database is advertised at '{Endpoint}' but this agent has no enrolled "
+                + "certificate, so ovn-controller cannot connect over SSL. The chassis stays on the local "
+                + "pipe until it re-applies with a certificate present.", endpoint);
+            return null;
+        }
+
+        // ovn-controller (OVS on Windows) cannot resolve a host name for an active 'ssl:' stream — it
+        // fails with "address family not supported". So resolve the advertised host to an IP literal
+        // here and configure ovn-remote with that. OVS validates the southbound server by certificate
+        // chain, not host name, so dialing by IP does not weaken authentication.
+        var address = await ResolveToIp(parsed.Host, cancellationToken);
+        if (address is null)
+        {
+            _logger.LogWarning(
+                "Could not resolve the OVN southbound host '{Host}' to an IP address; the chassis stays "
+                + "on the local pipe and re-applies on the next change.", parsed.Host);
+            return null;
+        }
+
+        return new ChassisSouthbound(address, parsed.Port, pem);
+    }
+
+    // Resolves a host to an IP literal for ovn-remote (OVS on Windows needs a literal). An IP literal
+    // (including a bracketed IPv6 host) passes through unchanged; a name is resolved via DNS, preferring
+    // IPv4 for the southbound tunnel underlay but accepting any resolved address. Returns null when the
+    // host does not resolve, so the caller degrades to the local pipe rather than failing the apply.
+    internal static async Task<string?> ResolveToIp(string host, CancellationToken cancellationToken)
+    {
+        var literal = host.StartsWith('[') && host.EndsWith(']') ? host[1..^1] : host;
+        if (IPAddress.TryParse(literal, out var parsed))
+            return FormatForRemote(parsed);
+
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await Dns.GetHostAddressesAsync(host, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Any resolution failure — NXDOMAIN, a transient DNS outage (SocketException), or a
+            // syntactically invalid / over-long host name (ArgumentException) — is treated as
+            // "unresolved" so the chassis keeps the local pipe and re-applies on the next change,
+            // instead of aborting the whole chassis-plan apply. Only genuine cancellation propagates.
+            return null;
+        }
+
+        var address = System.Array.Find(addresses, a => a.AddressFamily == AddressFamily.InterNetwork)
+                      ?? (addresses.Length > 0 ? addresses[0] : null);
+        return address is null ? null : FormatForRemote(address);
+    }
+
+    // ovn-remote is an 'ssl:host:port' string, so an IPv6 literal must be bracketed to stay unambiguous
+    // with the port separator — matching how OvnRemoteEndpoints.ParseSslEndpoint expects it.
+    private static string FormatForRemote(IPAddress address) =>
+        address.AddressFamily == AddressFamily.InterNetworkV6 ? $"[{address}]" : address.ToString();
+
+    // The Geneve overlay tunnel endpoint (ovn-encap-ip). Host-local and authoritative: the operator's
+    // agentsettings value when set, otherwise loopback (single-host only). Validation guarantees a set
+    // value parses, but re-check defensively and fall back rather than throwing during chassis apply.
+    private static async Task<IPAddress> ResolveEncapIp(Scope scope)
+    {
+        var configManager = scope.GetInstance<IVmHostAgentConfigurationManager>();
+        var hostSettingsProvider = scope.GetInstance<IHostSettingsProvider>();
+        var agentConfig = await hostSettingsProvider.GetHostSettings()
+            .Bind(configManager.GetCurrentConfiguration)
+            .Match(c => c, _ => (VmHostAgentConfiguration?)null);
+
+        var configured = agentConfig?.Ovn?.OverlayTransportIp;
+        return !string.IsNullOrWhiteSpace(configured) && IPAddress.TryParse(configured, out var ip)
+            ? ip
+            : IPAddress.Loopback;
+    }
+
     internal static ChassisPlan BuildChassisPlan(NetworkProvidersConfiguration config) =>
-        Optional(config.NetworkProviders).ToSeq()
+        BuildChassisPlan(config, IPAddress.Loopback, null);
+
+    internal static ChassisPlan BuildChassisPlan(
+        NetworkProvidersConfiguration config,
+        IPAddress encapIp,
+        ChassisSouthbound? southbound)
+    {
+        var plan = new ChassisPlan(EryphConstants.Networking.LocalChassisName)
+            .AddGeneveTunnelEndpoint(encapIp);
+
+        // Remote southbound: point ovn-remote at the SSL endpoint (an already-resolved IP literal — OVS
+        // on Windows cannot dial a host name for an active 'ssl:' stream) and configure the OVS SSL table
+        // with the agent's enrolled certificate (ovn-controller reads its client certificate from that
+        // table, not per-connection). The southbound server is authenticated by certificate chain, not
+        // host name, so dialing by IP does not weaken authentication. Co-located leaves the default
+        // local-pipe southbound connection untouched.
+        if (southbound is not null)
+            plan = plan.SetSwitchSsl(
+                    southbound.Pem.PrivateKeyPem, southbound.Pem.CertificatePem, southbound.Pem.CaBundlePem)
+                with
+            {
+                SouthboundDatabase = new OvsDbConnection(southbound.Address, southbound.Port, ssl: true),
+            };
+
+        return Optional(config.NetworkProviders).ToSeq()
             .Flatten()
             .Filter(p => p.Type is NetworkProviderType.Overlay or NetworkProviderType.NatOverlay)
             .Filter(p => !string.IsNullOrWhiteSpace(p.BridgeName))
-            .Fold(
-                new ChassisPlan(EryphConstants.Networking.LocalChassisName)
-                    .AddGeneveTunnelEndpoint(IPAddress.Loopback),
-                (plan, provider) => plan.AddBridgeMapping(provider.Name, provider.BridgeName!));
+            .Fold(plan, (p, provider) => p.AddBridgeMapping(provider.Name, provider.BridgeName!));
+    }
+
+    // The remote OVN southbound database the chassis dials: the resolved IP literal (OVS on Windows
+    // cannot dial a host name), the port, and the agent's enrolled certificate as PEM (SetSwitchSsl
+    // configures the OVS SSL table from PEM strings).
+    internal sealed record ChassisSouthbound(string Address, int Port, ComponentCertificatePem Pem)
+    {
+        // Redact: the record carries private-key PEM, and the default record ToString would print it.
+        public override string ToString() => $"ChassisSouthbound {{ Address = {Address}, Port = {Port} }}";
+    }
 
     private async Task UpdateNetworkProviders()
     {

--- a/src/modules/src/Eryph.Modules.Identity/Services/ComponentEnrollmentService.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Services/ComponentEnrollmentService.cs
@@ -246,15 +246,26 @@ public sealed class ComponentEnrollmentService(
                 .ToList();
         }
 
+        // The trust bundle must let a component validate a peer's leaf even when the peer presents only
+        // the leaf without its issuing chain — OVS/ovn-controller does exactly that on an SSL connection.
+        // So include the issuing intermediates (client + server CAs) alongside the trusted root(s), not
+        // just the roots; otherwise a leaf-only peer (the OVN southbound/northbound listeners) cannot be
+        // chained to a trusted root and validation fails.
         var trustCertificates = certificateAuthority.GetTrustedCaCertificates();
+        IReadOnlyList<X509Certificate2>? issuingCertificates = null;
         List<byte[]> trustBundle;
         try
         {
-            trustBundle = trustCertificates.Select(c => c.Export(X509ContentType.Cert)).ToList();
+            // Acquire inside the try so a throw here still disposes trustCertificates in the finally.
+            issuingCertificates = certificateAuthority.GetIssuingCaCertificates();
+            trustBundle = trustCertificates.Concat(issuingCertificates)
+                .Select(c => c.Export(X509ContentType.Cert)).ToList();
         }
         finally
         {
             foreach (var certificate in trustCertificates)
+                certificate.Dispose();
+            foreach (var certificate in issuingCertificates ?? [])
                 certificate.Dispose();
         }
 

--- a/src/modules/test/Eryph.ModuleCore.Tests/Components/ComponentEnrollmentClientTests.cs
+++ b/src/modules/test/Eryph.ModuleCore.Tests/Components/ComponentEnrollmentClientTests.cs
@@ -243,5 +243,7 @@ public class ComponentEnrollmentClientTests
             throw new NotSupportedException("The enrollment client tests do not use the server certificate.");
 
         public ComponentCertificatePem? ReadClientCertificatePem() => null;
+
+        public ComponentCertificatePem? ReadServerCertificatePem() => null;
     }
 }

--- a/src/modules/test/Eryph.ModuleCore.Tests/Components/FileComponentCertificateStoreReadPemTests.cs
+++ b/src/modules/test/Eryph.ModuleCore.Tests/Components/FileComponentCertificateStoreReadPemTests.cs
@@ -66,4 +66,62 @@ public class FileComponentCertificateStoreReadPemTests : IDisposable
 
         Store().ReadClientCertificatePem().Should().BeNull();
     }
+
+    [Fact]
+    public void ReadServerCertificatePem_AllFilesPresent_ReturnsPem()
+    {
+        Write("server.key", "KEYPEM");
+        Write("server.crt", "CERTPEM");
+        Write("ca-bundle.pem", "CAPEM");
+
+        var pem = Store().ReadServerCertificatePem();
+
+        pem.Should().NotBeNull();
+        pem!.PrivateKeyPem.Should().Be("KEYPEM");
+        pem.CertificatePem.Should().Be("CERTPEM");
+        pem.CaBundlePem.Should().Be("CAPEM");
+    }
+
+    [Fact]
+    public void ReadServerCertificatePem_AppendsIssuingChainToCertificate()
+    {
+        Write("server.key", "KEYPEM");
+        Write("server.crt", "LEAF\n");
+        Write("server-chain.pem", "INTERMEDIATE\n");
+        Write("ca-bundle.pem", "CAPEM");
+
+        var pem = Store().ReadServerCertificatePem();
+
+        pem!.CertificatePem.Should().Be("LEAF\nINTERMEDIATE\n");
+    }
+
+    [Fact]
+    public void ReadServerCertificatePem_ReadsServerTripleNotClientTriple()
+    {
+        // The server method must read the server.* files, not the client component.* files: the two
+        // present different EKUs (serverAuth vs clientAuth), so mixing them would break TLS.
+        Write("component.key", "CLIENTKEY");
+        Write("component.crt", "CLIENTCERT");
+        Write("server.key", "SERVERKEY");
+        Write("server.crt", "SERVERCERT");
+        Write("ca-bundle.pem", "CAPEM");
+
+        var pem = Store().ReadServerCertificatePem();
+
+        pem!.PrivateKeyPem.Should().Be("SERVERKEY");
+        pem.CertificatePem.Should().Be("SERVERCERT");
+    }
+
+    [Theory]
+    [InlineData("server.key")]
+    [InlineData("server.crt")]
+    [InlineData("ca-bundle.pem")]
+    public void ReadServerCertificatePem_MissingRequiredFile_ReturnsNull(string missing)
+    {
+        foreach (var name in new[] { "server.key", "server.crt", "ca-bundle.pem" })
+            if (name != missing)
+                Write(name, "X");
+
+        Store().ReadServerCertificatePem().Should().BeNull();
+    }
 }

--- a/src/modules/test/Eryph.ModuleCore.Tests/DistributedEndpointResolverTests.cs
+++ b/src/modules/test/Eryph.ModuleCore.Tests/DistributedEndpointResolverTests.cs
@@ -1,0 +1,63 @@
+using Eryph.ModuleCore;
+using FluentAssertions;
+using Xunit;
+
+namespace Eryph.ModuleCore.Tests;
+
+public class DistributedEndpointResolverTests
+{
+    [Fact]
+    public void TryGetRawEndpoint_Present_ReturnsTrueAndRawValue()
+    {
+        var resolver = new DistributedEndpointResolver();
+        resolver.Update(new Dictionary<string, string> { ["ovn-southbound"] = "ssl:host:6642" });
+
+        resolver.TryGetRawEndpoint("ovn-southbound", out var value).Should().BeTrue();
+        value.Should().Be("ssl:host:6642");
+    }
+
+    [Fact]
+    public void TryGetRawEndpoint_Missing_ReturnsFalse()
+    {
+        var resolver = new DistributedEndpointResolver();
+
+        resolver.TryGetRawEndpoint("ovn-southbound", out var value).Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryGetRawEndpoint_Whitespace_ReturnsFalse()
+    {
+        var resolver = new DistributedEndpointResolver();
+        resolver.Update(new Dictionary<string, string> { ["blank"] = "   " });
+
+        resolver.TryGetRawEndpoint("blank", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Update_ChangedContent_RaisesChanged()
+    {
+        var resolver = new DistributedEndpointResolver();
+        resolver.Update(new Dictionary<string, string> { ["a"] = "1" });
+
+        var raised = 0;
+        resolver.Changed += (_, _) => raised++;
+        resolver.Update(new Dictionary<string, string> { ["a"] = "2" });
+
+        raised.Should().Be(1);
+    }
+
+    [Fact]
+    public void Update_IdenticalContent_DoesNotRaiseChanged()
+    {
+        var resolver = new DistributedEndpointResolver();
+        resolver.Update(new Dictionary<string, string> { ["a"] = "1", ["b"] = "2" });
+
+        var raised = 0;
+        resolver.Changed += (_, _) => raised++;
+        // Same content, different insertion order — must be treated as no change.
+        resolver.Update(new Dictionary<string, string> { ["b"] = "2", ["a"] = "1" });
+
+        raised.Should().Be(0);
+    }
+}

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Networks/OvnNorthboundConnectionProviderTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Networks/OvnNorthboundConnectionProviderTests.cs
@@ -14,40 +14,6 @@ namespace Eryph.Modules.Controller.Tests.Networks;
 public class OvnNorthboundConnectionProviderTests
 {
     [Theory]
-    [InlineData("ssl:host:6641", "host", 6641)]
-    [InlineData("ssl:192.0.2.10:6641", "192.0.2.10", 6641)]
-    [InlineData("SSL:host:16641", "host", 16641)]
-    [InlineData("ssl:[fe80::1]:6641", "[fe80::1]", 6641)] // bracketed IPv6
-    [InlineData("  ssl:host:6641\t", "host", 6641)] // surrounding whitespace is trimmed
-    public void ParseSslEndpoint_Valid_ReturnsHostAndPort(string endpoint, string host, int port)
-    {
-        var result = OvnNorthboundConnectionProvider.ParseSslEndpoint(endpoint);
-
-        result.Host.Should().Be(host);
-        result.Port.Should().Be(port);
-    }
-
-    [Theory]
-    [InlineData("tcp:host:6641")] // wrong scheme
-    [InlineData("ssl:host")] // no port
-    [InlineData("ssl:host:port")] // non-numeric port
-    [InlineData("ssl::6641")] // empty host
-    [InlineData("ssl:   :6641")] // whitespace-only host
-    [InlineData("ssl:ho st:6641")] // whitespace inside the host
-    [InlineData("ssl:host: 6641")] // whitespace around the port
-    [InlineData("ssl:fe80::1:6641")] // bare (unbracketed) IPv6 host
-    [InlineData("ssl:host:0")] // port below range
-    [InlineData("ssl:host:99999")] // port above range
-    [InlineData("ssl:host:-5")] // negative port
-    [InlineData("host:6641")] // no scheme
-    public void ParseSslEndpoint_Invalid_Throws(string endpoint)
-    {
-        var act = () => OvnNorthboundConnectionProvider.ParseSslEndpoint(endpoint);
-
-        act.Should().Throw<InvalidOperationException>();
-    }
-
-    [Theory]
     [InlineData("host.domain.example", "host.domain.example", true)]
     [InlineData("HOST.domain.example", "host.domain.example", true)] // DNS is case-insensitive
     [InlineData("host", "host.domain.example", false)] // short name never equals the FQDN

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Configuration/VmHostAgentConfigurationTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Configuration/VmHostAgentConfigurationTests.cs
@@ -67,6 +67,26 @@ public class VmHostAgentConfigurationTests
         _fileMock.VerifyNoOtherCalls();
     }
 
+    [Fact]
+    public async Task GetConfigYaml_ConfigWithOvnOverlayIp_PreservesOvnSection()
+    {
+        // Regression: readConfig/applyHostDefaults (the read seam, distinct from the save seam) must
+        // preserve the ovn section — an earlier change dropped it, so the running agent and the
+        // get -> edit -> import workflow never saw the configured overlay transport IP.
+        _fileMock.Setup(m => m.Exists(ConfigPath)).Returns(true).Verifiable();
+        _fileMock.Setup(m => m.ReadAllText(ConfigPath, Encoding.UTF8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("""
+                          ovn:
+                            overlay_transport_ip: 10.0.0.5
+                          """)
+            .Verifiable();
+
+        var result = await getConfigYaml(ConfigPath, _hostSettings).Run(_runtime);
+
+        result.Should().BeSuccess().Which.Should()
+            .Contain("ovn:").And.Contain("overlay_transport_ip: 10.0.0.5");
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -391,6 +411,28 @@ public class VmHostAgentConfigurationTests
                 It.IsAny<CancellationToken>()),
             Times.Once);
         _fileMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task SaveConfig_ConfigWithOvnOverlayIp_PreservesOvnSection()
+    {
+        // Regression: the overlay transport IP must survive normalization + serialization (rebuilding
+        // the config for save previously dropped Ovn), and 'ovn:' appears only because it is set.
+        var config = new VmHostAgentConfiguration
+        {
+            Ovn = new VmHostAgentOvnConfiguration { OverlayTransportIp = "10.0.0.5" },
+        };
+
+        var result = await saveConfig(config, ConfigPath, _hostSettings).Run(_runtime);
+
+        result.Should().BeSuccess();
+        _fileMock.Verify(m => m.WriteAllText(
+                ConfigPath,
+                It.Is<string>(yaml =>
+                    yaml.Contains("ovn:") && yaml.Contains("overlay_transport_ip: 10.0.0.5")),
+                Encoding.UTF8,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     public readonly struct TestRuntime(TestRuntimeEnv env) :

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/OVNChassisServiceTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/OVNChassisServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Eryph.Core;
 using Eryph.Core.Network;
+using Eryph.ModuleCore.Components;
 
 namespace Eryph.Modules.HostAgent.HyperV.Test;
 
@@ -115,5 +116,76 @@ public class OVNChassisServiceTests
         plan.BridgeMappings.Find("nat").IfNoneUnsafe((string?)null).Should().Be("br-nat");
         plan.BridgeMappings.Find("tun").IfNoneUnsafe((string?)null).Should().Be("br-tun");
         plan.BridgeMappings.Find("flat").IsNone.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildChassisPlan_ConfiguredEncapIp_UsedAsTunnelEndpoint()
+    {
+        var config = new NetworkProvidersConfiguration { NetworkProviders = null };
+        var encapIp = IPAddress.Parse("10.0.0.21");
+
+        var plan = OVNChassisService.BuildChassisPlan(config, encapIp, southbound: null);
+
+        plan.TunnelEndpoints.Should().HaveCount(1);
+        plan.TunnelEndpoints[0].EncapsulationType.Should().Be("geneve");
+        plan.TunnelEndpoints[0].IpAddress.Should().Be(encapIp);
+    }
+
+    [Fact]
+    public void BuildChassisPlan_NoSouthbound_LeavesSouthboundNonSsl()
+    {
+        var config = new NetworkProvidersConfiguration { NetworkProviders = null };
+
+        var plan = OVNChassisService.BuildChassisPlan(config, IPAddress.Loopback, southbound: null);
+
+        // Co-located: the southbound connection is not switched to SSL and no OVS SSL material is set.
+        plan.SouthboundDatabase.Ssl.Should().BeFalse();
+        plan.PlannedSwitchSsl.Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildChassisPlan_RemoteSouthbound_SetsOvnRemoteSslAndSwitchSslAndEncapIp()
+    {
+        var config = new NetworkProvidersConfiguration
+        {
+            NetworkProviders =
+            [
+                new NetworkProvider { Name = "default", Type = NetworkProviderType.Overlay, BridgeName = "br-int" },
+            ],
+        };
+        var encapIp = IPAddress.Parse("10.0.0.21");
+        var pem = new ComponentCertificatePem("KEY-PEM", "CERT-PEM", "CA-PEM");
+        // The address is a resolved IP literal — OVS on Windows cannot dial a host name for 'ssl:'.
+        var southbound = new OVNChassisService.ChassisSouthbound("10.0.0.9", 6642, pem);
+
+        var plan = OVNChassisService.BuildChassisPlan(config, encapIp, southbound);
+
+        // ovn-remote points at the advertised SSL endpoint (resolved to an IP literal).
+        plan.SouthboundDatabase.Address.Should().Be("10.0.0.9");
+        plan.SouthboundDatabase.Port.Should().Be(6642);
+        plan.SouthboundDatabase.Ssl.Should().BeTrue();
+
+        // The OVS SSL table carries the agent's enrolled certificate material (ovn-controller reads it
+        // from there for the southbound connection).
+        plan.PlannedSwitchSsl.Should().NotBeNull();
+        plan.PlannedSwitchSsl!.PrivateKey.Should().Be("KEY-PEM");
+        plan.PlannedSwitchSsl.Certificate.Should().Be("CERT-PEM");
+        plan.PlannedSwitchSsl.CaCertificate.Should().Be("CA-PEM");
+
+        // The overlay tunnel endpoint uses the configured host IP, not loopback.
+        plan.TunnelEndpoints[0].IpAddress.Should().Be(encapIp);
+
+        // Bridge mappings are still applied on top of the SSL configuration.
+        plan.BridgeMappings.Find("default").IfNoneUnsafe((string?)null).Should().Be("br-int");
+    }
+
+    [Theory]
+    [InlineData("10.0.0.9", "10.0.0.9")]   // an IPv4 literal passes through unchanged
+    [InlineData("[fe80::1]", "[fe80::1]")] // a bracketed IPv6 literal stays bracketed for 'ssl:host:port'
+    public async Task ResolveToIp_IpLiteral_PreservesBracketingForRemote(string host, string expected)
+    {
+        // ovn-remote is an 'ssl:host:port' string, so an IPv6 address must remain bracketed to stay
+        // unambiguous with the port separator; an IPv4 address must not be bracketed.
+        (await OVNChassisService.ResolveToIp(host, CancellationToken.None)).Should().Be(expected);
     }
 }

--- a/src/modules/test/Eryph.Modules.Identity.Test/Services/ComponentEnrollmentServiceTests.cs
+++ b/src/modules/test/Eryph.Modules.Identity.Test/Services/ComponentEnrollmentServiceTests.cs
@@ -88,6 +88,32 @@ public class ComponentEnrollmentServiceTests
     }
 
     [Fact]
+    public async Task Enroll_includes_the_issuing_intermediates_in_the_ca_trust_bundle()
+    {
+        // OVS/ovn-controller presents a leaf-only chain over SSL, so a relying party needs the issuing
+        // intermediates in its trust bundle to build a path to the root. The bundle must therefore
+        // carry the intermediates in addition to the root(s), not just the roots.
+        var sut = CreateService(true);
+
+        var result = await sut.EnrollAsync(new ComponentEnrollmentRequest
+        {
+            ComponentType = ComponentType.VMHostAgent,
+            Fqdn = "agent1.eryph.local",
+            PublicKey = NewPublicKey(),
+        });
+
+        var bundle = new HashSet<string>();
+        foreach (var der in result.CaTrustBundle)
+            bundle.Add(Convert.ToHexString(der));
+
+        result.IssuingChain.Should().NotBeEmpty();
+        foreach (var intermediateDer in result.IssuingChain)
+            bundle.Should().Contain(Convert.ToHexString(intermediateDer),
+                "the CA trust bundle must include the issuing intermediate so a peer presenting a "
+                + "leaf-only chain can still build a path to the root");
+    }
+
+    [Fact]
     public async Task Enroll_also_issues_a_server_certificate_when_a_server_key_is_supplied()
     {
         var sut = CreateService(true);


### PR DESCRIPTION
Wires the Hyper-V agent's OVN chassis to dial a **remote** network module's southbound database over SSL/mTLS, so a chassis on a separate host can join the overlay (the split runtime). The agent resolves the advertised `ssl:host:6642` endpoint, sets `ovn-remote`, configures `ovn-controller` with its enrolled component certificate, and uses the host's real overlay IP as the Geneve encap address instead of loopback. The chassis plan is re-applied when the resolved endpoint changes.

Supporting fixes surfaced during a live split bring-up:
- OVS on Windows needs an IP literal (not a hostname) for the SB remote, so the agent resolves the advertised host to an address.
- The OVN SSL listeners present a server-auth leaf, so the network module reads the server certificate (serverAuth EKU) rather than the client one.
- The CA trust bundle now includes the issuing intermediates, since `ovn-controller` presents a leaf-only chain over SSL.
- New `VmHostAgentOvnConfiguration.OverlayTransportIp` for the encap IP.
- `ParseSslEndpoint` shared via `OvnRemoteEndpoints` (was northbound-only).
