### PR TITLE
Resolve host agents from the component registry for the split runtime

### DIFF
--- a/src/apps/src/Eryph-zero/HostControllerModuleExtensions.cs
+++ b/src/apps/src/Eryph-zero/HostControllerModuleExtensions.cs
@@ -69,6 +69,10 @@ public static class HostControllerModuleExtensions
                 container.RegisterInstance<IHostArchitectureProvider>(new HostArchitectureProvider());
                 container.RegisterSingleton<IPlacementCalculator, SingleHostPlacementCalculator>();
 
+                // Single local host: placement, storage-agent location and OVN topology resolve to the
+                // one local host agent / chassis. The split controller wires a registry-backed view.
+                container.RegisterSingleton<IComponentRegistry, SingleHostComponentRegistry>();
+
                 next(context, container);
             };
         }

--- a/src/apps/src/Eryph.Controller/ControllerPlacementCalculator.cs
+++ b/src/apps/src/Eryph.Controller/ControllerPlacementCalculator.cs
@@ -8,20 +8,23 @@ using static LanguageExt.Prelude;
 namespace Eryph.Controller;
 
 /// <summary>
-/// Placement for the standalone controller runtime.
+/// Basic placement for the standalone controller: every catlet is placed on the first registered host
+/// agent. <see cref="IComponentRegistry.GetHostAgents"/> returns agents in a deterministic order, so the
+/// selection is stable across calls and consistent with the other registry consumers. This is
+/// intentionally simple — no scoring across hosts and no architecture-capability filtering, because the
+/// controller does not yet receive the hosts' reported capabilities (architecture, free resources)
+/// through the component registry. Real multi-host scheduling is a later step; until then this places on
+/// the single available agent, and a host that cannot run the requested architecture surfaces the
+/// failure when the catlet is realized.
 /// </summary>
-/// <remarks>
-/// TODO: select the host agent and validate the requested architecture against the
-/// capabilities the registered host agents report, instead of returning the first
-/// registered agent. Until that exists this returns the single registered host.
-/// </remarks>
 internal sealed class ControllerPlacementCalculator(IComponentRegistry componentRegistry)
     : IPlacementCalculator
 {
     public Either<Error, string> CalculateVMPlacement(
         CatletConfig? dataConfig,
         Architecture architecture) =>
-        componentRegistry.GetHostAgents().HeadOrNone()
+        componentRegistry.GetHostAgents()
             .Map(agent => agent.AgentName)
+            .HeadOrNone()
             .ToEither(() => Error.New("No host agent is registered; cannot place the catlet."));
 }

--- a/src/apps/src/Eryph.Controller/HostControllerModuleExtensions.cs
+++ b/src/apps/src/Eryph.Controller/HostControllerModuleExtensions.cs
@@ -96,6 +96,11 @@ internal static class HostControllerModuleExtensions
                 // registered host agents (see ControllerPlacementCalculator for the open work).
                 container.RegisterSingleton<IPlacementCalculator, ControllerPlacementCalculator>();
 
+                // The read-side host-agent view is backed by the ComponentRegistration catalog, so
+                // placement, storage-agent location and OVN topology resolve the real registered agents
+                // (a Hyper-V host on another machine), not the controller's own machine name.
+                container.RegisterSingleton<IComponentRegistry, RegistryBackedComponentRegistry>();
+
                 // The split runtime manages a real broker, so the controller can delete a
                 // component's RabbitMQ user when it is decommissioned (the revocation cutoff);
                 // eryph-zero appends none and decommission only removes the registration.

--- a/src/modules/src/Eryph.Modules.Controller/ControllerModule.cs
+++ b/src/modules/src/Eryph.Modules.Controller/ControllerModule.cs
@@ -129,13 +129,11 @@ public class ControllerModule
         container.AddStateDbDataServices();
 
         container.Register<IProjectNetworkPlanBuilder, ProjectNetworkPlanBuilder>(Lifestyle.Scoped);
