### PR TITLE
Route gene-pool spec resolution to a registered host agent

### DIFF
--- a/src/modules/src/Eryph.Modules.Controller/Compute/CreateCatletSpecificationSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/CreateCatletSpecificationSaga.cs
@@ -23,6 +23,7 @@ namespace Eryph.Modules.Controller.Compute;
 [UsedImplicitly]
 internal class CreateCatletSpecificationSaga(
     IStateStoreRepository<CatletSpecification> repository,
+    IStorageManagementAgentLocator agentLocator,
     IWorkflow workflow)
     : OperationTaskWorkflowSaga<CreateCatletSpecificationCommand, EryphSagaData<CreateCatletSpecificationSagaData>>(
             workflow),
@@ -97,7 +98,11 @@ internal class CreateCatletSpecificationSaga(
     protected override async Task Initiated(CreateCatletSpecificationCommand message)
     {
         Data.Data.State = CreateCatletSpecificationSagaState.Initiated;
-        Data.Data.AgentName = Environment.MachineName;
+        // Resolve the genes on a registered host agent's gene pool, not the controller's own machine
+        // name: in the split runtime the gene pool runs on the host agent (e.g. WASD12), so routing to
+        // eryph.genepool.<controller-host> targets a queue that does not exist. FindAgentForGenePool
+        // returns the single host in eryph-zero (the same machine) and a real host agent in the split.
+        Data.Data.AgentName = agentLocator.FindAgentForGenePool();
         var architectures = message.Architectures ?? throw new InvalidOperationException("Architectures cannot be null");
         Data.Data.Architectures = architectures;
         Data.Data.ContentType = message.ContentType;

--- a/src/modules/src/Eryph.Modules.Controller/Compute/ExpandNewCatletConfigSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/ExpandNewCatletConfigSaga.cs
@@ -21,6 +21,7 @@ namespace Eryph.Modules.Controller.Compute;
 
 [UsedImplicitly]
 internal class ExpandNewCatletConfigSaga(
+    IStorageManagementAgentLocator agentLocator,
     IWorkflow workflow)
     : OperationTaskWorkflowSaga<ExpandNewCatletConfigCommand, EryphSagaData<ExpandNewCatletConfigSagaData>>(workflow),
         IHandleMessages<OperationTaskStatusEvent<BuildCatletSpecificationCommand>>
@@ -68,7 +69,9 @@ internal class ExpandNewCatletConfigSaga(
         Data.Data.Config = message.Config;
         Data.Data.ShowSecrets = message.ShowSecrets;
 
-        Data.Data.AgentName = Environment.MachineName;
+        // Resolve genes on a registered host agent's gene pool (see CreateCatletSpecificationSaga):
+        // the controller's own machine name has no gene pool queue in the split runtime.
+        Data.Data.AgentName = agentLocator.FindAgentForGenePool();
         Data.Data.Architecture = Architecture.New(EryphConstants.DefaultArchitecture);
 
         var config = message.Config ?? throw new InvalidOperationException("Config is required");

--- a/src/modules/src/Eryph.Modules.Controller/Compute/PopulateCatletConfigVariablesSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/PopulateCatletConfigVariablesSaga.cs
@@ -17,6 +17,7 @@ namespace Eryph.Modules.Controller.Compute;
 
 [UsedImplicitly]
 internal class PopulateCatletConfigVariablesSaga(
+    IStorageManagementAgentLocator agentLocator,
     IWorkflow workflow)
     : OperationTaskWorkflowSaga<PopulateCatletConfigVariablesCommand,
             EryphSagaData<PopulateCatletConfigVariablesSagaData>>(workflow),
@@ -38,7 +39,9 @@ internal class PopulateCatletConfigVariablesSaga(
         var config = message.Config ?? throw new InvalidOperationException("CatletConfig must not be null in PopulateCatletConfigVariablesSaga.");
 
         Data.Data.Config = config;
-        Data.Data.AgentName = Environment.MachineName;
+        // Resolve genes on a registered host agent's gene pool (see CreateCatletSpecificationSaga):
+        // the controller's own machine name has no gene pool queue in the split runtime.
+        Data.Data.AgentName = agentLocator.FindAgentForGenePool();
         Data.Data.Architecture = Architecture.New(EryphConstants.DefaultArchitecture);
 
         await StartNewTask(new BuildCatletSpecificationCommand

--- a/src/modules/src/Eryph.Modules.Controller/Compute/UpdateCatletSpecificationSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/UpdateCatletSpecificationSaga.cs
@@ -20,6 +20,7 @@ namespace Eryph.Modules.Controller.Compute;
 [UsedImplicitly]
 internal class UpdateCatletSpecificationSaga(
     IStateStore stateStore,
+    IStorageManagementAgentLocator agentLocator,
     IWorkflow workflow)
     : OperationTaskWorkflowSaga<UpdateCatletSpecificationCommand, EryphSagaData<UpdateCatletSpecificationSagaData>>(
             workflow),
@@ -101,7 +102,9 @@ internal class UpdateCatletSpecificationSaga(
         }
 
         Data.Data.SpecificationVersionId = Guid.NewGuid();
-        Data.Data.AgentName = Environment.MachineName;
+        // Resolve genes on a registered host agent's gene pool (see CreateCatletSpecificationSaga):
+        // the controller's own machine name has no gene pool queue in the split runtime.
+        Data.Data.AgentName = agentLocator.FindAgentForGenePool();
         Data.Data.ContentType = message.ContentType;
         Data.Data.OriginalConfig = message.Configuration;
         Data.Data.Architectures = message.Architectures ?? throw new InvalidOperationException("Architectures is required");

--- a/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSaga.cs
@@ -99,16 +99,18 @@ internal class ValidateCatletSpecificationSaga(
             ? defaultArchitecture
             : architectures.OrderBy(a => a.Value, StringComparer.Ordinal).First();
 
+        // Resolve genes on a registered host agent's gene pool (see CreateCatletSpecificationSaga):
+        // the controller's own machine name has no gene pool queue in the split runtime. Resolve once
+        // and reuse it for every architecture.
+        var geneAgentName = agentLocator.FindAgentForGenePool();
+
         foreach (var architecture in architectures)
             await StartNewTask(new BuildCatletSpecificationCommand
             {
                 ContentType = message.ContentType,
                 Configuration = message.Configuration,
                 Architecture = architecture,
-                // Resolve genes on a registered host agent's gene pool (see
-                // CreateCatletSpecificationSaga): the controller's own machine name has no gene pool
-                // queue in the split runtime.
-                AgentName = agentLocator.FindAgentForGenePool(),
+                AgentName = geneAgentName,
             });
     }
 

--- a/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSaga.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Compute/ValidateCatletSpecificationSaga.cs
@@ -18,6 +18,7 @@ namespace Eryph.Modules.Controller.Compute;
 
 [UsedImplicitly]
 internal class ValidateCatletSpecificationSaga(
+    IStorageManagementAgentLocator agentLocator,
     IWorkflow workflow)
     : OperationTaskWorkflowSaga<ValidateCatletSpecificationCommand, EryphSagaData<ValidateCatletSpecificationSagaData>>(
             workflow),
@@ -104,7 +105,10 @@ internal class ValidateCatletSpecificationSaga(
                 ContentType = message.ContentType,
                 Configuration = message.Configuration,
                 Architecture = architecture,
-                AgentName = Environment.MachineName,
+                // Resolve genes on a registered host agent's gene pool (see
+                // CreateCatletSpecificationSaga): the controller's own machine name has no gene pool
+                // queue in the split runtime.
+                AgentName = agentLocator.FindAgentForGenePool(),
             });
     }
 


### PR DESCRIPTION
## Problem

Gene-pool resolution that does **not** deploy — the app wizard's "resolve parent gene structure" and `New-Catlet`'s config preview (`ExpandNewCatletConfig` / `PopulateCatletConfigVariables`) — hung forever in the split runtime, surfacing as *"cannot resolve genes"*.

`BuildCatletSpecificationGenePoolCommand` is routed to `eryph.genepool.<AgentName>`. Five spec/config-resolution sagas set that `AgentName` to `Environment.MachineName` — the controller's own host name — which is the eryph-zero assumption that the gene pool is co-located with the controller. In the split runtime the gene pool runs on a host agent (`eryph.genepool.<host>`), so the command targeted a non-existent queue (`eryph.genepool.<controller>`), the task stayed `Queued`, and the operation never completed.

The catlet **deploy** path was unaffected because it routes to the placement host (a real agent).

## Fix

The five sagas now resolve the gene pool via `IStorageManagementAgentLocator.FindAgentForGenePool()` — exactly like `CleanupGenesSaga` and the inventory timer job. It returns the single co-located host in eryph-zero and a registered host agent in the split runtime, so both runtimes route to a gene pool that exists.
