### PR TITLE
Stop leftover OVS/OVN daemons before dropping databases on OVN upgrade

### DIFF
--- a/src/apps/src/Eryph-zero/ConsoleRuntime.cs
+++ b/src/apps/src/Eryph-zero/ConsoleRuntime.cs
@@ -28,6 +28,7 @@ public readonly struct ConsoleRuntime(ConsoleRuntimeEnv env) :
     HasLogger<ConsoleRuntime>,
     HasDirectory<ConsoleRuntime>,
     HasFile<ConsoleRuntime>,
+    HasProcessManager<ConsoleRuntime>,
     HasProcessRunner<ConsoleRuntime>,
     HasRegistry<ConsoleRuntime>,
     HasDism<ConsoleRuntime>
@@ -75,6 +76,8 @@ public readonly struct ConsoleRuntime(ConsoleRuntimeEnv env) :
     public Eff<ConsoleRuntime, DirectoryIO> DirectoryEff => SuccessEff(LanguageExt.Sys.Live.DirectoryIO.Default);
 
     public Eff<ConsoleRuntime, FileIO> FileEff => SuccessEff(LanguageExt.Sys.Live.FileIO.Default);
+
+    public Eff<ConsoleRuntime, ProcessManagerIO> ProcessManagerEff => SuccessEff(LiveProcessManagerIO.Default);
 
     public Eff<ConsoleRuntime, ProcessRunnerIO> ProcessRunnerEff => SuccessEff(LiveProcessRunnerIO.Default);
 

--- a/src/apps/src/Eryph-zero/DriverCommandsRuntime.cs
+++ b/src/apps/src/Eryph-zero/DriverCommandsRuntime.cs
@@ -20,6 +20,7 @@ internal readonly struct DriverCommandsRuntime(DriverCommandsRuntimeEnv env) :
     HasFile<DriverCommandsRuntime>,
     HasHostNetworkCommands<DriverCommandsRuntime>,
     HasLogger<DriverCommandsRuntime>,
+    HasProcessManager<DriverCommandsRuntime>,
     HasProcessRunner<DriverCommandsRuntime>,
     HasPowershell<DriverCommandsRuntime>,
     HasRegistry<DriverCommandsRuntime>,
@@ -47,6 +48,8 @@ internal readonly struct DriverCommandsRuntime(DriverCommandsRuntimeEnv env) :
     public Encoding Encoding => Encoding.UTF8;
 
     public Eff<DriverCommandsRuntime, FileIO> FileEff => SuccessEff(LanguageExt.Sys.Live.FileIO.Default);
+
+    public Eff<DriverCommandsRuntime, ProcessManagerIO> ProcessManagerEff => SuccessEff(LiveProcessManagerIO.Default);
 
     public Eff<DriverCommandsRuntime, ProcessRunnerIO> ProcessRunnerEff => SuccessEff(LiveProcessRunnerIO.Default);
 

--- a/src/core/src/Eryph.Core/Sys/HasProcessManager.cs
+++ b/src/core/src/Eryph.Core/Sys/HasProcessManager.cs
@@ -1,0 +1,9 @@
+using LanguageExt;
+
+namespace Eryph.Core.Sys;
+
+public interface HasProcessManager<RT>
+    where RT : struct, HasProcessManager<RT>
+{
+    Eff<RT, ProcessManagerIO> ProcessManagerEff { get; }
+}

--- a/src/core/src/Eryph.Core/Sys/ProcessManager.cs
+++ b/src/core/src/Eryph.Core/Sys/ProcessManager.cs
@@ -1,0 +1,13 @@
+using System;
+using LanguageExt;
+
+namespace Eryph.Core.Sys;
+
+public static class ProcessManager<RT> where RT : struct, HasProcessManager<RT>
+{
+    public static Eff<RT, Option<string>> getProcessName(int processId) =>
+        default(RT).ProcessManagerEff.Map(m => m.GetProcessName(processId));
+
+    public static Eff<RT, bool> stopProcess(int processId, TimeSpan timeout) =>
+        default(RT).ProcessManagerEff.Map(m => m.StopProcess(processId, timeout));
+}

--- a/src/core/src/Eryph.Core/Sys/ProcessManagerIO.cs
+++ b/src/core/src/Eryph.Core/Sys/ProcessManagerIO.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Diagnostics;
+using LanguageExt;
+using static LanguageExt.Prelude;
+
+namespace Eryph.Core.Sys;
+
+public interface ProcessManagerIO
+{
+    /// <summary>
+    /// The image name (without file extension) of the running process with the given
+    /// <paramref name="processId"/>, or <c>None</c> if no process with that id is
+    /// currently running.
+    /// </summary>
+    Option<string> GetProcessName(int processId);
+
+    /// <summary>
+    /// Terminates the process tree of the process with the given
+    /// <paramref name="processId"/> and waits up to <paramref name="timeout"/> for it to
+    /// exit. Returns <c>true</c> if the process is gone (it had already exited or was
+    /// terminated within the timeout), <c>false</c> if it was still running when the
+    /// timeout elapsed.
+    /// </summary>
+    bool StopProcess(int processId, TimeSpan timeout);
+}
+
+public readonly struct LiveProcessManagerIO : ProcessManagerIO
+{
+    public static readonly ProcessManagerIO Default = new LiveProcessManagerIO();
+
+    public Option<string> GetProcessName(int processId)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            return process.ProcessName;
+        }
+        catch (ArgumentException)
+        {
+            // No process with the given id is running (e.g. a stale pidfile).
+            return None;
+        }
+    }
+
+    public bool StopProcess(int processId, TimeSpan timeout)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            process.Kill(entireProcessTree: true);
+            return process.WaitForExit((int)timeout.TotalMilliseconds);
+        }
+        catch (ArgumentException)
+        {
+            // The process already exited; there is nothing to terminate.
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // The process exited between the lookup and the kill.
+            return true;
+        }
+    }
+}

--- a/src/core/src/Eryph.Core/Sys/ProcessManagerIO.cs
+++ b/src/core/src/Eryph.Core/Sys/ProcessManagerIO.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using LanguageExt;
 using static LanguageExt.Prelude;
@@ -35,30 +36,41 @@ public readonly struct LiveProcessManagerIO : ProcessManagerIO
             using var process = Process.GetProcessById(processId);
             return process.ProcessName;
         }