-        // KNOWN LIMITATION (deferred to the multi-host placement slice): the registry is
-        // single-host (derives the agent from Environment.MachineName / local chassis). It is
-        // correct for the all-in-one and the current single-host split dev runtime, but real
-        // multi-host placement must derive host agents from the ComponentRegistration catalog
-        // (IComponentRegistryService) instead. Not wired yet — same category as the documented
-        // network-sync accepted workaround.
-        container.RegisterSingleton<IComponentRegistry, SingleHostComponentRegistry>();
+        // IComponentRegistry (the read-side view of host agents that placement, storage-agent location
+        // and the OVN topology resolve from) is registered by the runtime host, like IPlacementCalculator:
+        // eryph-zero registers the single-host implementation, the standalone controller a registry-backed
+        // one that reads the ComponentRegistration catalog. This keeps the host-vs-single-host choice a DI
+        // composition decision rather than a runtime flag inside the module.
         container.RegisterSingleton<IClusterTopologyProvider, ComponentRegistryClusterTopologyProvider>();
         container.RegisterSingleton<INetworkSyncService, NetworkSyncService>();
 

--- a/src/modules/src/Eryph.Modules.Controller/IComponentRegistry.cs
+++ b/src/modules/src/Eryph.Modules.Controller/IComponentRegistry.cs
@@ -13,8 +13,10 @@ namespace Eryph.Modules.Controller;
 public interface IComponentRegistry
 {
     /// <summary>
-    /// The host agents currently part of the deployment. The single-host
-    /// implementation returns exactly one entry representing the local host.
+    /// The host agents currently part of the deployment, ordered deterministically by
+    /// <see cref="HostAgentComponent.AgentName"/> so that repeated calls and independent
+    /// consumers (placement, storage-agent location, OVN topology) always resolve to the same
+    /// agent. The single-host implementation returns exactly one entry representing the local host.
     /// </summary>
     Seq<HostAgentComponent> GetHostAgents();
 }

--- a/src/modules/src/Eryph.Modules.Controller/Inventory/InventoryTimerJob.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/InventoryTimerJob.cs
@@ -23,6 +23,19 @@ internal class InventoryTimerJob(Container container) : IJob
     public async Task Execute(IJobExecutionContext context)
     {
         _logger.LogDebug("Requesting scheduled inventory of all agents...");
+
+        // The two requests are independent: a failure to resolve/route the gene-pool inventory must not
+        // suppress the host inventory broadcast (and vice versa). Broadcast the VM/disk inventory request
+        // to all host agents first — it does not depend on resolving a specific agent.
+        try
+        {
+            await _bus.Advanced.Topics.Publish($"broadcast_{QueueNames.VMHostAgent}", new InventoryRequestedEvent());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to broadcast the host inventory request");
+        }
+
         try
         {
             // In the future, the gene pool might be shared between multiple agents. Hence,
@@ -33,13 +46,10 @@ internal class InventoryTimerJob(Container container) : IJob
                 {
                     AgentName = agentName,
                 });
-
-            // Broadcast the inventory request (for virtual machines and disks) to all agents
-            await _bus.Advanced.Topics.Publish($"broadcast_{QueueNames.VMHostAgent}", new InventoryRequestedEvent());
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to request scheduled inventory of all agents");
+            _logger.LogError(ex, "Failed to request gene pool inventory");
         }
     }
 }

