### PR TITLE
Configure component access URL uniformly (endpoints:public)

### DIFF
--- a/docker/cluster/compose.scale.yml
+++ b/docker/cluster/compose.scale.yml
@@ -24,7 +24,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: https://+:8080
-      ERYPH_IDENTITY_BASEURL: https://identity-lb:8080/
+      endpoints__public: https://identity-lb:8080/
       ERYPH_IDENTITYDB_CONNECTIONSTRING: "Server=mariadb;Port=3306;Database=eryph_identity;User Id=root;Password=eryph"
       RABBITMQ_CONNECTIONSTRING: "amqps://guest:guest@rabbit:5671"
       ERYPH_PKI_KEYSTORE: file
@@ -67,11 +67,11 @@ services:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: https://+:8000
       ERYPH_STATEDB_CONNECTIONSTRING: "Server=mariadb;Port=3306;Database=eryph;User Id=root;Password=eryph"
-      ERYPH_IDENTITY_URL: "https://identity-lb:8080/identity"
+      endpoints__public: https://compute-lb:8000/
+      ERYPH_IDENTITY_URL: "https://identity-lb:8080/"
       RABBITMQ_CONNECTIONSTRING: "amqps://guest:guest@rabbit:5671"
       componentMtls__enrollmentFile: /enroll/apiendpoint2.json
       componentMtls__certificateDirectory: /apiendpoint2-certs
-      componentMtls__serverDnsNames: compute-lb
     volumes:
       - apiendpoint2-certs:/apiendpoint2-certs
       - enroll:/enroll:ro

--- a/docker/cluster/compose.yml
+++ b/docker/cluster/compose.yml
@@ -125,10 +125,12 @@ services:
       identity-dbsetup: { condition: service_completed_successfully }
     environment:
       ASPNETCORE_ENVIRONMENT: Development
+      # Listening address (all interfaces) — independent of the access URL below.
       ASPNETCORE_URLS: https://+:8080
-      # Issuer + self-issued server-cert SAN target the LB host, so any identity replica is valid
-      # behind the load balancer (and tokens carry a stable issuer).
-      ERYPH_IDENTITY_BASEURL: https://identity-lb:8080/
+      # The access URL clients and components use to reach identity: the LB host. Drives the advertised
+      # endpoint, the self-issued server-cert SAN and (via the request-derived issuer, since clients use
+      # this URL) the token issuer — all identical, so any replica behind the LB is valid.
+      endpoints__public: https://identity-lb:8080/
       ERYPH_IDENTITYDB_CONNECTIONSTRING: "Server=mariadb;Port=3306;Database=eryph_identity;User Id=root;Password=eryph"
       RABBITMQ_CONNECTIONSTRING: "amqps://guest:guest@rabbit:5671"
       ERYPH_PKI_KEYSTORE: file
@@ -208,14 +210,18 @@ services:
       identity: { condition: service_started }
     environment:
       ASPNETCORE_ENVIRONMENT: Development
+      # Listening address — independent of the access URL below.
       ASPNETCORE_URLS: https://+:8000
       ERYPH_STATEDB_CONNECTIONSTRING: "Server=mariadb;Port=3306;Database=eryph;User Id=root;Password=eryph"
-      ERYPH_IDENTITY_URL: "https://identity-lb:8080/identity"
+      # This component's own access URL (LB host): its advertised endpoint and the SAN it requests for
+      # its enrolled server certificate (so clients reaching compute-lb validate it).
+      endpoints__public: https://compute-lb:8000/
+      # The identity access URL used as the JWT authority — the identity's own root URL (no /identity
+      # prefix: identity serves at its host root, so that is where discovery and the issuer live).
+      ERYPH_IDENTITY_URL: "https://identity-lb:8080/"
       RABBITMQ_CONNECTIONSTRING: "amqps://guest:guest@rabbit:5671"
       componentMtls__enrollmentFile: /enroll/apiendpoint.json
       componentMtls__certificateDirectory: /apiendpoint-certs
-      # Serve a certificate for the LB host so clients reaching compute-lb validate it.
-      componentMtls__serverDnsNames: compute-lb
     volumes:
       - apiendpoint-certs:/apiendpoint-certs
       - enroll:/enroll:ro