-        catch (ArgumentException)
+        // ArgumentException: no process with the given id is running (e.g. a stale
+        // pidfile). InvalidOperationException: the process exited while we inspected it.
+        // Win32Exception: the process cannot be inspected (e.g. access denied). In every
+        // case we cannot confirm the id belongs to a daemon, so report it as not present
+        // rather than letting the exception fail the upgrade.
+        catch (Exception ex) when (
+            ex is ArgumentException or InvalidOperationException or Win32Exception)
         {
-            // No process with the given id is running (e.g. a stale pidfile).
             return None;
         }
     }
 
     public bool StopProcess(int processId, TimeSpan timeout)
     {
+        // Process.WaitForExit takes an int; clamp so a large timeout cannot overflow.
+        var timeoutMs = (int)Math.Min(Math.Max(timeout.TotalMilliseconds, 0), int.MaxValue);
         try
         {
             using var process = Process.GetProcessById(processId);
             process.Kill(entireProcessTree: true);
-            return process.WaitForExit((int)timeout.TotalMilliseconds);
+            return process.WaitForExit(timeoutMs);
         }
-        catch (ArgumentException)
+        // The process already exited (ArgumentException: gone before the lookup;
+        // InvalidOperationException: gone between the lookup and the kill).
+        catch (Exception ex) when (
+            ex is ArgumentException or InvalidOperationException)
         {
-            // The process already exited; there is nothing to terminate.
             return true;
         }
-        catch (InvalidOperationException)
+        // The process could not be terminated (e.g. access denied). Do not fail the
+        // upgrade here: report that it is still running so the caller can log it, and
+        // the subsequent database drop fails loudly if the lock is still held.
+        catch (Exception ex) when (ex is Win32Exception or NotSupportedException)
         {
-            // The process exited between the lookup and the kill.
-            return true;
+            return false;
         }
     }
 }

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
@@ -26,6 +26,7 @@ public class OvsDriverProvider<RT> where RT : struct,
     HasHostNetworkCommands<RT>,
     HasLogger<RT>,
     HasPowershell<RT>,
+    HasProcessManager<RT>,
     HasProcessRunner<RT>,
     HasRegistry<RT>
 {
@@ -166,8 +167,8 @@ public class OvsDriverProvider<RT> where RT : struct,
                 appctlPath(ovnRunDir),
                 $"--timeout=5 -t \"{controlFile}\" exit",
                 includeStandardError: true)
-            | @catch(_ => SuccessAff<RT, ProcessRunnerResult>(
-                new ProcessRunnerResult(-1, "The exit command could not be sent.")))
+            | @catch(error => SuccessAff<RT, ProcessRunnerResult>(
+                new ProcessRunnerResult(-1, $"The exit command could not be sent: {error.Message}")))
         from _ in result.ExitCode == 0
             ? logInformation("Requested shutdown of OVS/OVN daemon '{ControlFile}'.", controlFile)
             : logInformation(
@@ -193,56 +194,60 @@ public class OvsDriverProvider<RT> where RT : struct,
         from _ in pidFiles.Map(forceStopDaemon).SequenceSerial()
         select unit;
 
-    // The executables of the OVS/OVN daemons that keep a pidfile. A pidfile's name is a
-    // logical name (e.g. ovs-db, ovn_nb, ovn_sb, ovn-controller) that does not map 1:1 to
-    // the executable, so we match a running process against this fixed daemon set instead.
-    private static readonly Seq<string> OvsDaemonImageNames = Seq(
-        "ovsdb-server.exe", "ovs-vswitchd.exe", "ovn-controller.exe", "ovn-northd.exe");
+    // The image names (as reported by the OS process list, i.e. without file extension)
+    // of the OVS/OVN daemons that keep a pidfile. A pidfile's name is a logical name
+    // (e.g. ovs-db, ovn_nb, ovn_sb, ovn-controller) that does not map 1:1 to the
+    // executable, so we match the running process against this fixed daemon set instead.
+    private static readonly Seq<string> OvsDaemonProcessNames = Seq(
+        "ovsdb-server", "ovs-vswitchd", "ovn-controller", "ovn-northd");
 
     private static Aff<RT, Unit> forceStopDaemon(string pidFile) =>
         from content in File<RT>.readAllText(pidFile)
-            | @catch(_ => SuccessAff<RT, string>(""))
+            | @catch(error => logWarning(
+                    "Could not read OVS/OVN pidfile '{PidFile}': {Error}. Its daemon cannot be force-stopped and may still hold the database lock.",
+                    pidFile, error.Message)
+                .Map(_ => "").ToAff())
         from _ in parseInt(content.Trim()).Match(
-            Some: pid =>
-                from isDaemon in pidBelongsToOvsDaemon(pid)
-                // A leftover pidfile can be stale: the daemon died without removing it and
-                // Windows recycled its PID for an unrelated process. Terminating that PID
-                // with 'taskkill /F /T' would kill the wrong process tree, so only proceed
-                // when the PID still belongs to an OVS/OVN daemon.
-                from __ in isDaemon
-                    ? forceKillDaemon(pid)
-                    : logWarning(
-                        "Not terminating pid {Pid} from a leftover OVS/OVN pidfile: no matching daemon is running. The pidfile is stale and the PID may have been reused by another process.",
-                        pid)
-                select unit,
-            None: () => SuccessAff<RT, Unit>(unit))
+            Some: forceStopDaemonProcess,
+            None: () => string.IsNullOrWhiteSpace(content)
+                ? SuccessAff<RT, Unit>(unit)
+                : logWarning(
+                        "Ignoring OVS/OVN pidfile '{PidFile}': its contents are not a valid process id.",
+                        pidFile)
+                    .ToAff())
         select unit;
 
-    private static Aff<RT, bool> pidBelongsToOvsDaemon(int pid) =>
-        from result in ProcessRunner<RT>.runProcess(
-                "tasklist.exe", $"/FI \"PID eq {pid}\" /FO CSV /NH", includeStandardError: true)
-            | @catch(_ => SuccessAff<RT, ProcessRunnerResult>(new ProcessRunnerResult(-1, "")))
-        // tasklist prints one CSV row per match ("<image>","<pid>",...); when no process
-        // has that PID it prints an INFO line instead. Treat only a known daemon image as
-        // a match; anything else means the pidfile is stale (or the PID was reused).
-        select OvsDaemonImageNames.Exists(name =>
-            result.Output.Contains($"\"{name}\"", StringComparison.OrdinalIgnoreCase));
+    // A leftover pidfile can be stale: the daemon died without removing it and Windows
+    // recycled its PID for an unrelated process. Look the PID up and only terminate it
+    // while it still belongs to a running OVS/OVN daemon.
+    private static Aff<RT, Unit> forceStopDaemonProcess(int pid) =>
+        from processName in ProcessManager<RT>.getProcessName(pid)
+        from _ in processName.Match(
+            Some: name => OvsDaemonProcessNames.Exists(n =>
+                    string.Equals(n, name, StringComparison.OrdinalIgnoreCase))
+                ? terminateDaemonProcess(pid, name)
+                : logInformation(
+                        "Not terminating pid {Pid} from a leftover OVS/OVN pidfile: it now belongs to the unrelated process '{ProcessName}'. The pidfile is stale and the PID was reused.",
+                        pid, name)
+                    .ToAff(),
+            None: () => logInformation(
+                    "OVS/OVN daemon (pid {Pid}) has already stopped; its pidfile is stale.", pid)
+                .ToAff())
+        select unit;
 