--- a/src/modules/src/Eryph.Modules.Controller/RegistryBackedComponentRegistry.cs
+++ b/src/modules/src/Eryph.Modules.Controller/RegistryBackedComponentRegistry.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Eryph.Core;
+using Eryph.Messages.Components;
+using Eryph.Modules.Controller.Components;
+using Eryph.Rebus;
+using Eryph.StateDb.Model;
+using LanguageExt;
+using SimpleInjector;
+using SimpleInjector.Lifestyles;
+using static LanguageExt.Prelude;
+
+namespace Eryph.Modules.Controller;
+
+/// <summary>
+/// Resolves the deployment's host agents from the durable <see cref="ComponentRegistration"/> catalog
+/// (via <see cref="IComponentRegistryService"/>), so placement, storage-agent location and the OVN
+/// cluster topology see the real registered agents in a split/cluster runtime — unlike
+/// <see cref="SingleHostComponentRegistry"/>, which only ever reports the local machine. The standalone
+/// controller host wires this; eryph-zero keeps the single-host implementation.
+/// </summary>
+public sealed class RegistryBackedComponentRegistry(Container container) : IComponentRegistry
+{
+    public Seq<HostAgentComponent> GetHostAgents()
+    {
+        // IComponentRegistryService reads the state DB and is scoped, but this seam is a singleton
+        // resolved by singleton consumers — so open a dedicated scope per call (the OvnNorthbound
+        // provider does the same). The consumers (placement, storage-agent location, OVN topology) are
+        // synchronous, so block on the async read: these run on Rebus/Quartz worker threads with no
+        // synchronization context, so there is no deadlock.
+        using var scope = AsyncScopedLifestyle.BeginScope(container);
+        var registry = scope.GetInstance<IComponentRegistryService>();
+        var active = registry.GetActiveAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+        // Order deterministically by agent name so every consumer of this seam (placement,
+        // storage-agent location, OVN topology) picks the same agent from the same catalog — the
+        // state DB returns no ordering guarantee, so without this a catlet's VM could be placed on
+        // one host while its disks are resolved to another.
+        return active.ToSeq()
+            .Filter(c => c.ComponentType == ComponentType.VMHostAgent)
+            .Choose(ToHostAgent)
+            .OrderBy(agent => agent.AgentName, StringComparer.OrdinalIgnoreCase)
+            .ToSeq();
+    }
+
+    /// <summary>
+    /// Maps a host-agent registration to the routing/placement view. The agent name is the queue-name
+    /// suffix the agent chose (its <see cref="Environment.MachineName"/>), i.e. the segment after the
+    /// <c>eryph.vmhostagent.</c> prefix in its inbound queue — NOT <see cref="ComponentRegistration.MachineName"/>,
+    /// which is the FQDN and differs in case and domain from the queue key. Returns <c>None</c> for a row
+    /// whose inbound queue does not match the expected shape, so a malformed row is skipped rather than
+    /// producing a command routed to a queue that does not exist.
+    /// </summary>
+    internal static Option<HostAgentComponent> ToHostAgent(ComponentRegistration registration)
+    {
+        const string prefix = QueueNames.VMHostAgent + ".";
+        if (registration.InboundQueue is null
+            || !registration.InboundQueue.StartsWith(prefix, StringComparison.Ordinal))
+            return None;
+
+        var agentName = registration.InboundQueue[prefix.Length..];
+        if (string.IsNullOrWhiteSpace(agentName))
+            return None;
+
+        // The agent registers its own OVN chassis under the well-known local chassis name; priority 1 as
+        // the single-host provider used. (Distinct per-host chassis naming/priority for multi-host gateway
+        // election is a separate concern — every agent registers its chassis as "local" today.)
+        return Some(new HostAgentComponent(
+            agentName, EryphConstants.Networking.LocalChassisName, 1));
+    }
+}

--- a/src/modules/src/Eryph.Modules.Controller/SingleHostComponentRegistry.cs
+++ b/src/modules/src/Eryph.Modules.Controller/SingleHostComponentRegistry.cs
@@ -10,7 +10,7 @@ namespace Eryph.Modules.Controller;
 /// previous hard-coded providers used — the local machine name and the single
 /// local OVN chassis — so introducing the registry seam changes no behavior.
 /// </summary>
