### PR TITLE
Commit the operation before dispatching its command

### DIFF
--- a/src/data/src/Eryph.StateDb/Workflows/OperationManager.cs
+++ b/src/data/src/Eryph.StateDb/Workflows/OperationManager.cs
@@ -57,6 +57,12 @@ public class OperationManager(
         log.LogTrace("created operation: {@operation}", res);
 
         await db.AddAsync(res);
+        // Persist the operation before the dispatcher sends its command: on a multi-process runtime the
+        // controller handling the CreateOperationCommand must be able to read this row, so it has to be
+        // durable before the send. Do not rely on the caller enlisting the write in a TransactionScope —
+        // the MariaDB provider commits an enlisted write via XA only at scope disposal, which races (and
+        // loses to) the Rebus send. SQLite never enlists, so eryph-zero already commits first.
+        await db.SaveChangesAsync();
         return new Operation(res);
     }
 

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Handlers/CreateEntityRequestHandler.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Handlers/CreateEntityRequestHandler.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Transactions;
 using AutoMapper;
 using Dbosoft.Rebus.Operations;
 using Eryph.ModuleCore;
-using Eryph.StateDb;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Rebus.TransactionScopes;
 using Operation = Eryph.Modules.AspNetCore.ApiProvider.Model.V1.Operation;
 
 namespace Eryph.Modules.AspNetCore.ApiProvider.Handlers;
