### PR TITLE
Use ReadCommitted for the controller unit of work on MariaDB

### DIFF
--- a/src/modules/src/Eryph.Modules.Controller/StateStoreDbUnitOfWork.cs
+++ b/src/modules/src/Eryph.Modules.Controller/StateStoreDbUnitOfWork.cs
@@ -1,7 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Data;
+using System.Threading.Tasks;
 using Dbosoft.Rebus;
 using Eryph.StateDb;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Eryph.Modules.Controller;
@@ -15,8 +18,21 @@ public sealed class StateStoreDbUnitOfWork(
 
     public async Task Initialize()
     {
-        _dbTransaction = await dbContext.Database.BeginTransactionAsync();
+        // A message handler's transaction wraps the whole handler. On MariaDB (the split-runtime store)
+        // the default REPEATABLE READ takes a consistent snapshot, so a row another process committed
+        // after the snapshot is invisible for the rest of the handler — the split-runtime
+        // "Operation not found" when the controller handles an operation the compute API just created.
+        // ReadCommitted re-reads the latest committed data on each statement.
+        //
+        // SQLite (eryph-zero, one process) has no such cross-process window and only supports
+        // Serializable/ReadUncommitted — asking for ReadCommitted throws — so it keeps its default there.
+        _dbTransaction = IsSqlite
+            ? await dbContext.Database.BeginTransactionAsync()
+            : await dbContext.Database.BeginTransactionAsync(IsolationLevel.ReadCommitted);
     }
+
+    private bool IsSqlite =>
+        dbContext.Database.ProviderName?.Contains("Sqlite", StringComparison.OrdinalIgnoreCase) == true;
 
     public async Task Commit()
     {

--- a/src/modules/test/Eryph.Modules.Controller.Tests/StateStoreDbUnitOfWorkTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/StateStoreDbUnitOfWorkTests.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using Eryph.StateDb;
+using Eryph.StateDb.TestBase;
+using FluentAssertions;
+using SimpleInjector;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Eryph.Modules.Controller.Tests;
+
+public class StateStoreDbUnitOfWorkTests(ITestOutputHelper outputHelper)
+    : InMemoryStateDbTestBase(outputHelper)
+{
+    /// <summary>
+    /// Guards the provider-aware isolation choice in <see cref="StateStoreDbUnitOfWork.Initialize"/>:
+    /// SQLite (eryph-zero and this test store) only supports Serializable/ReadUncommitted and throws for
+    /// ReadCommitted, so the unit of work must keep the default there. On MariaDB it requests
+    /// ReadCommitted instead, so a handler sees rows another process committed after its transaction
+    /// began (the fix for the split-runtime "Operation not found").
+    /// </summary>
+    [Fact]
+    public async Task Initialize_uses_a_supported_isolation_level_on_sqlite()
+    {
+        await using var scope = CreateScope();
+        var dbContext = scope.GetInstance<StateStoreContext>();
+
+        var unitOfWork = new StateStoreDbUnitOfWork(dbContext);
+
+        var act = async () =>
+        {
+            await unitOfWork.Initialize();
+            await unitOfWork.Commit();
+            await unitOfWork.DisposeAsync();
+        };
+
+        await act.Should().NotThrowAsync();
+    }
+}


### PR DESCRIPTION
The controller's Rebus unit of work (`StateStoreDbUnitOfWork`) wraps each message handler in a DB transaction. On MariaDB the default **REPEATABLE READ** takes a consistent snapshot at the transaction's first read, so a row another process committed afterwards stays invisible for the rest of the handler.

In the split runtime the compute API creates an operation (its own process/transaction) and dispatches to the controller, which handles it in a separate process. The controller's handler transaction could not see the just-created operation and cancelled the workflow with **"Operation not found"** — so *every* catlet deployment failed before dispatching any task. (eryph-zero doesn't hit this: it's one process on SQLite, and the in-memory bus delivers after commit.)

Fix: begin the handler transaction at **ReadCommitted**, so each statement re-reads the latest committed data. It's provider-aware — SQLite (eryph-zero) has no cross-process window and only supports Serializable/ReadUncommitted (asking for ReadCommitted throws), so it keeps its default there. A regression test guards the SQLite path.

Verified end to end against the split mTLS cluster with a Hyper-V host agent: after the change a system-client catlet submission runs the full create-catlet saga (validate → config drive → build spec → create VM) and the VM is created on the host — previously it stalled immediately at "Operation not found".