-    private static Aff<RT, Unit> forceKillDaemon(int pid) =>
+    private static Aff<RT, Unit> terminateDaemonProcess(int pid, string processName) =>
         from _1 in logWarning(
-            "OVS/OVN daemon (pid {Pid}) did not stop gracefully; terminating it.", pid)
-        from result in ProcessRunner<RT>.runProcess(
-                "taskkill.exe", $"/PID {pid} /F /T", includeStandardError: true)
-            | @catch(ex => SuccessAff<RT, ProcessRunnerResult>(
-                new ProcessRunnerResult(-1, ex.Message)))
+            "OVS/OVN daemon '{ProcessName}' (pid {Pid}) did not stop gracefully; terminating it.",
+            processName, pid)
+        from stopped in ProcessManager<RT>.stopProcess(pid, TimeSpan.FromSeconds(10))
         // Do not fail here: if a daemon genuinely could not be killed it still holds the
         // database lock, and the subsequent dropOvnDatabaseFiles fails loudly -- the
         // warning below explains why.
-        from _2 in result.ExitCode == 0
+        from _2 in stopped
             ? logInformation("Terminated OVS/OVN daemon (pid {Pid}).", pid)
             : logWarning(
-                "Could not terminate OVS/OVN daemon (pid {Pid}); it may already have stopped, or it still holds the OVN/OVS database lock: {Output}",
-                pid, result.Output.Trim())
+                "Could not terminate OVS/OVN daemon '{ProcessName}' (pid {Pid}); it may still hold the OVN/OVS database lock.",
+                processName, pid)
         select unit;
 
     public static Aff<RT, Unit> installDriver(string infPath) =>

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
@@ -230,8 +230,11 @@ public class OvsDriverProvider<RT> where RT : struct,
                         "Not terminating pid {Pid} from a leftover OVS/OVN pidfile: it now belongs to the unrelated process '{ProcessName}'. The pidfile is stale and the PID was reused.",
                         pid, name)
                     .ToAff(),
+            // No running process could be resolved for the pid. It has most likely
+            // already stopped (leaving a stale pidfile), but the lookup can also fail
+            // because the process cannot be inspected, so do not claim it stopped.
             None: () => logInformation(
-                    "OVS/OVN daemon (pid {Pid}) has already stopped; its pidfile is stale.", pid)
+                    "Not terminating pid {Pid} from a leftover OVS/OVN pidfile: no matching running process could be found.", pid)
                 .ToAff())
         select unit;
 

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
@@ -181,35 +181,61 @@ public class OvsDriverProvider<RT> where RT : struct,
             pidFiles => pidFiles.Count > 0)
         select unit;
 
-    private static Aff<RT, Unit> forceStopRemainingDaemons(string ovnDataDir) =>
+    internal static Aff<RT, Unit> forceStopRemainingDaemons(string ovnDataDir) =>
         from pidFiles in getDaemonFiles(ovnDataDir, "*.pid")
         from _ in pidFiles.Map(forceStopDaemon).SequenceSerial()
         select unit;
+
+    // The executables of the OVS/OVN daemons that keep a pidfile. A pidfile's name is a
+    // logical name (e.g. ovs-db, ovn_nb, ovn_sb, ovn-controller) that does not map 1:1 to
+    // the executable, so we match a running process against this fixed daemon set instead.
+    private static readonly Seq<string> OvsDaemonImageNames = Seq(
+        "ovsdb-server.exe", "ovs-vswitchd.exe", "ovn-controller.exe", "ovn-northd.exe");
 
     private static Aff<RT, Unit> forceStopDaemon(string pidFile) =>
         from content in File<RT>.readAllText(pidFile)
             | @catch(_ => SuccessAff<RT, string>(""))
         from _ in parseInt(content.Trim()).Match(
             Some: pid =>
-                from _1 in logWarning(
-                    "OVS/OVN daemon (pid {Pid}) did not stop gracefully; terminating it.", pid)
-                from result in ProcessRunner<RT>.runProcess(
-                        "taskkill.exe", $"/PID {pid} /F /T", includeStandardError: true)
-                    | @catch(ex => SuccessAff<RT, ProcessRunnerResult>(
-                        new ProcessRunnerResult(-1, ex.Message)))
-                // Do not fail here: a leftover pidfile often belongs to a daemon that
-                // has already exited (taskkill then reports "process not found"), which
-                // is exactly the outcome we want. Log the real result honestly instead of
-                // implying success. If a daemon genuinely could not be killed it still
-                // holds the database lock, and the subsequent dropOvnDatabaseFiles fails
-                // loudly -- the warning below explains why.
-                from _2 in result.ExitCode == 0
-                    ? logInformation("Terminated OVS/OVN daemon (pid {Pid}).", pid)
+                from isDaemon in pidBelongsToOvsDaemon(pid)
+                // A leftover pidfile can be stale: the daemon died without removing it and
+                // Windows recycled its PID for an unrelated process. Terminating that PID
+                // with 'taskkill /F /T' would kill the wrong process tree, so only proceed
+                // when the PID still belongs to an OVS/OVN daemon.
+                from __ in isDaemon
+                    ? forceKillDaemon(pid)
                     : logWarning(
-                        "Could not terminate OVS/OVN daemon (pid {Pid}); it may already have stopped, or it still holds the OVN/OVS database lock: {Output}",
-                        pid, result.Output.Trim())
+                        "Not terminating pid {Pid} from a leftover OVS/OVN pidfile: no matching daemon is running. The pidfile is stale and the PID may have been reused by another process.",
+                        pid)
                 select unit,
             None: () => SuccessAff<RT, Unit>(unit))