@@ -18,19 +15,19 @@ internal class CreateEntityRequestHandler<TEntity>(
     IEndpointResolver endpointResolver,
     IMapper mapper,
     IUserRightsProvider userRightsProvider,
-    IHttpContextAccessor httpContextAccessor,
-    StateStoreContext dbContext)
+    IHttpContextAccessor httpContextAccessor)
     : ICreateEntityRequestHandler<TEntity>
 {
     public async Task<ActionResult<Operation>> HandleOperationRequest(
         Func<object> createOperationFunc,
         CancellationToken cancellationToken)
     {
-        using var ta = new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled);
-        ta.EnlistRebus();
-
         var command = createOperationFunc();
 
+        // StartNew persists and commits the operation (OperationManager.GetOrCreateAsync) before it
+        // dispatches the command, so the row is durable before the controller can receive it. No
+        // ambient TransactionScope: an enlisted MariaDB write commits via XA only at scope disposal,
+        // which would let the dispatched command race ahead of the commit.
         var operation = await operationDispatcher.StartNew(
             userRightsProvider.GetUserTenantId(),
             httpContextAccessor.HttpContext?.TraceIdentifier ?? "",
@@ -40,9 +37,6 @@ internal class CreateEntityRequestHandler<TEntity>(
         var operationModel = ((StateDb.Workflows.Operation)operation).Model;
         var mappedModel = mapper.Map<Operation>(operationModel);
         var operationUri = new Uri(endpointResolver.GetEndpoint("compute") + $"/v1/operations/{operationModel.Id}");
-
-        await dbContext.SaveChangesAsync(cancellationToken);
-        ta.Complete();
 
         return new AcceptedResult(operationUri, mappedModel);
     }

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Handlers/CreateEntityRequestHandler.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Handlers/CreateEntityRequestHandler.cs
@@ -22,6 +22,9 @@ internal class CreateEntityRequestHandler<TEntity>(
         Func<object> createOperationFunc,
         CancellationToken cancellationToken)
     {
+        // Honour a client-aborted request before we create and dispatch an operation.
+        cancellationToken.ThrowIfCancellationRequested();
+
         var command = createOperationFunc();
 
         // StartNew persists and commits the operation (OperationManager.GetOrCreateAsync) before it

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Handlers/EntityOperationRequestHandler.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Handlers/EntityOperationRequestHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Transactions;
 using Ardalis.Specification;
 using AutoMapper;
 using Dbosoft.Rebus.Operations;
@@ -10,7 +9,6 @@ using Eryph.StateDb;
 using Eryph.StateDb.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Rebus.TransactionScopes;
 using Operation = Eryph.Modules.AspNetCore.ApiProvider.Model.V1.Operation;
 
 namespace Eryph.Modules.AspNetCore.ApiProvider.Handlers;
@@ -41,9 +39,6 @@ public class EntityOperationRequestHandler<TEntity>(
         CancellationToken cancellationToken,
         AccessRight accessRight = AccessRight.Write)
     {
-        using var ta = new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled);
-        ta.EnlistRebus();
-
         var spec = specificationFunc();
         var model = spec != null ? await repository.GetBySpecAsync(spec, cancellationToken) : null;
 
@@ -75,10 +70,11 @@ public class EntityOperationRequestHandler<TEntity>(
             return validationResult;
 
         var command = createOperationFunc(model);
+        // StartNew persists and commits the operation (OperationManager.GetOrCreateAsync) before it
+        // dispatches the command, so the row is durable before the controller can receive it. No
+        // ambient TransactionScope: an enlisted MariaDB write commits via XA only at scope disposal,
+        // which would let the dispatched command race ahead of the commit.
         var result = await StartOperation(command);
-
-        await repository.SaveChangesAsync(cancellationToken);
-        ta.Complete();
 
         return result;
     }

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Handlers/OperationRequestHandler.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Handlers/OperationRequestHandler.cs
@@ -33,6 +33,9 @@ public class OperationRequestHandler<TEntity>(
         Func<object> createOperationFunc,
         CancellationToken cancellationToken)
     {
+        // Honour a client-aborted request before we create and dispatch an operation.
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (typeof(TEntity) == typeof(Gene))
         {
             if (!await _userRightsProvider.HasDefaultTenantAccess(AccessRight.Admin))

--- a/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Handlers/OperationRequestHandler.cs
+++ b/src/modules/src/Eryph.Modules.AspNetCore/ApiProvider/Handlers/OperationRequestHandler.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Transactions;
 using AutoMapper;
 using Dbosoft.Rebus.Operations;
 using Eryph.ModuleCore;
 using Eryph.Modules.AspNetCore.ApiProvider.Model.V1;
-using Eryph.StateDb;
 using Eryph.StateDb.Model;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Rebus.TransactionScopes;
 
 namespace Eryph.Modules.AspNetCore.ApiProvider.Handlers;
 
@@ -20,7 +17,6 @@ public class OperationRequestHandler<TEntity>(
     IHttpContextAccessor httpContextAccessor,
     IMapper mapper,
     IOperationDispatcher operationDispatcher,
-    IStateStore stateStore,
     IUserRightsProvider userRightsProvider)
     : OperationRequestHandlerBase(
             apiResultFactory,
@@ -37,9 +33,6 @@ public class OperationRequestHandler<TEntity>(
         Func<object> createOperationFunc,
         CancellationToken cancellationToken)
     {
-        using var ta = new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled);
-        ta.EnlistRebus();
-
         if (typeof(TEntity) == typeof(Gene))
         {
             if (!await _userRightsProvider.HasDefaultTenantAccess(AccessRight.Admin))
@@ -58,10 +51,11 @@ public class OperationRequestHandler<TEntity>(
         }
 
         var command = createOperationFunc();
+        // StartNew persists and commits the operation (OperationManager.GetOrCreateAsync) before it
+        // dispatches the command, so the row is durable before the controller can receive it. No
+        // ambient TransactionScope: an enlisted MariaDB write commits via XA only at scope disposal,
+        // which would let the dispatched command race ahead of the commit.
         var result = await StartOperation(command);
-
-        await stateStore.SaveChangesAsync(cancellationToken);
-        ta.Complete();
 
         return result;
     }

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Workflows/OperationManagerTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Workflows/OperationManagerTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading.Tasks;
+using Dbosoft.Rebus.Operations;
+using Eryph;
+using Eryph.Core;
+using Eryph.StateDb;
+using Eryph.StateDb.TestBase;
+using Eryph.StateDb.Workflows;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit.Abstractions;
+
+namespace Eryph.Modules.Controller.Tests.Workflows;
+
+/// <summary>
+/// Verifies that <see cref="OperationManager.GetOrCreateAsync"/> persists (commits) the operation
+/// before it returns. The dispatcher sends the <c>CreateOperationCommand</c> immediately afterwards;
+/// on a multi-process runtime the controller handling that command must be able to read the row, so it
+/// has to be durable before the send — not merely tracked. Guards against re-introducing an ambient
+/// transaction that would defer the commit until after the command is on the wire.
+/// </summary>
+public class OperationManagerTests(ITestOutputHelper outputHelper)
+    : InMemoryStateDbTestBase(outputHelper)
+{
+    [Fact]
+    public async Task GetOrCreateAsync_commits_the_operation_before_returning()
+    {
+        var operationId = Guid.NewGuid();
+        var data = new OperationDataRecord(EryphConstants.DefaultTenantId, "trace-id", "test");
+
+        await using (var scope = CreateScope())
+        {
+            var db = scope.GetInstance<StateStoreContext>();
+            var manager = new OperationManager(db, new WorkflowOptions(), NullLogger<OperationManager>.Instance);
+
+            await manager.GetOrCreateAsync(operationId, new object(), DateTimeOffset.UtcNow, data, null);
+
+            // Intentionally do NOT commit this scope: the operation must already be durable. If it is
+            // only tracked (the old behaviour, where an ambient transaction deferred the commit), the
+            // fresh context below would not find it.
+        }
+
+        await using (var verifyScope = CreateScope())
+        {
+            var db = verifyScope.GetInstance<StateStoreContext>();
+
+            var persisted = await db.Operations.FindAsync(operationId);
+            persisted.Should().NotBeNull(
+                "GetOrCreateAsync must commit the operation before the dispatcher sends its command");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

In the split runtime, catlet (and other) operations intermittently failed with the controller logging *"Operation not found - cancelling workflow"*.

The compute API creates the operation inside a `TransactionScope` that enlists both the MariaDB write and the Rebus send (`EnlistRebus`). On MariaDB the EF write joins the scope's XA transaction, so the operation row is only committed when the scope disposes — and Rebus's volatile enlistment can flush the `CreateOperationCommand` before that `XA COMMIT` completes. A controller in a separate process then handles the command before the row is visible and cancels the workflow.

eryph-zero never hit this because `Microsoft.Data.Sqlite` does not enlist in the ambient `System.Transactions` transaction, so its write commits immediately — before the deferred send.

## Fix

`OperationManager.GetOrCreateAsync` now persists the operation (`SaveChangesAsync`) before returning, i.e. before the dispatcher sends the command. The `TransactionScope`/`EnlistRebus` dance is removed from the three dispatch handlers (`CreateEntity`, `EntityOperation`, `OperationRequestHandler`), since the only write there is the operation row. The row is now durable before the command is on the wire — making MariaDB behave the way SQLite already does.

The single remaining trade-off is that a send failure after the commit leaves a benign `Queued` orphan operation (reaped by `OperationCleanupJob`), which is strictly preferable to dispatching a command for a row that isn't committed.