-internal sealed class SingleHostComponentRegistry : IComponentRegistry
+public sealed class SingleHostComponentRegistry : IComponentRegistry
 {
     public Seq<HostAgentComponent> GetHostAgents() =>
         Seq1(new HostAgentComponent(

--- a/src/modules/test/Eryph.Modules.Controller.Tests/RegistryBackedComponentRegistryTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/RegistryBackedComponentRegistryTests.cs
@@ -1,0 +1,109 @@
+using Eryph.Core;
+using Eryph.Messages.Components;
+using Eryph.Modules.Controller;
+using Eryph.Modules.Controller.Components;
+using Eryph.StateDb.Model;
+using SimpleInjector;
+using SimpleInjector.Lifestyles;
+
+namespace Eryph.Modules.Controller.Tests;
+
+public class RegistryBackedComponentRegistryTests
+{
+    [Fact]
+    public void GetHostAgents_ReturnsVmHostAgentsOrderedByName_SkippingNonAgentAndMalformedRows()
+    {
+        var active = new[]
+        {
+            Registration(ComponentType.VMHostAgent, "eryph.vmhostagent.WASD30"),
+            Registration(ComponentType.Network, "eryph.network.WASD10"),      // not an agent → filtered
+            Registration(ComponentType.VMHostAgent, "eryph.vmhostagent.wasd05"),
+            Registration(ComponentType.VMHostAgent, "eryph.vmhostagent."),    // malformed → skipped
+            Registration(ComponentType.VMHostAgent, "eryph.vmhostagent.WASD20"),
+        };
+
+        var agents = CreateRegistry(active).GetHostAgents();
+
+        // Deterministic, case-insensitive order so every consumer resolves to the same first agent.
+        agents.Select(a => a.AgentName).ToList()
+            .Should().Equal("wasd05", "WASD20", "WASD30");
+    }
+
+    [Fact]
+    public void GetHostAgents_NoAgents_ReturnsEmpty()
+    {
+        CreateRegistry([]).GetHostAgents().Should().BeEmpty();
+    }
+
+    private static RegistryBackedComponentRegistry CreateRegistry(
+        IReadOnlyList<ComponentRegistration> active)
+    {
+        var container = new Container();
+        container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
+        container.Register<IComponentRegistryService>(() => new StubRegistry(active), Lifestyle.Scoped);
+        return new RegistryBackedComponentRegistry(container);
+    }
+
+    [Fact]
+    public void ToHostAgent_HostAgentRow_MapsAgentNameFromInboundQueue()
+    {
+        var registration = Registration(ComponentType.VMHostAgent, "eryph.vmhostagent.WASD12");
+
+        var result = RegistryBackedComponentRegistry.ToHostAgent(registration);
+
+        result.IsSome.Should().BeTrue();
+        var agent = result.IfNoneUnsafe(() => null!);
+        // The routing key is the queue suffix (Environment.MachineName), not the FQDN MachineName.
+        agent.AgentName.Should().Be("WASD12");
+        agent.ChassisName.Should().Be(EryphConstants.Networking.LocalChassisName);
+        agent.ChassisPriority.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("eryph.genepool.WASD12")] // a different component's queue shape
+    [InlineData("eryph.vmhostagent")] // no suffix
+    [InlineData("eryph.vmhostagent.")] // empty suffix
+    [InlineData("something.else.WASD12")] // wrong prefix
+    public void ToHostAgent_MalformedInboundQueue_ReturnsNone(string inboundQueue)
+    {
+        var registration = Registration(ComponentType.VMHostAgent, inboundQueue);
+
+        RegistryBackedComponentRegistry.ToHostAgent(registration).IsNone.Should().BeTrue();
+    }
+
+    private static ComponentRegistration Registration(ComponentType type, string inboundQueue) =>
+        new()
+        {
+            ComponentType = type,
+            MachineName = "wasd12.was.corp",
+            InboundQueue = inboundQueue,
+        };
+
+    /// <summary>
+    /// Hand-written stub: <see cref="IComponentRegistryService"/> is internal, which Moq cannot proxy.
+    /// Only GetActiveAsync is exercised here.
+    /// </summary>
+    private sealed class StubRegistry(IReadOnlyList<ComponentRegistration> active) : IComponentRegistryService
+    {
+        public Task<ComponentRegistration> UpsertAsync(RegisterComponentCommand command,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task RecordHeartbeatAsync(Guid componentId, Guid instanceId,
+            IReadOnlyDictionary<ConfigDomain, long> appliedConfigVersions, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task RecordAppliedAsync(Guid componentId, ConfigDomain domain, long version,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<bool> DeregisterAsync(Guid componentId, Guid instanceId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<bool> RemoveRegistrationAsync(Guid componentId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<ComponentRegistration>> GetActiveAsync(CancellationToken cancellationToken)
+            => Task.FromResult(active);
+    }
+}


### PR DESCRIPTION
In the split runtime the controller runs in its own container, so the single-host locator's `Environment.MachineName` no longer names a real Hyper-V host — inventory and placement break. This adds a registry-backed `IComponentRegistry` that lists live `VMHostAgent` components from the component-registry service (deriving the agent name from its bound queue), and wires DI so the standalone controller host uses it while eryph-zero keeps the single-host locator. `ControllerPlacementCalculator` now picks the first agent deterministically instead of assuming the local host.

`InventoryTimerJob`'s host-broadcast and gene-pool send are split into independent try/catch blocks so one failing no longer suppresses the other.