+        select unit;
+
+    private static Aff<RT, bool> pidBelongsToOvsDaemon(int pid) =>
+        from result in ProcessRunner<RT>.runProcess(
+                "tasklist.exe", $"/FI \"PID eq {pid}\" /FO CSV /NH", includeStandardError: true)
+            | @catch(_ => SuccessAff<RT, ProcessRunnerResult>(new ProcessRunnerResult(-1, "")))
+        // tasklist prints one CSV row per match ("<image>","<pid>",...); when no process
+        // has that PID it prints an INFO line instead. Treat only a known daemon image as
+        // a match; anything else means the pidfile is stale (or the PID was reused).
+        select OvsDaemonImageNames.Exists(name =>
+            result.Output.Contains($"\"{name}\"", StringComparison.OrdinalIgnoreCase));
+
+    private static Aff<RT, Unit> forceKillDaemon(int pid) =>
+        from _1 in logWarning(
+            "OVS/OVN daemon (pid {Pid}) did not stop gracefully; terminating it.", pid)
+        from result in ProcessRunner<RT>.runProcess(
+                "taskkill.exe", $"/PID {pid} /F /T", includeStandardError: true)
+            | @catch(ex => SuccessAff<RT, ProcessRunnerResult>(
+                new ProcessRunnerResult(-1, ex.Message)))
+        // Do not fail here: if a daemon genuinely could not be killed it still holds the
+        // database lock, and the subsequent dropOvnDatabaseFiles fails loudly -- the
+        // warning below explains why.
+        from _2 in result.ExitCode == 0
+            ? logInformation("Terminated OVS/OVN daemon (pid {Pid}).", pid)
+            : logWarning(
+                "Could not terminate OVS/OVN daemon (pid {Pid}); it may already have stopped, or it still holds the OVN/OVS database lock: {Output}",
+                pid, result.Output.Trim())
         select unit;
 
     public static Aff<RT, Unit> installDriver(string infPath) =>

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
@@ -116,18 +116,25 @@ public class OvsDriverProvider<RT> where RT : struct,
 
     // On an upgrade, OVS/OVN daemons started by the previous installation keep running
     // (stopping the eryph service does not stop them). They hold the OVN/OVS database lock
-    // files open, so dropOvnDatabaseFiles cannot delete the data directory. Send each daemon
-    // the OVS 'exit' control command and wait for it to remove its pidfile, force-terminating
-    // only those that do not stop within the timeout.
+    // files open, so dropOvnDatabaseFiles cannot delete the data directory. Ask each daemon
+    // with a control socket to exit gracefully, then force-terminate any that remain.
+    // A running (or crashed) daemon leaves both a control socket (*.ctl) and a pidfile
+    // (*.pid); treat either as evidence of a daemon to stop, since a leftover pidfile
+    // without a control socket still points at a process that may hold the database lock.
     public static Aff<RT, Unit> stopRunningOvsDaemons(string ovnRunDir, string ovnDataDir) =>
         from controlFiles in getDaemonFiles(ovnDataDir, "*.ctl")
-        from _ in controlFiles.IsEmpty
+        from pidFiles in getDaemonFiles(ovnDataDir, "*.pid")
+        from _ in controlFiles.IsEmpty && pidFiles.IsEmpty
             ? logInformation("No running OVS/OVN daemons found before the OVN update.").ToAff()
             : from _1 in logInformation(
-                    "Stopping {Count} OVS/OVN daemon(s) left over from the previous version...",
-                    controlFiles.Count)
+                    "Stopping OVS/OVN daemon(s) left over from the previous version...")
+                // Gracefully stop the daemons that still expose a control socket, then wait
+                // for their pidfiles to disappear. Without a control socket there is nothing
+                // to ask, so skip straight to force-termination below.
                 from _2 in controlFiles.Map(ctl => sendDaemonExit(ovnRunDir, ctl)).SequenceSerial()
-                from _3 in waitUntilDaemonsStopped(ovnDataDir)
+                from _3 in controlFiles.IsEmpty
+                    ? SuccessAff<RT, Unit>(unit)
+                    : waitUntilDaemonsStopped(ovnDataDir)
                 from _4 in forceStopRemainingDaemons(ovnDataDir)
                 select unit
         select unit;

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
@@ -193,8 +193,21 @@ public class OvsDriverProvider<RT> where RT : struct,
             Some: pid =>
                 from _1 in logWarning(
                     "OVS/OVN daemon (pid {Pid}) did not stop gracefully; terminating it.", pid)
-                from _2 in ProcessRunner<RT>.runProcess("taskkill.exe", $"/PID {pid} /F /T")
-                    | @catch(_ => SuccessAff<RT, ProcessRunnerResult>(new ProcessRunnerResult(0, "")))
+                from result in ProcessRunner<RT>.runProcess(
+                        "taskkill.exe", $"/PID {pid} /F /T", includeStandardError: true)
+                    | @catch(ex => SuccessAff<RT, ProcessRunnerResult>(
+                        new ProcessRunnerResult(-1, ex.Message)))
+                // Do not fail here: a leftover pidfile often belongs to a daemon that
+                // has already exited (taskkill then reports "process not found"), which
+                // is exactly the outcome we want. Log the real result honestly instead of
+                // implying success. If a daemon genuinely could not be killed it still
+                // holds the database lock, and the subsequent dropOvnDatabaseFiles fails
+                // loudly -- the warning below explains why.
+                from _2 in result.ExitCode == 0
+                    ? logInformation("Terminated OVS/OVN daemon (pid {Pid}).", pid)
+                    : logWarning(
+                        "Could not terminate OVS/OVN daemon (pid {Pid}); it may already have stopped, or it still holds the OVN/OVS database lock: {Output}",
+                        pid, result.Output.Trim())
                 select unit,
             None: () => SuccessAff<RT, Unit>(unit))
         select unit;

--- a/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
+++ b/src/modules/src/Eryph.Modules.HostAgent.HyperV/Networks/OvsDriverProvider.cs
@@ -71,6 +71,12 @@ public class OvsDriverProvider<RT> where RT : struct,
                     // installation of the new driver might fail with error code 0x80070430.
                     from ___ in waitUntilDriverServiceHasStopped()
                     from ____ in removeAllDriverPackages()
+                    // Stop any OVS/OVN daemons still running from the previous version.
+                    // Stopping the eryph service does not stop them, and they keep the
+                    // OVN/OVS database lock files open. Dropping the data directory below
+                    // would then fail. Ask each daemon to exit gracefully and only
+                    // force-terminate the ones that do not stop in time.
+                    from _stopDaemons in stopRunningOvsDaemons(ovnRunDir, ovnDataDir)
                     // The OVN/OVS database schemas are tied to the binaries shipped in
                     // the package. On any version change we drop the databases so the new
                     // binaries start from a clean state. The network plan realizer rebuilds
