### PR TITLE
Seed the identity API scopes from the module

### DIFF
--- a/src/apps/src/Eryph-zero/HostIdentityModuleExtensions.cs
+++ b/src/apps/src/Eryph-zero/HostIdentityModuleExtensions.cs
@@ -72,11 +72,10 @@ public static class HostIdentityModuleExtensions
 
                 next(context, container);
 
-                // Client persistence is now handled by the identity module's change-tracking export
+                // Client persistence is handled by the identity module's change-tracking export
                 // (replacing the old ClientServiceWithConfigServiceDecorator write-through) and its
-                // ClientSeeder (replacing IdentityClientSeeder). IFileSystem + SeedFromConfigHandler
-                // are registered by the module. Only the scope seeder remains zero-specific.
-                container.Collection.Append<IConfigSeeder<IdentityModule>, IdentityScopesSeeder>();
+                // ClientSeeder (replacing IdentityClientSeeder); scope seeding is module-owned too. So
+                // eryph-zero adds no identity seeders of its own here.
 
                 // Supply the system-client key store the module's SystemClientBootstrap resolves. It keeps
                 // the DPAPI-encrypted system-client.key at the client-config path (the external contract),

--- a/src/modules/src/Eryph.Modules.Identity/ChangeTracking/IdentityChangeTrackingContainerExtensions.cs
+++ b/src/modules/src/Eryph.Modules.Identity/ChangeTracking/IdentityChangeTrackingContainerExtensions.cs
@@ -49,9 +49,11 @@ public static class IdentityChangeTrackingContainerExtensions
         {
             // Always append (so the IConfigSeeder<IdentityModule> collection is registered even when no
             // other seeders are — SimpleInjector requires the collection to exist for SeedFromConfigHandler
-            // to resolve it). The seeder itself honours IdentityChangeTrackingConfig.SeedDatabase, so it is a
-            // no-op when seeding is disabled. eryph-zero appends its own client/scope seeders too; the appends
-            // compose into one collection that the single handler runs.
+            // to resolve it). The client/token seeders honour IdentityChangeTrackingConfig.SeedDatabase, so
+            // they are a no-op when seeding is disabled; the scope seeder always runs, because the token
+            // endpoint needs the API scopes registered regardless of the change-tracking config. eryph-zero
+            // appends its own client seeder too; the appends compose into one collection the single handler runs.
+            options.Container.Collection.Append<IConfigSeeder<IdentityModule>, IdentityScopesSeeder>(Lifestyle.Scoped);
             options.Container.Collection.Append<IConfigSeeder<IdentityModule>, ClientSeeder>(Lifestyle.Scoped);
             options.Container.Collection.Append<IConfigSeeder<IdentityModule>, RedeemedTokenSeeder>(Lifestyle.Scoped);
 

--- a/src/modules/src/Eryph.Modules.Identity/Seeding/IdentityScopesSeeder.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Seeding/IdentityScopesSeeder.cs
@@ -1,14 +1,18 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 using Eryph.Configuration;
 using Eryph.Core;
-using Eryph.Modules.Identity;
-using JetBrains.Annotations;
 using OpenIddict.Abstractions;
 
-namespace Eryph.Runtime.Zero.Configuration.Clients;
+namespace Eryph.Modules.Identity.Seeding;
 
-[UsedImplicitly]
+/// <summary>
+/// Registers the eryph API scopes (<see cref="EryphConstants.Authorization.AllScopes"/>) as OpenIddict
+/// scope resources on startup, so the token endpoint accepts them. Module-owned (not host-specific): the
+/// scopes are a shared constant and both eryph-zero and the standalone identity host need them — without
+/// this the token endpoint rejects every scoped request with <c>invalid_scope</c>. Add-only: an existing
+/// scope is left untouched.
+/// </summary>
 internal class IdentityScopesSeeder(
     IOpenIddictScopeManager scopeManager)
     : IConfigSeeder<IdentityModule>
@@ -17,7 +21,8 @@ internal class IdentityScopesSeeder(
     {
         foreach (var scope in EryphConstants.Authorization.AllScopes)
         {
-            if (await scopeManager.FindByNameAsync(scope.Name, stoppingToken) is not null) continue;
+            if (await scopeManager.FindByNameAsync(scope.Name, stoppingToken) is not null)
+                continue;
 
             var descriptor = new OpenIddictScopeDescriptor
             {


### PR DESCRIPTION
The scope registration (`IdentityScopesSeeder`) lived only in the eryph-zero apps layer, so a standalone split-runtime identity host booted with no `OpenIddictScopes` rows and rejected every scoped token request with `invalid_scope`. The bootstrapped system-client could authenticate via cert-JWT but could not obtain a usable token.

The scopes are a shared constant (`EryphConstants.Authorization.AllScopes`) with no host-specific dependency, so move the seeder into the identity module (registered in `AddIdentitySeeding`, run regardless of the change-tracking `SeedDatabase` flag) and drop the eryph-zero copy. Both packagings now register the scopes identically — the same convergence as the system-client bootstrap (#405).

Verified end to end against the split-runtime mTLS cluster: `create-db` builds the OpenIddict schema, the identity host bootstraps the system-client and its break-glass key, seeds the scopes, and the system-client obtains a Bearer access token (audience `compute_api` + `identity_api`) via the cert-JWT flow.
