### PR TITLE
Seed LastSeenProvisioningStatus with the Unix epoch, not default

### DIFF
--- a/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
+++ b/src/modules/src/Eryph.Modules.Controller/Inventory/UpdateInventoryCommandHandlerBase.cs
@@ -294,10 +294,14 @@ internal class UpdateInventoryCommandHandlerBase
                 LastSeenState = timestamp,
                 // Seed the provisioning status. When inventory could not read it
                 // (VM not running / no guest-services) it stays Unknown and its
-                // observation time stays at the default so a later report wins.
+                // observation time stays at the Unix-epoch sentinel so a later report
+                // wins. Must not be default(DateTimeOffset) (0001-01-01): that is below
+                // MySQL datetime's minimum and would fail the insert on that provider.
                 ProvisioningStatus = vmInfo.ProvisioningStatus?.ToCatletProvisioningStatus()
                                      ?? CatletProvisioningStatus.Unknown,
-                LastSeenProvisioningStatus = vmInfo.ProvisioningStatus is not null ? timestamp : default,
+                LastSeenProvisioningStatus = vmInfo.ProvisioningStatus is not null
+                    ? timestamp
+                    : DateTimeOffset.UnixEpoch,
                 Host = hostMachine,
                 AgentName = hostMachine.Name,
                 DataStore = dataStore,


### PR DESCRIPTION
When inventory creates a catlet whose provisioning status could not be read (VM not running or no guest-services), it seeded `LastSeenProvisioningStatus` with `default(DateTimeOffset)` (`0001-01-01`). That is below MySQL `datetime`'s minimum (`1000-01-01`) and fails the insert on the MySQL provider (flagged by Copilot on #416).

Use `DateTimeOffset.UnixEpoch` as the "never observed" sentinel instead — within MySQL's range, and it preserves the monotonic guard: any real observation timestamp is greater, so the first real report still wins.