@@ -106,6 +112,91 @@ public class OvsDriverProvider<RT> where RT : struct,
             from ____ in logInformation("Successfully dropped OVN database files")
             select unit
             : logInformation("No OVN database files to drop at {Path}.", ovnDataDir)
+        select unit;
+
+    // On an upgrade, OVS/OVN daemons started by the previous installation keep running
+    // (stopping the eryph service does not stop them). They hold the OVN/OVS database lock
+    // files open, so dropOvnDatabaseFiles cannot delete the data directory. Send each daemon
+    // the OVS 'exit' control command and wait for it to remove its pidfile, force-terminating
+    // only those that do not stop within the timeout.
+    public static Aff<RT, Unit> stopRunningOvsDaemons(string ovnRunDir, string ovnDataDir) =>
+        from controlFiles in getDaemonFiles(ovnDataDir, "*.ctl")
+        from _ in controlFiles.IsEmpty
+            ? logInformation("No running OVS/OVN daemons found before the OVN update.").ToAff()
+            : from _1 in logInformation(
+                    "Stopping {Count} OVS/OVN daemon(s) left over from the previous version...",
+                    controlFiles.Count)
+                from _2 in controlFiles.Map(ctl => sendDaemonExit(ovnRunDir, ctl)).SequenceSerial()
+                from _3 in waitUntilDaemonsStopped(ovnDataDir)
+                from _4 in forceStopRemainingDaemons(ovnDataDir)
+                select unit
+        select unit;
+
+    // The OVS/OVN daemons keep their control sockets (*.ctl) and pidfiles under
+    // '<ovnDataDir>\var\run\{openvswitch,ovn}'. A running daemon has both; a clean exit
+    // removes the pidfile.
+    private static readonly Seq<string> DaemonRunSubDirectories = Seq("openvswitch", "ovn");
+
+    private static string appctlPath(string ovnRunDir) =>
+        Path.Combine(ovnRunDir, "usr", "bin", "ovs-appctl.exe");
+
+    private static Aff<RT, Seq<string>> getDaemonFiles(string ovnDataDir, string searchPattern) =>
+        DaemonRunSubDirectories
+            .Map(subDir => enumerateExistingFiles(
+                Path.Combine(ovnDataDir, "var", "run", subDir), searchPattern))
+            .SequenceSerial()
+            .Map(files => files.Flatten());
+
+    private static Aff<RT, Seq<string>> enumerateExistingFiles(string directory, string searchPattern) =>
+        from exists in Directory<RT>.exists(directory)
+        from files in exists
+            ? Directory<RT>.enumerateFiles(directory, searchPattern).ToAff()
+            : SuccessAff<RT, Seq<string>>(Seq<string>())
+        select files;
+
+    private static Aff<RT, Unit> sendDaemonExit(string ovnRunDir, string controlFile) =>
+        from result in ProcessRunner<RT>.runProcess(
+                appctlPath(ovnRunDir),
+                $"--timeout=5 -t \"{controlFile}\" exit",
+                includeStandardError: true)
+            | @catch(_ => SuccessAff<RT, ProcessRunnerResult>(
+                new ProcessRunnerResult(-1, "The exit command could not be sent.")))
+        from _ in result.ExitCode == 0
+            ? logInformation("Requested shutdown of OVS/OVN daemon '{ControlFile}'.", controlFile)
+            : logInformation(
+                "OVS/OVN daemon '{ControlFile}' did not accept the exit command (it may have already stopped): {Output}",
+                controlFile, result.Output.Trim())
+        select unit;
+
+    private static Aff<RT, Unit> waitUntilDaemonsStopped(string ovnDataDir) =>
+        from _ in repeatWhile(
+            Schedule.NoDelayOnFirst
+            & Schedule.spaced(TimeSpan.FromSeconds(2))
+            & Schedule.upto(TimeSpan.FromSeconds(30)),
+            from pidFiles in getDaemonFiles(ovnDataDir, "*.pid")
+            from __ in pidFiles.IsEmpty
+                ? SuccessEff<RT, Unit>(unit)
+                : logInformation("Waiting for {Count} OVS/OVN daemon(s) to stop...", pidFiles.Count)
+            select pidFiles,
+            pidFiles => pidFiles.Count > 0)
+        select unit;
+
+    private static Aff<RT, Unit> forceStopRemainingDaemons(string ovnDataDir) =>
+        from pidFiles in getDaemonFiles(ovnDataDir, "*.pid")
+        from _ in pidFiles.Map(forceStopDaemon).SequenceSerial()
+        select unit;
+
+    private static Aff<RT, Unit> forceStopDaemon(string pidFile) =>
+        from content in File<RT>.readAllText(pidFile)
+            | @catch(_ => SuccessAff<RT, string>(""))
+        from _ in parseInt(content.Trim()).Match(
+            Some: pid =>
+                from _1 in logWarning(
+                    "OVS/OVN daemon (pid {Pid}) did not stop gracefully; terminating it.", pid)
+                from _2 in ProcessRunner<RT>.runProcess("taskkill.exe", $"/PID {pid} /F /T")
+                    | @catch(_ => SuccessAff<RT, ProcessRunnerResult>(new ProcessRunnerResult(0, "")))
+                select unit,
+            None: () => SuccessAff<RT, Unit>(unit))
         select unit;
 
     public static Aff<RT, Unit> installDriver(string infPath) =>

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/OvsDriverProviderTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/OvsDriverProviderTests.cs
@@ -34,6 +34,7 @@ public class OvsDriverProviderTests
     private readonly Mock<FileIO> _fileMock = new();
     private readonly Mock<IHostNetworkCommands<RT>> _hostNetworkCommandsMock = new();
     private readonly Mock<IPowershellEngine> _powershellEngineMock = new();
+    private readonly Mock<ProcessManagerIO> _processManagerIOMock = new();
     private readonly Mock<ProcessRunnerIO> _processRunnerIOMock = new();
     private readonly Mock<RegistryIO> _registryIOMock = new();
     private readonly RT _runtime;
@@ -48,6 +49,7 @@ public class OvsDriverProviderTests
             _hostNetworkCommandsMock.Object,
             new NullLoggerFactory(),
             _powershellEngineMock.Object,
+            _processManagerIOMock.Object,
             _processRunnerIOMock.Object,
             _registryIOMock.Object));
     }