--- a/src/apps/src/Eryph.ApiEndpoint/ApiEndpointContainerExtensions.cs
+++ b/src/apps/src/Eryph.ApiEndpoint/ApiEndpointContainerExtensions.cs
@@ -44,24 +44,25 @@ internal static class ApiEndpointContainerExtensions
 
     private static Dictionary<string, string> GetEndpoints()
     {
-        var baseUrl = Environment.GetEnvironmentVariable("ERYPH_API_BASEURL")
-                      ?? "http://localhost:8081/";
-        // Normalize so appending a path segment ("{baseUrl}compute") can't yield
-        // a malformed URL when the env value is supplied without a trailing '/'.
-        if (!baseUrl.EndsWith('/'))
-            baseUrl += "/";
-        var computeUrl = Environment.GetEnvironmentVariable("ERYPH_COMPUTE_URL")
-                         ?? $"{baseUrl}compute";
-        // The identity issuer used as the JWT authority. In a real deployment this is the
-        // distributed/overridden identity endpoint; for the standalone dev run it is config.
+        // The compute API's own public access URL (endpoints:public) — its advertised endpoint and
+        // module path, and the host baked into its enrolled server certificate. Independent of
+        // ASPNETCORE_URLS (the bind address), so a load balancer can front it. It serves at the root of
+        // its own host, so the URL carries no path prefix.
+        var accessUrl = (ComponentPublicEndpoint.GetFromEnvironment()
+            ?? throw new InvalidOperationException(
+                "endpoints:public must be set to the compute API access URL.")).ToString();
+
+        // The identity access URL used as the JWT authority — a consumer pointer to another component,
+        // so it stays its own value (the identity's endpoints:public, addressed at its host root).
         var identityUrl = Environment.GetEnvironmentVariable("ERYPH_IDENTITY_URL")
-                          ?? "http://localhost:8080/identity";
+            ?? throw new InvalidOperationException(
+                "ERYPH_IDENTITY_URL must be set to the identity access URL (the JWT authority).");
 
         return new Dictionary<string, string>
         {
-            ["base"] = baseUrl,
-            ["default"] = baseUrl,
-            ["compute"] = computeUrl,
+            ["base"] = accessUrl,
+            ["default"] = accessUrl,
+            ["compute"] = accessUrl,
             ["identity"] = identityUrl,
         };
     }

--- a/src/apps/src/Eryph.Identity/IdentityContainerExtensions.cs
+++ b/src/apps/src/Eryph.Identity/IdentityContainerExtensions.cs
@@ -76,33 +76,29 @@ internal static class IdentityContainerExtensions
     public static string GetSystemClientKeyFile()
         => Path.Combine(PkiOptions.Resolve().Directory, "system-client.key");
 
-    /// <summary>The identity component's own public URL (config/env, default for dev).</summary>
-    public static string GetIdentityUrl()
-    {
-        return Environment.GetEnvironmentVariable("ERYPH_IDENTITY_URL")
-               ?? $"{GetBaseUrl()}identity";
-    }
-
     /// <summary>
-    /// The base URL the identity host listens on, always normalized to end with '/'
-    /// so callers can safely append path segments (e.g. "{baseUrl}identity").
+    /// The identity component's public access URL (<c>endpoints:public</c>) — the URL clients and peer
+    /// components use to reach it. It is its advertised endpoint, its module path and (via the served
+    /// path) its OpenIddict issuer, so all three agree; it carries no path prefix because the identity
+    /// owns its whole host and serves at its root. Independent of <c>ASPNETCORE_URLS</c> (the bind
+    /// address), so a load balancer can front it. Required — the component must know how it is reached.
     /// </summary>
-    private static string GetBaseUrl()
-    {
-        var baseUrl = Environment.GetEnvironmentVariable("ERYPH_IDENTITY_BASEURL")
-                      ?? "http://localhost:8080/";
-        return baseUrl.EndsWith('/') ? baseUrl : baseUrl + "/";
-    }
+    public static string GetAccessUrl()
+        => (ComponentPublicEndpoint.GetFromEnvironment()
+            ?? throw new InvalidOperationException(
+                "endpoints:public must be set to the identity access URL (the URL clients and "
+                + "components use to reach identity)."))
+           .ToString();
 
     private static Dictionary<string, string> GetOwnEndpoints()
     {
-        var baseUrl = GetBaseUrl();
+        var accessUrl = GetAccessUrl();
 
         return new Dictionary<string, string>
         {
-            ["base"] = baseUrl,
-            ["default"] = baseUrl,
-            ["identity"] = GetIdentityUrl(),
+            ["base"] = accessUrl,
+            ["default"] = accessUrl,
+            ["identity"] = accessUrl,
         };
     }
 }

