### PR TITLE
Reconcile config drift on component heartbeat

### DIFF
--- a/src/modules/src/Eryph.ModuleCore/Components/ConfigSnapshotCommandHandler.cs
+++ b/src/modules/src/Eryph.ModuleCore/Components/ConfigSnapshotCommandHandler.cs
@@ -5,8 +5,9 @@ using Rebus.Handlers;
 namespace Eryph.ModuleCore.Components;
 
 /// <summary>
-/// Applies the initial (or delta) configuration snapshot the controller sends to
-/// this component's inbound queue on registration.
+/// Applies a configuration snapshot the controller sends to this component's inbound queue: either the
+/// reply to the component's startup config request, or a heartbeat-driven drift re-push (from
+/// <c>ComponentHeartbeatCommandHandler</c>) when the component is found behind the authoritative records.
 /// </summary>
 internal sealed class ConfigSnapshotCommandHandler(
     ComponentIdentity identity,

--- a/src/modules/src/Eryph.Modules.Controller/Components/ComponentHeartbeatCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Components/ComponentHeartbeatCommandHandler.cs
@@ -36,14 +36,22 @@ internal sealed class ComponentHeartbeatCommandHandler(
         if (registration is null)
             return;
 
+        // NOTE (pre-auth trust boundary): like RequestConfigCommandHandler, the heartbeat's component
+        // identity is not yet verified against an authenticated sender. A forged heartbeat carrying a
+        // real component/instance id and a low applied version can therefore now trigger a drift re-push
+        // on that component's heartbeat interval — an escalation from the passive registry update this
+        // used to be. The push still only targets the queue persisted at registration (never a message
+        // field), so it cannot be redirected or leak config to a new party; binding the heartbeat to an
+        // authenticated component is part of the component authentication phase.
         var outdated = await distribution.GetOutdatedBundlesAsync(
             registration.ComponentType, message.AppliedConfigVersions, CancellationToken.None);
         if (outdated.Count == 0)
             return;
 
-        // Route to the queue persisted at registration (never a message field) so a drift push
-        // cannot be redirected, and reuse ConfigSnapshotCommand: the component applies it exactly
-        // like the startup snapshot reply.
+        // Route to the queue persisted at registration (never a message field) so a drift push cannot be
+        // redirected. ConfigSnapshotCommand (not the single-domain PushConfigCommand the refresh path
+        // uses) carries every outdated domain in one send; the component applies it exactly like the
+        // startup snapshot reply.
         await bus.Advanced.Routing.Send(registration.InboundQueue, new ConfigSnapshotCommand
         {
             ComponentId = registration.ComponentId,

--- a/src/modules/src/Eryph.Modules.Controller/Components/ComponentHeartbeatCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Components/ComponentHeartbeatCommandHandler.cs
@@ -2,22 +2,52 @@ using System.Threading;
 using System.Threading.Tasks;
 using Eryph.Messages.Components;
 using JetBrains.Annotations;
+using Rebus.Bus;
 using Rebus.Handlers;
 
 namespace Eryph.Modules.Controller.Components;
 
 /// <summary>
-/// Refreshes a component's liveness from its periodic heartbeat.
+/// Refreshes a component's liveness from its periodic heartbeat and reconciles configuration drift.
+/// The targeted push in <see cref="RefreshConfigDomainCommandHandler"/> is fire-and-forget with no
+/// retry of its own, so a component that was unreachable when a domain changed — or whose apply
+/// failed — would otherwise run stale config indefinitely. On each heartbeat the component reports
+/// what it has applied; if that is behind the authoritative records, the newer bundles are re-sent to
+/// its inbound queue. This is the self-healing safety net of the distribution loop. A failed apply
+/// never advances the reported version, so it is retried on the next heartbeat too.
 /// </summary>
 [UsedImplicitly]
 internal sealed class ComponentHeartbeatCommandHandler(
-    IComponentRegistryService registry)
+    IBus bus,
+    IComponentRegistryService registry,
+    ConfigDistributionService distribution)
     : IHandleMessages<ComponentHeartbeatCommand>
 {
-    public Task Handle(ComponentHeartbeatCommand message) =>
-        registry.RecordHeartbeatAsync(
+    public async Task Handle(ComponentHeartbeatCommand message)
+    {
+        var registration = await registry.RecordHeartbeatAsync(
             message.ComponentId,
             message.InstanceId,
             message.AppliedConfigVersions,
             CancellationToken.None);
+
+        // Only the live, matching instance drives reconciliation: a heartbeat from an unregistered
+        // or superseded instance records nothing and returns null.
+        if (registration is null)
+            return;
+
+        var outdated = await distribution.GetOutdatedBundlesAsync(
+            registration.ComponentType, message.AppliedConfigVersions, CancellationToken.None);
+        if (outdated.Count == 0)
+            return;
+
+        // Route to the queue persisted at registration (never a message field) so a drift push
+        // cannot be redirected, and reuse ConfigSnapshotCommand: the component applies it exactly
+        // like the startup snapshot reply.
+        await bus.Advanced.Routing.Send(registration.InboundQueue, new ConfigSnapshotCommand
+        {
+            ComponentId = registration.ComponentId,
+            Bundles = outdated,
+        });
+    }
 }

--- a/src/modules/src/Eryph.Modules.Controller/Components/ComponentHeartbeatCommandHandler.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Components/ComponentHeartbeatCommandHandler.cs
@@ -43,8 +43,10 @@ internal sealed class ComponentHeartbeatCommandHandler(
         // used to be. The push still only targets the queue persisted at registration (never a message
         // field), so it cannot be redirected or leak config to a new party; binding the heartbeat to an
         // authenticated component is part of the component authentication phase.
+        // Reconcile against the applied state as recorded (the returned registration), not the raw
+        // message, so drift detection stays aligned with whatever the registry accepted.
         var outdated = await distribution.GetOutdatedBundlesAsync(
-            registration.ComponentType, message.AppliedConfigVersions, CancellationToken.None);
+            registration.ComponentType, registration.AppliedConfigVersions, CancellationToken.None);
         if (outdated.Count == 0)
             return;
 

--- a/src/modules/src/Eryph.Modules.Controller/Components/ComponentRegistryQueries.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Components/ComponentRegistryQueries.cs
@@ -32,7 +32,10 @@ internal static class ConfigRecordSpecs
     {
         public GetByDomain(ConfigDomain domain)
         {
+            Domain = domain;
             Query.Where(x => x.Domain == domain);
         }
+
+        public ConfigDomain Domain { get; }
     }
 }

--- a/src/modules/src/Eryph.Modules.Controller/Components/ComponentRegistryService.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Components/ComponentRegistryService.cs
@@ -58,7 +58,7 @@ internal sealed class ComponentRegistryService(
         return existing;
     }
 
-    public async Task RecordHeartbeatAsync(
+    public async Task<ComponentRegistration?> RecordHeartbeatAsync(
         Guid componentId,
         Guid instanceId,
         IReadOnlyDictionary<ConfigDomain, long> appliedConfigVersions,
@@ -67,7 +67,7 @@ internal sealed class ComponentRegistryService(
         var registration = await repository.GetBySpecAsync(
             new ComponentRegistrationSpecs.GetByComponentId(componentId), cancellationToken);
         if (registration is null)
-            return;
+            return null;
 
         // Ignore heartbeats that do not belong to the currently-registered instance.
         // Registration is the authority for the live InstanceId; on a brokered transport a
@@ -76,7 +76,7 @@ internal sealed class ComponentRegistryService(
         // state) to the stale instance. A restart re-registers with its new InstanceId first,
         // so the matching heartbeat still resets applied state as intended.
         if (registration.InstanceId != instanceId)
-            return;
+            return null;
 
         registration.LastHeartbeat = DateTimeOffset.UtcNow;
         registration.Status = ComponentRegistrationStatus.Active;
@@ -85,6 +85,7 @@ internal sealed class ComponentRegistryService(
         // the controller's view does not lag behind reality.
         registration.AppliedConfigVersions = new Dictionary<ConfigDomain, long>(appliedConfigVersions);
         await repository.UpdateAsync(registration, cancellationToken);
+        return registration;
     }
 
     public async Task RecordAppliedAsync(

--- a/src/modules/src/Eryph.Modules.Controller/Components/ConfigDistributionService.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Components/ConfigDistributionService.cs
@@ -81,6 +81,39 @@ internal sealed class ConfigDistributionService(
     }
 
     /// <summary>
+    /// Compares a component's reported applied versions against the current materialized records
+    /// and returns the bundles for the entitled domains where it is behind — <b>without</b>
+    /// re-evaluating the sources or taking the per-domain lock. Used by heartbeat drift
+    /// reconciliation: unlike <see cref="BuildSnapshotAsync"/> (the startup pull, which re-reads the
+    /// sources to guarantee freshness), this reflects only what the push path already published, so
+    /// it stays a cheap, lock-free read that runs on every heartbeat. A source that changed without a
+    /// refresh trigger is a separate concern (the record, not the component, is then stale).
+    /// </summary>
+    public async Task<List<ConfigBundle>> GetOutdatedBundlesAsync(
+        ComponentType componentType,
+        IReadOnlyDictionary<ConfigDomain, long> appliedVersions,
+        CancellationToken cancellationToken)
+    {
+        var bundles = new List<ConfigBundle>();
+        foreach (var domain in GetEntitledDomains(componentType))
+        {
+            var record = await records.GetBySpecAsync(
+                new ConfigRecordSpecs.GetByDomain(domain), cancellationToken);
+            if (record is null)
+                continue;
+
+            var applied = appliedVersions.GetValueOrDefault(domain, 0);
+            if (record.Version > applied)
+                bundles.Add(new ConfigBundle
+                {
+                    Domain = domain, Version = record.Version, Payload = record.Payload,
+                });
+        }
+
+        return bundles;
+    }
+
+    /// <summary>
     /// Re-evaluates a domain against its source and returns the new bundle when the
     /// payload changed — or <c>null</c> when nothing changed (so the push path can
     /// skip publishing). The pull path uses <see cref="EnsureCurrentRecordAsync"/>

--- a/src/modules/src/Eryph.Modules.Controller/Components/IComponentRegistryService.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Components/IComponentRegistryService.cs
@@ -20,10 +20,12 @@ internal interface IComponentRegistryService
     /// applied-config state with what the component reports. The heartbeat is the
     /// component's authoritative current state: a restart (signalled by a new
     /// <paramref name="instanceId"/>) resets <paramref name="appliedConfigVersions"/>,
-    /// so this overwrites rather than merges. Does nothing if the component is not
-    /// registered.
+    /// so this overwrites rather than merges. Returns the updated registration, or
+    /// <c>null</c> when the component is not registered or the heartbeat is from a
+    /// superseded instance — in which case nothing is recorded and the caller must not
+    /// act on it (e.g. drift reconciliation).
     /// </summary>
-    Task RecordHeartbeatAsync(
+    Task<ComponentRegistration?> RecordHeartbeatAsync(
         Guid componentId,
         Guid instanceId,
         IReadOnlyDictionary<ConfigDomain, long> appliedConfigVersions,

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Components/ComponentHeartbeatCommandHandlerTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Components/ComponentHeartbeatCommandHandlerTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Eryph.DistributedLock;
 using Eryph.Messages.Components;
 using Eryph.Modules.Controller.Components;
@@ -77,6 +73,60 @@ public class ComponentHeartbeatCommandHandlerTests
                     && c.Bundles[0].Domain == ConfigDomain.OvnCluster
                     && c.Bundles[0].Version == 5
                     && c.Bundles[0].Payload == "p"),
+                It.IsAny<IDictionary<string, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Behind_component_is_re_pushed_only_the_domains_it_is_behind_on()
+    {
+        // A host agent (three entitled domains) behind on placement but current on network-providers is
+        // re-pushed exactly the placement bundle — the multi-domain partial-drift case, asserted through
+        // the handler's actual bus send.
+        var registration = new ComponentRegistration
+        {
+            Id = Guid.NewGuid(),
+            ComponentId = ComponentId,
+            ComponentType = ComponentType.VMHostAgent,
+            InstanceId = InstanceId,
+            MachineName = "host",
+            InboundQueue = "host-inbound",
+            AppliedConfigVersions = new Dictionary<ConfigDomain, long>(),
+        };
+        var byDomain = new Dictionary<ConfigDomain, ConfigRecord>
+        {
+            [ConfigDomain.PlacementConfig] = new()
+                { Id = Guid.NewGuid(), Domain = ConfigDomain.PlacementConfig, Version = 5, Payload = "placement" },
+            [ConfigDomain.NetworkProviders] = new()
+                { Id = Guid.NewGuid(), Domain = ConfigDomain.NetworkProviders, Version = 2, Payload = "network" },
+            // No Endpoints record.
+        };
+        var records = new Mock<IStateStoreRepository<ConfigRecord>>();
+        records.Setup(r => r.GetBySpecAsync(It.IsAny<ConfigRecordSpecs.GetByDomain>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConfigRecordSpecs.GetByDomain spec, CancellationToken _) =>
+                byDomain.GetValueOrDefault(spec.Domain));
+
+        var registry = new StubRegistry(registration);
+        var bus = new Mock<IBus> { DefaultValue = DefaultValue.Mock };
+        var handler = new ComponentHeartbeatCommandHandler(bus.Object, registry, Distribution(records));
+
+        await handler.Handle(new ComponentHeartbeatCommand
+        {
+            ComponentId = ComponentId,
+            InstanceId = InstanceId,
+            AppliedConfigVersions = new Dictionary<ConfigDomain, long>
+            {
+                [ConfigDomain.PlacementConfig] = 3,   // behind: record is v5
+                [ConfigDomain.NetworkProviders] = 2,  // current: record is v2
+            },
+        });
+
+        Mock.Get(bus.Object.Advanced.Routing).Verify(r => r.Send(
+                "host-inbound",
+                It.Is<ConfigSnapshotCommand>(c =>
+                    c.Bundles.Count == 1
+                    && c.Bundles[0].Domain == ConfigDomain.PlacementConfig
+                    && c.Bundles[0].Version == 5),
                 It.IsAny<IDictionary<string, string>>()),
             Times.Once);
     }

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Components/ComponentHeartbeatCommandHandlerTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Components/ComponentHeartbeatCommandHandlerTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Eryph.DistributedLock;
+using Eryph.Messages.Components;
+using Eryph.Modules.Controller.Components;
+using Eryph.StateDb;
+using Eryph.StateDb.Model;
+using Moq;
+using Rebus.Bus;
+
+namespace Eryph.Modules.Controller.Tests.Components;
+
+/// <summary>
+/// Verifies heartbeat drift reconciliation: a component reporting an applied-config state behind the
+/// authoritative records is re-pushed the newer bundles on its own inbound queue; a current component
+/// (or a stale/unregistered heartbeat) is not. <see cref="IComponentRegistryService"/> is internal and
+/// cannot be proxied by Moq, so it is hand-stubbed like elsewhere in these tests.
+/// </summary>
+public class ComponentHeartbeatCommandHandlerTests
+{
+    private static readonly Guid ComponentId = Guid.NewGuid();
+    private static readonly Guid InstanceId = Guid.NewGuid();
+
+    private static ConfigDistributionService Distribution(Mock<IStateStoreRepository<ConfigRecord>> records) =>
+        new(records.Object, [], new Mock<IDistributedLockScopeHolder>().Object);
+
+    private static ComponentHeartbeatCommand Heartbeat(long appliedOvnClusterVersion) =>
+        new()
+        {
+            ComponentId = ComponentId,
+            InstanceId = InstanceId,
+            AppliedConfigVersions = new Dictionary<ConfigDomain, long>
+                { [ConfigDomain.OvnCluster] = appliedOvnClusterVersion },
+        };
+
+    private static ComponentRegistration NetworkRegistration() =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            ComponentId = ComponentId,
+            ComponentType = ComponentType.Network,
+            InstanceId = InstanceId,
+            MachineName = "net",
+            InboundQueue = "net-inbound",
+            AppliedConfigVersions = new Dictionary<ConfigDomain, long> { [ConfigDomain.OvnCluster] = 1 },
+        };
+
+    private static Mock<IStateStoreRepository<ConfigRecord>> RecordsAt(long ovnClusterVersion)
+    {
+        var records = new Mock<IStateStoreRepository<ConfigRecord>>();
+        records.Setup(r => r.GetBySpecAsync(It.IsAny<ConfigRecordSpecs.GetByDomain>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConfigRecord
+            {
+                Id = Guid.NewGuid(), Domain = ConfigDomain.OvnCluster, Version = ovnClusterVersion, Payload = "p",
+            });
+        return records;
+    }
+
+    [Fact]
+    public async Task Behind_component_is_re_pushed_the_outdated_bundle_to_its_inbound_queue()
+    {
+        var registry = new StubRegistry(NetworkRegistration());
+        var records = RecordsAt(5);
+        var bus = new Mock<IBus> { DefaultValue = DefaultValue.Mock };
+        var handler = new ComponentHeartbeatCommandHandler(bus.Object, registry, Distribution(records));
+
+        // The component reports OvnCluster v1 but the record is at v5 — it missed a push.
+        await handler.Handle(Heartbeat(1));
+
+        Mock.Get(bus.Object.Advanced.Routing).Verify(r => r.Send(
+                "net-inbound",
+                It.Is<ConfigSnapshotCommand>(c =>
+                    c.ComponentId == ComponentId
+                    && c.Bundles.Count == 1
+                    && c.Bundles[0].Domain == ConfigDomain.OvnCluster
+                    && c.Bundles[0].Version == 5
+                    && c.Bundles[0].Payload == "p"),
+                It.IsAny<IDictionary<string, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Current_component_is_not_re_pushed_anything()
+    {
+        var registry = new StubRegistry(NetworkRegistration());
+        var records = RecordsAt(5);
+        var bus = new Mock<IBus> { DefaultValue = DefaultValue.Mock };
+        var handler = new ComponentHeartbeatCommandHandler(bus.Object, registry, Distribution(records));
+
+        // The component already holds v5.
+        await handler.Handle(Heartbeat(5));
+
+        Mock.Get(bus.Object.Advanced.Routing).Verify(r => r.Send(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IDictionary<string, string>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Stale_or_unregistered_heartbeat_reconciles_nothing()
+    {
+        // RecordHeartbeatAsync returns null for an unregistered component or a superseded instance;
+        // the handler must then neither read records nor push.
+        var registry = new StubRegistry(null);
+        var records = new Mock<IStateStoreRepository<ConfigRecord>>();
+        var bus = new Mock<IBus> { DefaultValue = DefaultValue.Mock };
+        var handler = new ComponentHeartbeatCommandHandler(bus.Object, registry, Distribution(records));
+
+        await handler.Handle(Heartbeat(1));
+
+        records.Verify(r => r.GetBySpecAsync(
+            It.IsAny<ConfigRecordSpecs.GetByDomain>(), It.IsAny<CancellationToken>()), Times.Never);
+        Mock.Get(bus.Object.Advanced.Routing).Verify(r => r.Send(
+                It.IsAny<string>(), It.IsAny<object>(), It.IsAny<IDictionary<string, string>>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Returns <paramref name="heartbeatResult"/> from <see cref="RecordHeartbeatAsync"/> (the recorded
+    /// registration, or null for an unregistered/superseded heartbeat). Only that member is exercised.
+    /// </summary>
+    private sealed class StubRegistry(ComponentRegistration? heartbeatResult) : IComponentRegistryService
+    {
+        public Task<ComponentRegistration?> RecordHeartbeatAsync(Guid componentId, Guid instanceId,
+            IReadOnlyDictionary<ConfigDomain, long> appliedConfigVersions, CancellationToken cancellationToken)
+            => Task.FromResult(heartbeatResult);
+
+        public Task<ComponentRegistration> UpsertAsync(RegisterComponentCommand command,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task RecordAppliedAsync(Guid componentId, ConfigDomain domain, long version,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<bool> DeregisterAsync(Guid componentId, Guid instanceId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<bool> RemoveRegistrationAsync(Guid componentId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<ComponentRegistration>> GetActiveAsync(CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+}

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Components/ComponentHeartbeatCommandHandlerTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Components/ComponentHeartbeatCommandHandlerTests.cs
@@ -174,7 +174,13 @@ public class ComponentHeartbeatCommandHandlerTests
     {
         public Task<ComponentRegistration?> RecordHeartbeatAsync(Guid componentId, Guid instanceId,
             IReadOnlyDictionary<ConfigDomain, long> appliedConfigVersions, CancellationToken cancellationToken)
-            => Task.FromResult(heartbeatResult);
+        {
+            // Mirror the real service: the recorded registration reflects the heartbeat's applied state,
+            // which is what the handler reconciles against.
+            if (heartbeatResult is not null)
+                heartbeatResult.AppliedConfigVersions = new Dictionary<ConfigDomain, long>(appliedConfigVersions);
+            return Task.FromResult(heartbeatResult);
+        }
 
         public Task<ComponentRegistration> UpsertAsync(RegisterComponentCommand command,
             CancellationToken cancellationToken)

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Components/ComponentRegistryServiceTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Components/ComponentRegistryServiceTests.cs
@@ -143,9 +143,10 @@ public class ComponentRegistryServiceTests
 
         // A restart reports an empty/reset applied set; the heartbeat from the registered
         // instance must reflect it verbatim.
-        await service.RecordHeartbeatAsync(
+        var result = await service.RecordHeartbeatAsync(
             componentId, instanceId, new Dictionary<ConfigDomain, long>(), CancellationToken.None);
 
+        result.Should().BeSameAs(existing);
         repo.Verify(r => r.UpdateAsync(existing, It.IsAny<CancellationToken>()), Times.Once);
         existing.Status.Should().Be(ComponentRegistrationStatus.Active);
         existing.AppliedConfigVersions.Should().BeEmpty();
@@ -173,9 +174,10 @@ public class ComponentRegistryServiceTests
 
         // A delayed heartbeat from a previous process instance (e.g. reordered on the broker)
         // must be ignored so it cannot revert InstanceId or applied-config state.
-        await service.RecordHeartbeatAsync(
+        var result = await service.RecordHeartbeatAsync(
             componentId, staleInstance, new Dictionary<ConfigDomain, long>(), CancellationToken.None);
 
+        result.Should().BeNull();
         repo.Verify(r => r.UpdateAsync(It.IsAny<ComponentRegistration>(), It.IsAny<CancellationToken>()), Times.Never);
         existing.InstanceId.Should().Be(currentInstance);
         existing.AppliedConfigVersions.Should().HaveCount(2);
@@ -186,10 +188,11 @@ public class ComponentRegistryServiceTests
     {
         var (service, repo) = Create();
 
-        await service.RecordHeartbeatAsync(
+        var result = await service.RecordHeartbeatAsync(
             Guid.NewGuid(), Guid.NewGuid(),
             new Dictionary<ConfigDomain, long>(), CancellationToken.None);
 
+        result.Should().BeNull();
         repo.Verify(r => r.UpdateAsync(It.IsAny<ComponentRegistration>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Components/ConfigDistributionServiceTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Components/ConfigDistributionServiceTests.cs
@@ -331,6 +331,40 @@ public class ConfigDistributionServiceTests
     }
 
     [Fact]
+    public async Task GetOutdatedBundles_returns_only_the_domains_the_component_is_behind_on()
+    {
+        // A host agent is entitled to three domains: it is behind on placement, current on
+        // network-providers, and no endpoints record exists yet — only the placement bundle is returned.
+        var byDomain = new Dictionary<ConfigDomain, ConfigRecord>
+        {
+            [ConfigDomain.PlacementConfig] = new()
+                { Id = Guid.NewGuid(), Domain = ConfigDomain.PlacementConfig, Version = 5, Payload = "placement" },
+            [ConfigDomain.NetworkProviders] = new()
+                { Id = Guid.NewGuid(), Domain = ConfigDomain.NetworkProviders, Version = 2, Payload = "network" },
+            // No Endpoints record.
+        };
+        var records = new Mock<IStateStoreRepository<ConfigRecord>>();
+        records.Setup(r => r.GetBySpecAsync(It.IsAny<ConfigRecordSpecs.GetByDomain>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConfigRecordSpecs.GetByDomain spec, CancellationToken _) =>
+                byDomain.GetValueOrDefault(spec.Domain));
+
+        var service = CreateService(records);
+
+        var applied = new Dictionary<ConfigDomain, long>
+        {
+            [ConfigDomain.PlacementConfig] = 3,   // behind: record is v5
+            [ConfigDomain.NetworkProviders] = 2,  // current: record is v2
+            // Endpoints: neither applied nor a record — skipped.
+        };
+        var bundles = await service.GetOutdatedBundlesAsync(ComponentType.VMHostAgent, applied, CancellationToken.None);
+
+        bundles.Should().ContainSingle();
+        bundles[0].Domain.Should().Be(ConfigDomain.PlacementConfig);
+        bundles[0].Version.Should().Be(5);
+        bundles[0].Payload.Should().Be("placement");
+    }
+
+    [Fact]
     public async Task GetOutdatedBundles_for_an_unentitled_component_reads_nothing()
     {
         var records = new Mock<IStateStoreRepository<ConfigRecord>>();

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Components/ConfigDistributionServiceTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Components/ConfigDistributionServiceTests.cs
@@ -248,6 +248,102 @@ public class ConfigDistributionServiceTests
             .Should().Contain(ConfigDomain.OvnCluster);
     }
 
+    [Fact]
+    public async Task GetOutdatedBundles_returns_the_bundle_for_a_domain_the_component_is_behind_on()
+    {
+        var records = new Mock<IStateStoreRepository<ConfigRecord>>();
+        records.Setup(r => r.GetBySpecAsync(It.IsAny<ConfigRecordSpecs.GetByDomain>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConfigRecord
+            {
+                Id = Guid.NewGuid(),
+                Domain = ConfigDomain.OvnCluster,
+                Version = 3,
+                Payload = """{"chassis":[]}""",
+            });
+
+        var service = CreateService(records);
+
+        var applied = new Dictionary<ConfigDomain, long> { [ConfigDomain.OvnCluster] = 1 };
+        var bundles = await service.GetOutdatedBundlesAsync(ComponentType.Network, applied, CancellationToken.None);
+
+        bundles.Should().ContainSingle();
+        bundles[0].Domain.Should().Be(ConfigDomain.OvnCluster);
+        bundles[0].Version.Should().Be(3);
+        bundles[0].Payload.Should().Be("""{"chassis":[]}""");
+    }
+
+    [Fact]
+    public async Task GetOutdatedBundles_uses_the_stored_record_without_re_evaluating_the_source()
+    {
+        // Drift detection must be cheap: it reflects the record the push path already published, not a
+        // fresh source build, and never bumps the version. Even with a source that would produce a
+        // different (newer) payload, the outdated bundle is the stored v3.
+        var records = new Mock<IStateStoreRepository<ConfigRecord>>();
+        records.Setup(r => r.GetBySpecAsync(It.IsAny<ConfigRecordSpecs.GetByDomain>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConfigRecord
+            {
+                Id = Guid.NewGuid(), Domain = ConfigDomain.OvnCluster, Version = 3, Payload = "stored",
+            });
+
+        var service = CreateService(records, new StubSource(ConfigDomain.OvnCluster, "fresh-would-bump"));
+
+        var applied = new Dictionary<ConfigDomain, long> { [ConfigDomain.OvnCluster] = 1 };
+        var bundles = await service.GetOutdatedBundlesAsync(ComponentType.Network, applied, CancellationToken.None);
+
+        bundles.Should().ContainSingle();
+        bundles[0].Version.Should().Be(3);
+        bundles[0].Payload.Should().Be("stored");
+        records.Verify(r => r.UpdateAsync(It.IsAny<ConfigRecord>(), It.IsAny<CancellationToken>()), Times.Never);
+        records.Verify(r => r.AddAsync(It.IsAny<ConfigRecord>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetOutdatedBundles_is_empty_when_the_component_is_current()
+    {
+        var records = new Mock<IStateStoreRepository<ConfigRecord>>();
+        records.Setup(r => r.GetBySpecAsync(It.IsAny<ConfigRecordSpecs.GetByDomain>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConfigRecord
+            {
+                Id = Guid.NewGuid(), Domain = ConfigDomain.OvnCluster, Version = 3, Payload = "p",
+            });
+
+        var service = CreateService(records);
+
+        var applied = new Dictionary<ConfigDomain, long> { [ConfigDomain.OvnCluster] = 3 };
+        var bundles = await service.GetOutdatedBundlesAsync(ComponentType.Network, applied, CancellationToken.None);
+
+        bundles.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetOutdatedBundles_skips_a_domain_with_no_record_yet()
+    {
+        var records = new Mock<IStateStoreRepository<ConfigRecord>>();
+        records.Setup(r => r.GetBySpecAsync(It.IsAny<ConfigRecordSpecs.GetByDomain>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ConfigRecord?)null);
+
+        var service = CreateService(records);
+
+        var bundles = await service.GetOutdatedBundlesAsync(
+            ComponentType.Network, new Dictionary<ConfigDomain, long>(), CancellationToken.None);
+
+        bundles.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetOutdatedBundles_for_an_unentitled_component_reads_nothing()
+    {
+        var records = new Mock<IStateStoreRepository<ConfigRecord>>();
+        var service = CreateService(records);
+
+        var bundles = await service.GetOutdatedBundlesAsync(
+            ComponentType.GenePoolAgent, new Dictionary<ConfigDomain, long>(), CancellationToken.None);
+
+        bundles.Should().BeEmpty();
+        records.Verify(r => r.GetBySpecAsync(It.IsAny<ConfigRecordSpecs.GetByDomain>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     /// <summary>A config source whose payload the test controls directly.</summary>
     private sealed class StubSource(ConfigDomain domain, string payload) : IConfigSource
     {

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Components/DecommissionComponentCommandHandlerTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Components/DecommissionComponentCommandHandlerTests.cs
@@ -87,7 +87,7 @@ public class DecommissionComponentCommandHandlerTests
             CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        public Task RecordHeartbeatAsync(Guid componentId, Guid instanceId,
+        public Task<ComponentRegistration?> RecordHeartbeatAsync(Guid componentId, Guid instanceId,
             IReadOnlyDictionary<ConfigDomain, long> appliedConfigVersions, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Components/EndpointsConfigSourceTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Components/EndpointsConfigSourceTests.cs
@@ -144,7 +144,7 @@ public class EndpointsConfigSourceTests
             CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        public Task RecordHeartbeatAsync(Guid componentId, Guid instanceId,
+        public Task<ComponentRegistration?> RecordHeartbeatAsync(Guid componentId, Guid instanceId,
             IReadOnlyDictionary<ConfigDomain, long> appliedConfigVersions, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Networks/OvnNorthboundConnectionProviderTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Networks/OvnNorthboundConnectionProviderTests.cs
@@ -132,7 +132,7 @@ public class OvnNorthboundConnectionProviderTests
             CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        public Task RecordHeartbeatAsync(Guid componentId, Guid instanceId,
+        public Task<ComponentRegistration?> RecordHeartbeatAsync(Guid componentId, Guid instanceId,
             IReadOnlyDictionary<ConfigDomain, long> appliedConfigVersions, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 

--- a/src/modules/test/Eryph.Modules.Controller.Tests/RegistryBackedComponentRegistryTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/RegistryBackedComponentRegistryTests.cs
@@ -89,7 +89,7 @@ public class RegistryBackedComponentRegistryTests
             CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        public Task RecordHeartbeatAsync(Guid componentId, Guid instanceId,
+        public Task<ComponentRegistration?> RecordHeartbeatAsync(Guid componentId, Guid instanceId,
             IReadOnlyDictionary<ConfigDomain, long> appliedConfigVersions, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 


### PR DESCRIPTION
Makes the component config-distribution loop self-healing. The targeted push (`RefreshConfigDomainCommandHandler`) is fire-and-forget with no retry, so a component that was unreachable when a domain changed — or whose apply failed — ran stale config indefinitely.

Now, on each heartbeat, the controller compares what the component reports applied against the authoritative `ConfigRecord`s and re-pushes anything it is behind on to the queue persisted at registration. A failed apply never advances the reported version, so it is retried on the next heartbeat too.

- `ConfigDistributionService.GetOutdatedBundlesAsync`: a lock-free, no-source-rebuild read returning the entitled domains where the component is behind the materialized record (unlike the startup pull, which re-evaluates sources).
- `RecordHeartbeatAsync` returns the validated registration (null for an unregistered or superseded-instance heartbeat) so the handler acts only on a live heartbeat.
- `ComponentHeartbeatCommandHandler` re-pushes the outdated bundles via the existing `ConfigSnapshotCommand` — no new message type, no component-side change.

Content-hash detection of within-version divergence is a follow-up. The heartbeat can now trigger a re-push under the same pre-auth bus trust boundary already documented on `RequestConfigCommandHandler`; it is noted in code and closes with the component-authentication phase.