@@ -302,10 +304,8 @@ public class OvsDriverProviderTests
         result.Should().BeSuccess();
         _processRunnerIOMock.Verify(m => m.RunProcess(
             AppCtlPath, $"--timeout=5 -t \"{ctlFile}\" exit", "", true), Times.Once);
-        _processRunnerIOMock.Verify(m => m.RunProcess(
-            "taskkill.exe", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
-        _processRunnerIOMock.Verify(m => m.RunProcess(
-            "tasklist.exe", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+        // The daemon removed its pidfile on exit, so no process is force-terminated.
+        _processManagerIOMock.Verify(m => m.StopProcess(It.IsAny<int>(), It.IsAny<TimeSpan>()), Times.Never);
     }
 
     [Fact]
@@ -320,19 +320,13 @@ public class OvsDriverProviderTests
         _fileMock.Setup(m => m.ReadAllText(pidFile, Encoding.UTF8, It.IsAny<CancellationToken>()))
             .ReturnsAsync("1234");
 
-        _processRunnerIOMock.Setup(m => m.RunProcess(
-                "tasklist.exe", "/FI \"PID eq 1234\" /FO CSV /NH", "", true))
-            .ReturnsAsync(new ProcessRunnerResult(
-                0, "\"ovsdb-server.exe\",\"1234\",\"Services\",\"0\",\"12,345 K\""));
-        _processRunnerIOMock.Setup(m => m.RunProcess(
-                "taskkill.exe", "/PID 1234 /F /T", "", true))
-            .ReturnsAsync(new ProcessRunnerResult(0, ""));
+        _processManagerIOMock.Setup(m => m.GetProcessName(1234)).Returns(Some("ovsdb-server"));
+        _processManagerIOMock.Setup(m => m.StopProcess(1234, It.IsAny<TimeSpan>())).Returns(true);
 
         var result = await stopRunningOvsDaemons(OvnRunDir, OvnDataDir).Run(_runtime);
 
         result.Should().BeSuccess();
-        _processRunnerIOMock.Verify(m => m.RunProcess(
-            "taskkill.exe", "/PID 1234 /F /T", "", true), Times.Once);
+        _processManagerIOMock.Verify(m => m.StopProcess(1234, It.IsAny<TimeSpan>()), Times.Once);
         // No control socket, so no graceful exit is attempted.
         _processRunnerIOMock.Verify(m => m.RunProcess(
             AppCtlPath, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
@@ -347,19 +341,13 @@ public class OvsDriverProviderTests
         _fileMock.Setup(m => m.ReadAllText(pidFile, Encoding.UTF8, It.IsAny<CancellationToken>()))
             .ReturnsAsync("1234");
 
-        _processRunnerIOMock.Setup(m => m.RunProcess(
-                "tasklist.exe", "/FI \"PID eq 1234\" /FO CSV /NH", "", true))
-            .ReturnsAsync(new ProcessRunnerResult(
-                0, "\"ovsdb-server.exe\",\"1234\",\"Services\",\"0\",\"12,345 K\""));
-        _processRunnerIOMock.Setup(m => m.RunProcess(
-                "taskkill.exe", "/PID 1234 /F /T", "", true))
-            .ReturnsAsync(new ProcessRunnerResult(0, ""));
+        _processManagerIOMock.Setup(m => m.GetProcessName(1234)).Returns(Some("ovs-vswitchd"));
+        _processManagerIOMock.Setup(m => m.StopProcess(1234, It.IsAny<TimeSpan>())).Returns(true);
 
         var result = await forceStopRemainingDaemons(OvnDataDir).Run(_runtime);
 
         result.Should().BeSuccess();
-        _processRunnerIOMock.Verify(m => m.RunProcess(
-            "taskkill.exe", "/PID 1234 /F /T", "", true), Times.Once);
+        _processManagerIOMock.Verify(m => m.StopProcess(1234, It.IsAny<TimeSpan>()), Times.Once);
     }
 
     [Fact]
@@ -372,16 +360,47 @@ public class OvsDriverProviderTests
             .ReturnsAsync("1234");
 
         // The daemon has exited and Windows reused its PID for an unrelated process.
-        _processRunnerIOMock.Setup(m => m.RunProcess(
-                "tasklist.exe", "/FI \"PID eq 1234\" /FO CSV /NH", "", true))
-            .ReturnsAsync(new ProcessRunnerResult(
-                0, "\"explorer.exe\",\"1234\",\"Console\",\"1\",\"50,000 K\""));
+        _processManagerIOMock.Setup(m => m.GetProcessName(1234)).Returns(Some("explorer"));
 
         var result = await forceStopRemainingDaemons(OvnDataDir).Run(_runtime);
 
         result.Should().BeSuccess();
-        _processRunnerIOMock.Verify(m => m.RunProcess(
-            "taskkill.exe", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+        _processManagerIOMock.Verify(m => m.StopProcess(It.IsAny<int>(), It.IsAny<TimeSpan>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ForceStopRemainingDaemons_PidNoLongerRunning_DoesNotTerminate()
+    {
+        // The daemon exited and removed no pidfile; the PID belongs to no running process.
+        var pidFile = Path.Combine(OpenvswitchRunDir, "ovs-db.pid");
+        _directoryMock.Setup(m => m.Exists(OpenvswitchRunDir)).Returns(true);
+        _directoryMock.Setup(m => m.EnumerateFiles(OpenvswitchRunDir, "*.pid")).Returns(Seq1(pidFile));
+        _fileMock.Setup(m => m.ReadAllText(pidFile, Encoding.UTF8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("1234");
+
+        _processManagerIOMock.Setup(m => m.GetProcessName(1234)).Returns(Option<string>.None);
+
+        var result = await forceStopRemainingDaemons(OvnDataDir).Run(_runtime);
+
+        result.Should().BeSuccess();
+        _processManagerIOMock.Verify(m => m.StopProcess(It.IsAny<int>(), It.IsAny<TimeSpan>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ForceStopRemainingDaemons_PidFileGarbled_DoesNotTerminate()
+    {
+        // A pidfile that does not contain a valid process id must not be acted on.
+        var pidFile = Path.Combine(OpenvswitchRunDir, "ovs-db.pid");
+        _directoryMock.Setup(m => m.Exists(OpenvswitchRunDir)).Returns(true);
+        _directoryMock.Setup(m => m.EnumerateFiles(OpenvswitchRunDir, "*.pid")).Returns(Seq1(pidFile));
+        _fileMock.Setup(m => m.ReadAllText(pidFile, Encoding.UTF8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("not-a-pid");
+
+        var result = await forceStopRemainingDaemons(OvnDataDir).Run(_runtime);
+
+        result.Should().BeSuccess();
+        _processManagerIOMock.Verify(m => m.GetProcessName(It.IsAny<int>()), Times.Never);
+        _processManagerIOMock.Verify(m => m.StopProcess(It.IsAny<int>(), It.IsAny<TimeSpan>()), Times.Never);
     }
 
     private void ArrangeIsTestSigningEnabled(bool isEnabled)
@@ -474,6 +493,7 @@ public class OvsDriverProviderTests
         HasFile<RT>,
         HasHostNetworkCommands<RT>,
         HasLogger<RT>,
+        HasProcessManager<RT>,
         HasProcessRunner<RT>,
         HasPowershell<RT>,
         HasRegistry<RT>
@@ -488,6 +508,7 @@ public class OvsDriverProviderTests
             Env.HostNetworkCommands,
             Env.LoggerFactory,
             Env.PowershellEngine,
+            Env.ProcessManager,
             Env.ProcessRunner,
             Env.Registry));
 
@@ -513,6 +534,8 @@ public class OvsDriverProviderTests
 
         public Eff<RT, IPowershellEngine> Powershell => Eff<RT, IPowershellEngine>(rt => rt.Env.PowershellEngine);
 
+        public Eff<RT, ProcessManagerIO> ProcessManagerEff => Eff<RT, ProcessManagerIO>(rt => rt.Env.ProcessManager);
+
         public Eff<RT, ProcessRunnerIO> ProcessRunnerEff => Eff<RT, ProcessRunnerIO>(rt => rt.Env.ProcessRunner);
 
         public Eff<RT, RegistryIO> RegistryEff => Eff<RT, RegistryIO>(rt => rt.Env.Registry);
@@ -526,6 +549,7 @@ public class OvsDriverProviderTests
         IHostNetworkCommands<RT> hostNetworkCommands,
         ILoggerFactory loggerFactory,
         IPowershellEngine powershellEngine,
+        ProcessManagerIO processManager,
         ProcessRunnerIO processRunner,
         RegistryIO registry)
     {
@@ -542,6 +566,8 @@ public class OvsDriverProviderTests
         public ILoggerFactory LoggerFactory { get; } = loggerFactory;
 
         public IPowershellEngine PowershellEngine { get; } = powershellEngine;
+
+        public ProcessManagerIO ProcessManager { get; } = processManager;
 
         public ProcessRunnerIO ProcessRunner { get; } = processRunner;
 

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/OvsDriverProviderTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/OvsDriverProviderTests.cs
@@ -25,6 +25,7 @@ public class OvsDriverProviderTests
     private const string OvnDataDir = @"Z:\ovndatadir";
 
     private static readonly string OpenvswitchRunDir = Path.Combine(OvnDataDir, "var", "run", "openvswitch");
+    private static readonly string OvnRunSubDir = Path.Combine(OvnDataDir, "var", "run", "ovn");
     private static readonly string AppCtlPath = Path.Combine(OvnRunDir, "usr", "bin", "ovs-appctl.exe");
 
     private static readonly Guid SwitchId = Guid.NewGuid();
@@ -348,6 +349,26 @@ public class OvsDriverProviderTests
 
         result.Should().BeSuccess();
         _processManagerIOMock.Verify(m => m.StopProcess(1234, It.IsAny<TimeSpan>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ForceStopRemainingDaemons_DaemonInOvnRunDir_TerminatesProcess()
+    {
+        // ovn-controller keeps its pidfile under '...\var\run\ovn', so that directory
+        // must be scanned as well as the openvswitch one.
+        var pidFile = Path.Combine(OvnRunSubDir, "ovn-controller.pid");
+        _directoryMock.Setup(m => m.Exists(OvnRunSubDir)).Returns(true);
+        _directoryMock.Setup(m => m.EnumerateFiles(OvnRunSubDir, "*.pid")).Returns(Seq1(pidFile));
+        _fileMock.Setup(m => m.ReadAllText(pidFile, Encoding.UTF8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("4321");
+
+        _processManagerIOMock.Setup(m => m.GetProcessName(4321)).Returns(Some("ovn-controller"));
+        _processManagerIOMock.Setup(m => m.StopProcess(4321, It.IsAny<TimeSpan>())).Returns(true);
+
+        var result = await forceStopRemainingDaemons(OvnDataDir).Run(_runtime);
+
+        result.Should().BeSuccess();
+        _processManagerIOMock.Verify(m => m.StopProcess(4321, It.IsAny<TimeSpan>()), Times.Once);
     }
 
     [Fact]

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/OvsDriverProviderTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/OvsDriverProviderTests.cs
@@ -24,6 +24,9 @@ public class OvsDriverProviderTests
     private const string OvnRunDir = @"Z:\ovnrundir";
     private const string OvnDataDir = @"Z:\ovndatadir";
 
+    private static readonly string OpenvswitchRunDir = Path.Combine(OvnDataDir, "var", "run", "openvswitch");
+    private static readonly string AppCtlPath = Path.Combine(OvnRunDir, "usr", "bin", "ovs-appctl.exe");
+
     private static readonly Guid SwitchId = Guid.NewGuid();
 
     private readonly Mock<DirectoryIO> _directoryMock = new();
@@ -268,6 +271,88 @@ public class OvsDriverProviderTests
         VerifyOvnDataNotDropped();
     }
 
+
+    [Fact]
+    public async Task StopRunningOvsDaemons_NoDaemonFiles_DoesNothing()
+    {
+        // No daemon run directories exist, so there is nothing to stop.
+        var result = await stopRunningOvsDaemons(OvnRunDir, OvnDataDir).Run(_runtime);
+
+        result.Should().BeSuccess();
+        _processRunnerIOMock.Verify(
+            m => m.RunProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task StopRunningOvsDaemons_DaemonsExitGracefully_SendsExitAndDoesNotForceKill()
+    {
+        var ctlFile = Path.Combine(OpenvswitchRunDir, "ovs-db.ctl");
+        _directoryMock.Setup(m => m.Exists(OpenvswitchRunDir)).Returns(true);
+        _directoryMock.Setup(m => m.EnumerateFiles(OpenvswitchRunDir, "*.ctl")).Returns(Seq1(ctlFile));
+        // The daemon removes its pidfile when it exits, so no pidfiles remain.
+        _directoryMock.Setup(m => m.EnumerateFiles(OpenvswitchRunDir, "*.pid")).Returns(Seq<string>());
+
+        _processRunnerIOMock.Setup(m => m.RunProcess(
+                AppCtlPath, $"--timeout=5 -t \"{ctlFile}\" exit", "", true))
+            .ReturnsAsync(new ProcessRunnerResult(0, ""));
+
+        var result = await stopRunningOvsDaemons(OvnRunDir, OvnDataDir).Run(_runtime);
+
+        result.Should().BeSuccess();
+        _processRunnerIOMock.Verify(m => m.RunProcess(
+            AppCtlPath, $"--timeout=5 -t \"{ctlFile}\" exit", "", true), Times.Once);
+        _processRunnerIOMock.Verify(m => m.RunProcess(
+            "taskkill.exe", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+        _processRunnerIOMock.Verify(m => m.RunProcess(
+            "tasklist.exe", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ForceStopRemainingDaemons_PidBelongsToDaemon_TerminatesProcess()
+    {
+        var pidFile = Path.Combine(OpenvswitchRunDir, "ovs-db.pid");
+        _directoryMock.Setup(m => m.Exists(OpenvswitchRunDir)).Returns(true);
+        _directoryMock.Setup(m => m.EnumerateFiles(OpenvswitchRunDir, "*.pid")).Returns(Seq1(pidFile));
+        _fileMock.Setup(m => m.ReadAllText(pidFile, Encoding.UTF8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("1234");
+
+        _processRunnerIOMock.Setup(m => m.RunProcess(
+                "tasklist.exe", "/FI \"PID eq 1234\" /FO CSV /NH", "", true))
+            .ReturnsAsync(new ProcessRunnerResult(
+                0, "\"ovsdb-server.exe\",\"1234\",\"Services\",\"0\",\"12,345 K\""));
+        _processRunnerIOMock.Setup(m => m.RunProcess(
+                "taskkill.exe", "/PID 1234 /F /T", "", true))
+            .ReturnsAsync(new ProcessRunnerResult(0, ""));
+
+        var result = await forceStopRemainingDaemons(OvnDataDir).Run(_runtime);
+
+        result.Should().BeSuccess();
+        _processRunnerIOMock.Verify(m => m.RunProcess(
+            "taskkill.exe", "/PID 1234 /F /T", "", true), Times.Once);
+    }
+
+    [Fact]
+    public async Task ForceStopRemainingDaemons_PidStaleOrReused_DoesNotTerminate()
+    {
+        var pidFile = Path.Combine(OpenvswitchRunDir, "ovs-db.pid");
+        _directoryMock.Setup(m => m.Exists(OpenvswitchRunDir)).Returns(true);
+        _directoryMock.Setup(m => m.EnumerateFiles(OpenvswitchRunDir, "*.pid")).Returns(Seq1(pidFile));
+        _fileMock.Setup(m => m.ReadAllText(pidFile, Encoding.UTF8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("1234");
+
+        // The daemon has exited and Windows reused its PID for an unrelated process.
+        _processRunnerIOMock.Setup(m => m.RunProcess(
+                "tasklist.exe", "/FI \"PID eq 1234\" /FO CSV /NH", "", true))
+            .ReturnsAsync(new ProcessRunnerResult(
+                0, "\"explorer.exe\",\"1234\",\"Console\",\"1\",\"50,000 K\""));
+
+        var result = await forceStopRemainingDaemons(OvnDataDir).Run(_runtime);
+
+        result.Should().BeSuccess();
+        _processRunnerIOMock.Verify(m => m.RunProcess(
+            "taskkill.exe", It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
 
     private void ArrangeIsTestSigningEnabled(bool isEnabled)
     {

--- a/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/OvsDriverProviderTests.cs
+++ b/src/modules/test/Eryph.Modules.HostAgent.HyperV.Test/Networks/OvsDriverProviderTests.cs
@@ -309,6 +309,36 @@ public class OvsDriverProviderTests
     }
 
     [Fact]
+    public async Task StopRunningOvsDaemons_OnlyPidFilePresent_ForceStopsWithoutGracefulExit()
+    {
+        // A leftover pidfile without a control socket: there is no socket to send an
+        // exit command to, so we go straight to force-termination.
+        var pidFile = Path.Combine(OpenvswitchRunDir, "ovs-db.pid");
+        _directoryMock.Setup(m => m.Exists(OpenvswitchRunDir)).Returns(true);
+        _directoryMock.Setup(m => m.EnumerateFiles(OpenvswitchRunDir, "*.ctl")).Returns(Seq<string>());
+        _directoryMock.Setup(m => m.EnumerateFiles(OpenvswitchRunDir, "*.pid")).Returns(Seq1(pidFile));
+        _fileMock.Setup(m => m.ReadAllText(pidFile, Encoding.UTF8, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("1234");
+
+        _processRunnerIOMock.Setup(m => m.RunProcess(
+                "tasklist.exe", "/FI \"PID eq 1234\" /FO CSV /NH", "", true))
+            .ReturnsAsync(new ProcessRunnerResult(
+                0, "\"ovsdb-server.exe\",\"1234\",\"Services\",\"0\",\"12,345 K\""));
+        _processRunnerIOMock.Setup(m => m.RunProcess(
+                "taskkill.exe", "/PID 1234 /F /T", "", true))
+            .ReturnsAsync(new ProcessRunnerResult(0, ""));
+
+        var result = await stopRunningOvsDaemons(OvnRunDir, OvnDataDir).Run(_runtime);
+
+        result.Should().BeSuccess();
+        _processRunnerIOMock.Verify(m => m.RunProcess(
+            "taskkill.exe", "/PID 1234 /F /T", "", true), Times.Once);
+        // No control socket, so no graceful exit is attempted.
+        _processRunnerIOMock.Verify(m => m.RunProcess(
+            AppCtlPath, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+    }
+
+    [Fact]
     public async Task ForceStopRemainingDaemons_PidBelongsToDaemon_TerminatesProcess()
     {
         var pidFile = Path.Combine(OpenvswitchRunDir, "ovs-db.pid");


### PR DESCRIPTION
On an OVN package upgrade, the OVS/OVN daemons started by the previous installation keep running — stopping the eryph service does not stop them. They hold the OVN/OVS database lock files open, so `dropOvnDatabaseFiles` cannot delete the data directory and the upgrade fails.

Before dropping the databases, each running daemon is now asked to exit gracefully via its `ovs-appctl` control socket; we wait for it to remove its pidfile and force-terminate only the ones that do not stop within the timeout. This replaces the previous need to manually kill leftover `ovsdb-server`/`ovs-vswitchd` processes.