--- a/src/apps/src/Eryph.Identity/IdentityServerTls.cs
+++ b/src/apps/src/Eryph.Identity/IdentityServerTls.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
+using Eryph.ModuleCore;
 using Eryph.Modules.AspNetCore.Components;
 using Eryph.Modules.Identity.Services;
 using Microsoft.AspNetCore.Hosting;
@@ -21,16 +22,16 @@ internal static class IdentityServerTls
     {
         webHostBuilder.ConfigureKestrel((context, options) =>
         {
-            // Require an explicit base URL: the host name is baked into the self-issued server
-            // certificate, so falling back to "localhost" would silently issue a certificate
-            // components can never validate against the address they connect to.
-            var baseUrl = context.Configuration["ERYPH_IDENTITY_BASEURL"];
-            if (string.IsNullOrWhiteSpace(baseUrl)
-                || !Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri))
+            // The host name(s) baked into the self-issued server certificate come from the component's
+            // access URL (endpoints:public), the same value it advertises — so the certificate matches
+            // the address components connect to. componentMtls:serverDnsNames can override for a
+            // multi-SAN certificate. Require it: falling back to "localhost" would silently issue a
+            // certificate components can never validate against the address they connect to.
+            var dnsNames = ComponentPublicEndpoint.GetServerDnsNames(context.Configuration);
+            if (dnsNames.Count == 0)
                 throw new InvalidOperationException(
-                    "ERYPH_IDENTITY_BASEURL must be set to an absolute URL; it is required to issue the "
-                    + "identity server certificate for the correct host name.");
-            var dnsName = baseUri.Host;
+                    "endpoints:public must be set to the identity access URL; its host is baked into the "
+                    + "self-issued identity server certificate (or set componentMtls:serverDnsNames).");
 
             // Build the platform key/cert backend directly (the listener runs outside the module
             // container, so it cannot resolve these from DI). PkiOptions.CreateServices is the same
@@ -39,7 +40,7 @@ internal static class IdentityServerTls
             var (keyService, storeService, generator) = PkiOptions.CreateServices();
             var certificateAuthority = new ComponentCertificateAuthority(storeService, generator, keyService);
             var issued = new CaServerCertificateProvider(keyService, certificateAuthority)
-                .GetServerCertificate(dnsName);
+                .GetServerCertificate(dnsNames);
 
             var chain = new X509Certificate2Collection();
             foreach (var certificate in issued.IssuingChain)

--- a/src/modules/src/Eryph.ModuleCore/ComponentPublicEndpoint.cs
+++ b/src/modules/src/Eryph.ModuleCore/ComponentPublicEndpoint.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+
+namespace Eryph.ModuleCore;
+
+/// <summary>
+/// A component's public access URL (config key <c>endpoints:public</c>) — the URL at which clients and
+/// peer components reach it. It is the single source for both the component's advertised endpoint and
+/// the host name baked into its server certificate. It is deliberately independent of
+/// <c>ASPNETCORE_URLS</c> (the listening address), so a reverse proxy / load balancer can front the
+/// component. Every ASP.NET-serving component configures it the same way; there is no per-component key.
+/// </summary>
+public static class ComponentPublicEndpoint
+{
+    private const string PublicEndpointKey = "endpoints:public";
+    private const string ServerDnsNamesKey = "componentMtls:serverDnsNames";
+
+    /// <summary>The public access URL, or <see langword="null"/> when not configured.</summary>
+    public static Uri? Get(IConfiguration configuration) => Parse(configuration[PublicEndpointKey]);
+
+    /// <summary>
+    /// The public access URL read from the environment (<c>endpoints__public</c>), for hosts that
+    /// build their endpoint map before an <see cref="IConfiguration"/> is available.
+    /// </summary>
+    public static Uri? GetFromEnvironment() =>
+        Parse(Environment.GetEnvironmentVariable("endpoints__public"));
+
+    /// <summary>
+    /// The server-certificate DNS names: the explicit <c>componentMtls:serverDnsNames</c> override
+    /// (comma-separated, for a multi-SAN certificate) when set; otherwise the single host of the public
+    /// access URL; otherwise empty (the caller falls back to the component FQDN).
+    /// </summary>
+    public static IReadOnlyList<string> GetServerDnsNames(IConfiguration configuration)
+    {
+        var explicitNames = Split(configuration[ServerDnsNamesKey]);
+        if (explicitNames.Count > 0)
+            return explicitNames;
+
+        var url = Get(configuration);
+        return url is null ? [] : [url.Host];
+    }
+
+    private static Uri? Parse(string? value) =>
+        Uri.TryCreate(value, UriKind.Absolute, out var uri) ? uri : null;
+
+    private static IReadOnlyList<string> Split(string? value) =>
+        (value ?? "").Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+}

--- a/src/modules/src/Eryph.ModuleCore/Components/ComponentMtlsTransport.cs
+++ b/src/modules/src/Eryph.ModuleCore/Components/ComponentMtlsTransport.cs
@@ -78,11 +78,11 @@ public static class ComponentMtlsTransport
         {
             ["identity"] = enrollment.IdentityEndpoint,
         });
-        // A component behind a load balancer must serve a certificate for the LB host name, not just
-        // its own FQDN; componentMtls:serverDnsNames (comma-separated) sets the server certificate
-        // SAN(s) it requests at enrollment. Empty means the component's own FQDN is used.
-        var serverDnsNames = (mtls["serverDnsNames"] ?? "")
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        // A component behind a load balancer must serve a certificate for the access-URL host name, not
+        // just its own FQDN. The server certificate SAN(s) requested at enrollment default to the host
+        // of the public access URL (endpoints:public); componentMtls:serverDnsNames overrides that for a
+        // multi-SAN certificate. Empty (neither configured) means the component's own FQDN is used.
+        var serverDnsNames = ComponentPublicEndpoint.GetServerDnsNames(configuration);
         var options = new ComponentEnrollmentClientOptions
         {
             Token = enrollment.Token,

--- a/src/modules/src/Eryph.Modules.Identity/Services/CaServerCertificateProvider.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Services/CaServerCertificateProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Eryph.Security.Cryptography;
 
@@ -14,12 +15,12 @@ public sealed class CaServerCertificateProvider(
     IComponentCertificateAuthority certificateAuthority)
     : IServerCertificateProvider
 {
-    public IssuedCertificate GetServerCertificate(string dnsName)
+    public IssuedCertificate GetServerCertificate(IReadOnlyList<string> dnsNames)
     {
         // CopyWithPrivateKey binds an independent copy of the key into the returned certificate, so
         // the source key can be disposed once the bound leaf has been created.
         using var key = certificateKeyService.GenerateRsaKey(2048);
-        var issued = certificateAuthority.IssueServerCertificate([dnsName], key);
+        var issued = certificateAuthority.IssueServerCertificate(dnsNames, key);
 
         // The server presents the leaf, so it needs the private key bound; the issuing chain is
         // carried through unchanged for the listener to present alongside it. The key is re-imported

--- a/src/modules/src/Eryph.Modules.Identity/Services/IServerCertificateProvider.cs
+++ b/src/modules/src/Eryph.Modules.Identity/Services/IServerCertificateProvider.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Eryph.Modules.Identity.Services;
 
 /// <summary>
@@ -9,8 +11,9 @@ namespace Eryph.Modules.Identity.Services;
 public interface IServerCertificateProvider
 {
     /// <summary>
-    /// The server-TLS certificate (leaf, with private key) for <paramref name="dnsName"/> plus the
-    /// issuing intermediate(s) to present so a relying party can chain it to a trusted root.
+    /// The server-TLS certificate (leaf, with private key) for <paramref name="dnsNames"/> — the first
+    /// is the subject common name, all are subject alternative names — plus the issuing intermediate(s)
+    /// to present so a relying party can chain it to a trusted root.
     /// </summary>
-    IssuedCertificate GetServerCertificate(string dnsName);
+    IssuedCertificate GetServerCertificate(IReadOnlyList<string> dnsNames);
 }

--- a/src/modules/test/Eryph.ModuleCore.Tests/ComponentPublicEndpointTests.cs
+++ b/src/modules/test/Eryph.ModuleCore.Tests/ComponentPublicEndpointTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using Eryph.ModuleCore;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Eryph.ModuleCore.Tests;
+
+public class ComponentPublicEndpointTests
+{
+    [Fact]
+    public void Get_returns_the_configured_public_url()
+    {
+        var config = Build(("endpoints:public", "https://identity-lb:8080/"));
+
+        ComponentPublicEndpoint.Get(config)!.ToString().Should().Be("https://identity-lb:8080/");
+    }
+
+    [Fact]
+    public void Get_returns_null_when_unset_or_not_absolute()
+    {
+        ComponentPublicEndpoint.Get(Build()).Should().BeNull();
+        ComponentPublicEndpoint.Get(Build(("endpoints:public", "not a url"))).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetServerDnsNames_defaults_to_the_public_url_host()
+    {
+        var config = Build(("endpoints:public", "https://compute-lb:8000/"));
+
+        ComponentPublicEndpoint.GetServerDnsNames(config).Should().Equal("compute-lb");
+    }
+
+    [Fact]
+    public void GetServerDnsNames_uses_the_explicit_override_when_set()
+    {
+        // The explicit multi-SAN override wins over the public-url host.
+        var config = Build(
+            ("endpoints:public", "https://compute-lb:8000/"),
+            ("componentMtls:serverDnsNames", "compute-lb, compute.example.test"));
+
+        ComponentPublicEndpoint.GetServerDnsNames(config)
+            .Should().Equal("compute-lb", "compute.example.test");
+    }
+
+    [Fact]
+    public void GetServerDnsNames_is_empty_when_neither_is_configured()
+    {
+        ComponentPublicEndpoint.GetServerDnsNames(Build()).Should().BeEmpty();
+    }
+
+    private static IConfiguration Build(params (string Key, string Value)[] values)
+    {
+        var dict = new Dictionary<string, string?>();
+        foreach (var (key, value) in values)
+            dict[key] = value;
+        return new ConfigurationBuilder().AddInMemoryCollection(dict).Build();
+    }
+}

--- a/src/modules/test/Eryph.Modules.Identity.Test/Services/CaServerCertificateProviderTests.cs
+++ b/src/modules/test/Eryph.Modules.Identity.Test/Services/CaServerCertificateProviderTests.cs
@@ -19,7 +19,7 @@ public class CaServerCertificateProviderTests
             new InMemoryCertificateStore(), new CertificateGenerator(), keyService);
         var sut = new CaServerCertificateProvider(keyService, ca);
 
-        using var issued = sut.GetServerCertificate("identity.eryph.local");
+        using var issued = sut.GetServerCertificate(["identity.eryph.local"]);
 
         issued.Leaf.HasPrivateKey.Should().BeTrue("the listener must be able to present the key");
         issued.IssuingChain.Should().NotBeEmpty();


### PR DESCRIPTION
The split-runtime Kestrel hosts bind `host:port` only, so a `WebModule` serves at its host root — but `module.Path`, the advertised endpoint and consumers' JWT authority all carried a `/identity` (or `/compute`) prefix that was never served. OpenIddict therefore minted a bare-root issuer while the compute API's authority pointed at `.../identity`, so every token failed validation (`IDX10204`). eryph-zero only worked because http.sys `UrlPrefixes` sets the `PathBase` as a side effect.

This introduces one access-URL concept every ASP.NET component configures the same way — **`endpoints:public`**: the URL clients and peers use to reach the component, independent of `ASPNETCORE_URLS` (the listening address, so a reverse proxy / load balancer can front it). It drives both the advertised endpoint and the server-certificate host name (self-issued for identity, requested at enrollment for the others); `componentMtls:serverDnsNames` remains an optional multi-SAN override. The issuer stays request-derived — it matches because clients use this same URL. No path prefixes: each split component serves at its own host root.

Replaces the per-component `ERYPH_IDENTITY_BASEURL` / `ERYPH_API_BASEURL` and the standalone `serverDnsNames` default with one uniform key.

Verified end to end against the split mTLS cluster: after the change the compute API accepts a system-client token issued via the load balancer, and a catlet submission is accepted (HTTP 202) and reaches controller placement.
