### PR TITLE
Add configuration option-list endpoints to the compute API

### DIFF
--- a/src/core/src/Eryph.Core/EryphConstants.cs
+++ b/src/core/src/Eryph.Core/EryphConstants.cs
@@ -101,6 +101,8 @@ public static class EryphConstants
     {
         public static readonly IReadOnlyList<Scope> AllScopes =
         [
+            new(Scopes.ComputeBasic, [Audiences.ComputeApi],
+                "Grants read access to basic compute reference data such as configuration option lists"),
             new(Scopes.ComputeRead, [Audiences.ComputeApi], "Grants read access to the compute API"),
             new(Scopes.ComputeWrite, [Audiences.ComputeApi], "Grants write access to the compute API"),
             new(Scopes.CatletsRead, [Audiences.ComputeApi], "Grants read access for catlets"),
@@ -134,6 +136,7 @@ public static class EryphConstants
 
         public static class Scopes
         {
+            public static readonly string ComputeBasic = "compute:basic";
             public static readonly string ComputeRead = "compute:read";
             public static readonly string ComputeWrite = "compute:write";
             public static readonly string CatletsRead = "compute:catlets:read";

--- a/src/modules/src/Eryph.ModuleCore/Authorization/ScopeDefinitions.cs
+++ b/src/modules/src/Eryph.ModuleCore/Authorization/ScopeDefinitions.cs
@@ -14,6 +14,7 @@ public static class ScopeDefinitions
     /// </summary>
     public static readonly string[] ComputeApiScopes =
     [
+        EryphConstants.Authorization.Scopes.ComputeBasic,
         EryphConstants.Authorization.Scopes.CatletsRead,
         EryphConstants.Authorization.Scopes.CatletsWrite,
         EryphConstants.Authorization.Scopes.CatletsControl,

--- a/src/modules/src/Eryph.ModuleCore/Authorization/ScopeHierarchy.cs
+++ b/src/modules/src/Eryph.ModuleCore/Authorization/ScopeHierarchy.cs
@@ -18,10 +18,16 @@ public static class ScopeHierarchy
     /// </summary>
     private static readonly Dictionary<string, HashSet<string>> ScopeHierarchyList = new()
     {
-        // Compute API hierarchies
+        // Compute API hierarchies.
+        // compute:basic is the universal-minimum compute scope: it guards only read-only reference data
+        // (the configuration option lists). Every other compute scope grants it, so any client with any
+        // compute access can read those lists, while a token with no compute scope at all cannot. Because
+        // the hierarchy is flattened (see the warning above), it is listed explicitly on every entry —
+        // including the read leaves, which therefore need their own entry.
         [EryphConstants.Authorization.Scopes.ComputeWrite] =
         [
             EryphConstants.Authorization.Scopes.ComputeRead,
+            EryphConstants.Authorization.Scopes.ComputeBasic,
             EryphConstants.Authorization.Scopes.CatletsWrite,
             EryphConstants.Authorization.Scopes.CatletsRead,
             EryphConstants.Authorization.Scopes.CatletsControl,
@@ -33,28 +39,49 @@ public static class ScopeHierarchy
         ],
         [EryphConstants.Authorization.Scopes.ComputeRead] =
         [
+            EryphConstants.Authorization.Scopes.ComputeBasic,
             EryphConstants.Authorization.Scopes.CatletsRead,
             EryphConstants.Authorization.Scopes.GenesRead,
             EryphConstants.Authorization.Scopes.ProjectsRead,
         ],
         [EryphConstants.Authorization.Scopes.CatletsWrite] =
         [
+            EryphConstants.Authorization.Scopes.ComputeBasic,
             EryphConstants.Authorization.Scopes.CatletsRead,
             EryphConstants.Authorization.Scopes.CatletsControl,
             EryphConstants.Authorization.Scopes.CatletsRemoteAccess,
         ],
         [EryphConstants.Authorization.Scopes.CatletsControl] =
         [
+            EryphConstants.Authorization.Scopes.ComputeBasic,
             EryphConstants.Authorization.Scopes.CatletsRead,
             EryphConstants.Authorization.Scopes.CatletsRemoteAccess,
         ],
+        [EryphConstants.Authorization.Scopes.CatletsRead] =
+        [
+            EryphConstants.Authorization.Scopes.ComputeBasic,
+        ],
+        [EryphConstants.Authorization.Scopes.CatletsRemoteAccess] =
+        [
+            EryphConstants.Authorization.Scopes.ComputeBasic,
+        ],
         [EryphConstants.Authorization.Scopes.GenesWrite] =
         [
+            EryphConstants.Authorization.Scopes.ComputeBasic,
             EryphConstants.Authorization.Scopes.GenesRead,
+        ],
+        [EryphConstants.Authorization.Scopes.GenesRead] =
+        [
+            EryphConstants.Authorization.Scopes.ComputeBasic,
         ],
         [EryphConstants.Authorization.Scopes.ProjectsWrite] =
         [
+            EryphConstants.Authorization.Scopes.ComputeBasic,
             EryphConstants.Authorization.Scopes.ProjectsRead,
+        ],
+        [EryphConstants.Authorization.Scopes.ProjectsRead] =
+        [
+            EryphConstants.Authorization.Scopes.ComputeBasic,
         ],
 
         // Identity API hierarchies

--- a/src/modules/src/Eryph.ModuleCore/Configuration/ComponentConfigEntitlements.cs
+++ b/src/modules/src/Eryph.ModuleCore/Configuration/ComponentConfigEntitlements.cs
@@ -30,6 +30,12 @@ public static class ComponentConfigEntitlements
             [ComponentType.GenePoolAgent] =
                 [ConfigDomain.StorageConfig],
 
+            // The compute API is a read-only consumer: it caches the datastore and environment/site
+            // vocabulary so it can serve them to clients as configuration option lists. It realizes
+            // nothing against system state.
+            [ComponentType.ComputeApi] =
+                [ConfigDomain.StorageConfig, ConfigDomain.Environments],
+
             // The network component hosts the OVN databases; it receives the northbound cluster
             // topology (gateway chassis groups) and realizes it locally, so the controller never
             // writes the northbound cluster tables as a remote client.

--- a/src/modules/src/Eryph.Modules.ComputeApi/ComputeApiModule.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/ComputeApiModule.cs
@@ -103,14 +103,10 @@ public class ComputeApiModule(IEndpointResolver endpointResolver)
 
     public static void ConfigureScopes(AuthorizationOptions options, string authority)
     {
-        // Create policies for each scope using hierarchy-aware scope resolution
+        // Create policies for each scope using hierarchy-aware scope resolution. This includes
+        // compute:basic (the config option-list endpoints), which the scope hierarchy grants to every
+        // other compute scope, so any authenticated compute client satisfies it.
         foreach (var scope in ScopeDefinitions.ComputeApiScopes) CreateScopePolicy(options, authority, scope);
-
-        // A neutral, authenticated-only policy for read-only reference data (configuration option lists)
-        // that any compute-API client may read. It intentionally carries no scope requirement — there is
-        // nothing to protect here, and gating it on a specific read scope would exclude narrowly-scoped
-        // clients that legitimately need the option values to author their input.
-        options.AddPolicy("compute:basic", policy => policy.RequireAuthenticatedUserOrSwaggerEndpoint());
     }
 
     private static void CreateScopePolicy(AuthorizationOptions options, string authority, string requiredScope)

--- a/src/modules/src/Eryph.Modules.ComputeApi/ComputeApiModule.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/ComputeApiModule.cs
@@ -9,6 +9,7 @@ using Eryph.Modules.AspNetCore;
 using Eryph.Modules.AspNetCore.ApiProvider;
 using Eryph.Modules.AspNetCore.ApiProvider.Handlers;
 using Eryph.Modules.AspNetCore.ApiProvider.Model;
+using Eryph.Modules.ComputeApi.Configuration;
 using Eryph.Modules.ComputeApi.Handlers;
 using Eryph.Modules.ComputeApi.Model.V1;
 using Eryph.Rebus;
@@ -50,7 +51,15 @@ public class ComputeApiModule(IEndpointResolver endpointResolver)
             new Dictionary<string, string>
             {
                 ["compute"] = endpointResolver.GetEndpoint("compute").ToString(),
-            });
+            },
+            // Consume the datastore and environment/site vocabulary so the configuration-option
+            // endpoints can serve it. The realizers cache the distributed value in the providers
+            // registered below.
+            typeof(StorageConfigRealizer),
+            typeof(EnvironmentsConfigRealizer));
+
+        options.Container.RegisterSingleton<IStorageConfigProvider, StorageConfigProvider>();
+        options.Container.RegisterSingleton<IEnvironmentsConfigProvider, EnvironmentsConfigProvider>();
     }
 
     public override void ConfigureServices(
@@ -96,6 +105,12 @@ public class ComputeApiModule(IEndpointResolver endpointResolver)
     {
         // Create policies for each scope using hierarchy-aware scope resolution
         foreach (var scope in ScopeDefinitions.ComputeApiScopes) CreateScopePolicy(options, authority, scope);
+
+        // A neutral, authenticated-only policy for read-only reference data (configuration option lists)
+        // that any compute-API client may read. It intentionally carries no scope requirement — there is
+        // nothing to protect here, and gating it on a specific read scope would exclude narrowly-scoped
+        // clients that legitimately need the option values to author their input.
+        options.AddPolicy("compute:basic", policy => policy.RequireAuthenticatedUserOrSwaggerEndpoint());
     }
 
     private static void CreateScopePolicy(AuthorizationOptions options, string authority, string requiredScope)

--- a/src/modules/src/Eryph.Modules.ComputeApi/Configuration/EnvironmentsConfigRealizer.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Configuration/EnvironmentsConfigRealizer.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Eryph.Core;
+using Eryph.Messages.Components;
+using Eryph.ModuleCore.Components;
+using Microsoft.Extensions.Logging;
+
+namespace Eryph.Modules.ComputeApi.Configuration;
+
+/// <summary>
+/// Applies the controller-distributed environment catalog for the compute API. As with the storage
+/// configuration there is nothing local to merge or realize — the API caches the distributed sites and
+/// environments in memory so the environment/site option endpoints can serve them. Idempotent: applying
+/// any version just replaces the cached value.
+/// </summary>
+internal sealed class EnvironmentsConfigRealizer(
+    IEnvironmentsConfigProvider environmentsConfigProvider,
+    ILogger<EnvironmentsConfigRealizer> logger)
+    : IConfigRealizer
+{
+    public ConfigDomain Domain => ConfigDomain.Environments;
+
+    public Task ApplyAsync(long version, string payload, CancellationToken cancellationToken)
+    {
+        var config = EnvironmentsConfigYamlSerializer.Deserialize(payload);
+        environmentsConfigProvider.Update(config);
+
+        logger.LogInformation(
+            "Applied environment configuration v{Version}: {SiteCount} site(s), {EnvironmentCount} environment(s).",
+            version, (config.Sites ?? []).Length, (config.Environments ?? []).Length);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Configuration/IEnvironmentsConfigProvider.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Configuration/IEnvironmentsConfigProvider.cs
@@ -1,0 +1,25 @@
+using Eryph.Core;
+
+namespace Eryph.Modules.ComputeApi.Configuration;
+
+/// <summary>
+/// Holds the most recently applied controller-distributed <see cref="EnvironmentsConfig"/> — the sites
+/// and environments of the deployment — so the configuration-option endpoints can present them to
+/// clients. Updated by <see cref="EnvironmentsConfigRealizer"/>; the compute API only reads it.
+/// </summary>
+public interface IEnvironmentsConfigProvider
+{
+    /// <summary>The last applied environment configuration; an empty catalog until the first apply.</summary>
+    EnvironmentsConfig Current { get; }
+
+    void Update(EnvironmentsConfig config);
+}
+
+internal sealed class EnvironmentsConfigProvider : IEnvironmentsConfigProvider
+{
+    private volatile EnvironmentsConfig _current = new();
+
+    public EnvironmentsConfig Current => _current;
+
+    public void Update(EnvironmentsConfig config) => _current = config;
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Configuration/IStorageConfigProvider.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Configuration/IStorageConfigProvider.cs
@@ -1,0 +1,26 @@
+using Eryph.Core;
+
+namespace Eryph.Modules.ComputeApi.Configuration;
+
+/// <summary>
+/// Holds the most recently applied controller-distributed <see cref="StorageConfig"/> — the datastore
+/// name vocabulary — so the configuration-option endpoints can present it to clients. The compute API
+/// is a read-only consumer of the config-distribution channel: it caches the distributed value here
+/// (updated by <see cref="StorageConfigRealizer"/>) and never authors or realizes it.
+/// </summary>
+public interface IStorageConfigProvider
+{
+    /// <summary>The last applied storage configuration; an empty vocabulary until the first apply.</summary>
+    StorageConfig Current { get; }
+
+    void Update(StorageConfig config);
+}
+
+internal sealed class StorageConfigProvider : IStorageConfigProvider
+{
+    private volatile StorageConfig _current = new();
+
+    public StorageConfig Current => _current;
+
+    public void Update(StorageConfig config) => _current = config;
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Configuration/StorageConfigRealizer.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Configuration/StorageConfigRealizer.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Eryph.Core;
+using Eryph.Messages.Components;
+using Eryph.ModuleCore.Components;
+using Microsoft.Extensions.Logging;
+
+namespace Eryph.Modules.ComputeApi.Configuration;
+
+/// <summary>
+/// Applies the controller-distributed storage configuration for the compute API. Unlike the host agent,
+/// the API has no local settings to merge into and nothing to realize against system state — it only
+/// caches the distributed vocabulary in memory so the datastore option endpoint can serve it. Idempotent
+/// by construction: applying any version just replaces the cached value.
+/// </summary>
+internal sealed class StorageConfigRealizer(
+    IStorageConfigProvider storageConfigProvider,
+    ILogger<StorageConfigRealizer> logger)
+    : IConfigRealizer
+{
+    public ConfigDomain Domain => ConfigDomain.StorageConfig;
+
+    public Task ApplyAsync(long version, string payload, CancellationToken cancellationToken)
+    {
+        var config = StorageConfigYamlSerializer.Deserialize(payload);
+        storageConfigProvider.Update(config);
+
+        logger.LogInformation(
+            "Applied storage configuration v{Version}: {DatastoreCount} datastore(s).",
+            version, (config.Datastores ?? []).Length);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListDatastores.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListDatastores.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ardalis.ApiEndpoints;
+using Eryph.Core;
+using Eryph.Modules.AspNetCore.ApiProvider.Model;
+using Eryph.Modules.ComputeApi.Configuration;
+using Eryph.Modules.ComputeApi.Model.V1;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Eryph.Modules.ComputeApi.Endpoints.V1.Configuration;
+
+[Route("v{version:apiVersion}")]
+public class ListDatastores(IStorageConfigProvider storageConfigProvider)
+    : EndpointBaseAsync.WithoutRequest.WithActionResult<ListResponse<Datastore>>
+{
+    [Authorize(Policy = "compute:basic")]
+    [HttpGet("datastores")]
+    [SwaggerOperation(
+            Summary = "List all datastores",
+            Description = "List the datastore names of the deployment's storage vocabulary as an option "
+                          + "list for configuration input. Paths are agent-local and not included.",
+            OperationId = "Datastores_List",
+            Tags = ["Configuration"])]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(ListResponse<Datastore>), "application/json")]
+    public override Task<ActionResult<ListResponse<Datastore>>> HandleAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var config = storageConfigProvider.Current;
+
+        // The default datastore is always available; add it first so the option list is complete even
+        // before any storage config is distributed. Names are deduplicated case-insensitively.
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { EryphConstants.DefaultDataStoreName };
+        var datastores = new List<Datastore> { new() { Name = EryphConstants.DefaultDataStoreName } };
+
+        void Add(string? name)
+        {
+            if (!string.IsNullOrWhiteSpace(name) && seen.Add(name))
+                datastores.Add(new Datastore { Name = name });
+        }
+
+        // Union the global vocabulary with the per-environment datastores, so every selectable
+        // datastore name appears once regardless of the scope it is declared at.
+        foreach (var datastore in config.Datastores ?? [])
+            Add(datastore.Name);
+
+        foreach (var environment in config.Environments ?? [])
+        foreach (var datastore in environment.Datastores ?? [])
+            Add(datastore.Name);
+
+        return Task.FromResult<ActionResult<ListResponse<Datastore>>>(
+            new ListResponse<Datastore> { Value = datastores });
+    }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListDatastores.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListDatastores.cs
@@ -19,13 +19,13 @@ public class ListDatastores(IStorageConfigProvider storageConfigProvider)
     : EndpointBaseAsync.WithoutRequest.WithActionResult<ListResponse<Datastore>>
 {
     [Authorize(Policy = "compute:basic")]
-    [HttpGet("datastores")]
+    [HttpGet("config/datastores")]
     [SwaggerOperation(
             Summary = "List all datastores",
             Description = "List the datastore names of the deployment's storage vocabulary as an option "
                           + "list for configuration input. Paths are agent-local and not included.",
-            OperationId = "Datastores_List",
-            Tags = ["Configuration"])]
+            OperationId = "Config_ListDatastores",
+            Tags = ["Config"])]
     [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(ListResponse<Datastore>), "application/json")]
     public override Task<ActionResult<ListResponse<Datastore>>> HandleAsync(
         CancellationToken cancellationToken = default)

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListEnvironments.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListEnvironments.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ardalis.ApiEndpoints;
+using Eryph.Core;
+using Eryph.Modules.AspNetCore.ApiProvider.Model;
+using Eryph.Modules.ComputeApi.Configuration;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+using Environment = Eryph.Modules.ComputeApi.Model.V1.Environment;
+
+namespace Eryph.Modules.ComputeApi.Endpoints.V1.Configuration;
+
+[Route("v{version:apiVersion}")]
+public class ListEnvironments(IEnvironmentsConfigProvider environmentsConfigProvider)
+    : EndpointBaseAsync.WithoutRequest.WithActionResult<ListResponse<Environment>>
+{
+    [Authorize(Policy = "compute:basic")]
+    [HttpGet("environments")]
+    [SwaggerOperation(
+            Summary = "List all environments",
+            Description = "List the environments of the deployment together with the site which realizes "
+                          + "each, as an option list for configuration input.",
+            OperationId = "Environments_List",
+            Tags = ["Configuration"])]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(ListResponse<Environment>), "application/json")]
+    public override Task<ActionResult<ListResponse<Environment>>> HandleAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var config = environmentsConfigProvider.Current;
+
+        // The default environment is reserved and never authored, so it is absent from the distributed
+        // catalog; add it here (mapped to the default site) so the option list is complete for clients.
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { EryphConstants.DefaultEnvironmentName };
+        var environments = new List<Environment>
+        {
+            new() { Name = EryphConstants.DefaultEnvironmentName, Site = EryphConstants.DefaultSiteName },
+        };
+
+        foreach (var environment in config.Environments ?? [])
+        {
+            if (string.IsNullOrWhiteSpace(environment.Name) || !seen.Add(environment.Name))
+                continue;
+
+            // A distributed payload always names the site (filled with the default at authoring time),
+            // but guard the empty case so a malformed value still yields a usable option.
+            environments.Add(new Environment
+            {
+                Name = environment.Name,
+                Site = string.IsNullOrWhiteSpace(environment.Site)
+                    ? EryphConstants.DefaultSiteName
+                    : environment.Site,
+            });
+        }
+
+        return Task.FromResult<ActionResult<ListResponse<Environment>>>(
+            new ListResponse<Environment> { Value = environments });
+    }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListEnvironments.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListEnvironments.cs
@@ -19,13 +19,13 @@ public class ListEnvironments(IEnvironmentsConfigProvider environmentsConfigProv
     : EndpointBaseAsync.WithoutRequest.WithActionResult<ListResponse<Environment>>
 {
     [Authorize(Policy = "compute:basic")]
-    [HttpGet("environments")]
+    [HttpGet("config/environments")]
     [SwaggerOperation(
             Summary = "List all environments",
             Description = "List the environments of the deployment together with the site which realizes "
                           + "each, as an option list for configuration input.",
-            OperationId = "Environments_List",
-            Tags = ["Configuration"])]
+            OperationId = "Config_ListEnvironments",
+            Tags = ["Config"])]
     [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(ListResponse<Environment>), "application/json")]
     public override Task<ActionResult<ListResponse<Environment>>> HandleAsync(
         CancellationToken cancellationToken = default)

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListSites.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListSites.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ardalis.ApiEndpoints;
+using Eryph.Core;
+using Eryph.Modules.AspNetCore.ApiProvider.Model;
+using Eryph.Modules.ComputeApi.Configuration;
+using Eryph.Modules.ComputeApi.Model.V1;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Eryph.Modules.ComputeApi.Endpoints.V1.Configuration;
+
+[Route("v{version:apiVersion}")]
+public class ListSites(IEnvironmentsConfigProvider environmentsConfigProvider)
+    : EndpointBaseAsync.WithoutRequest.WithActionResult<ListResponse<Site>>
+{
+    [Authorize(Policy = "compute:basic")]
+    [HttpGet("sites")]
+    [SwaggerOperation(
+            Summary = "List all sites",
+            Description = "List the sites of the deployment as an option list for configuration input.",
+            OperationId = "Sites_List",
+            Tags = ["Configuration"])]
+    [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(ListResponse<Site>), "application/json")]
+    public override Task<ActionResult<ListResponse<Site>>> HandleAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var config = environmentsConfigProvider.Current;
+
+        // The default site is reserved and never authored, so it is absent from the distributed
+        // catalog; add it here so the option list is complete for clients. Names are deduplicated
+        // case-insensitively (the catalog is already lower-cased, but the default guard must not
+        // depend on that).
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { EryphConstants.DefaultSiteName };
+        var sites = new List<Site> { new() { Name = EryphConstants.DefaultSiteName } };
+
+        foreach (var site in config.Sites ?? [])
+        {
+            if (!string.IsNullOrWhiteSpace(site.Name) && seen.Add(site.Name))
+                sites.Add(new Site { Name = site.Name });
+        }
+
+        return Task.FromResult<ActionResult<ListResponse<Site>>>(
+            new ListResponse<Site> { Value = sites });
+    }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListSites.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Endpoints/V1/Configuration/ListSites.cs
@@ -19,12 +19,12 @@ public class ListSites(IEnvironmentsConfigProvider environmentsConfigProvider)
     : EndpointBaseAsync.WithoutRequest.WithActionResult<ListResponse<Site>>
 {
     [Authorize(Policy = "compute:basic")]
-    [HttpGet("sites")]
+    [HttpGet("config/sites")]
     [SwaggerOperation(
             Summary = "List all sites",
             Description = "List the sites of the deployment as an option list for configuration input.",
-            OperationId = "Sites_List",
-            Tags = ["Configuration"])]
+            OperationId = "Config_ListSites",
+            Tags = ["Config"])]
     [SwaggerResponse(StatusCodes.Status200OK, "Success", typeof(ListResponse<Site>), "application/json")]
     public override Task<ActionResult<ListResponse<Site>>> HandleAsync(
         CancellationToken cancellationToken = default)

--- a/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/Datastore.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/Datastore.cs
@@ -1,0 +1,12 @@
+namespace Eryph.Modules.ComputeApi.Model.V1;
+
+/// <summary>
+/// A datastore name from the deployment's storage vocabulary. Provided as an option list so clients can
+/// offer the selectable datastores when authoring configuration. Only the name is exposed — the
+/// filesystem paths a datastore maps to are agent-local and not part of this catalog.
+/// </summary>
+public class Datastore
+{
+    /// <summary>The datastore name.</summary>
+    public required string Name { get; set; }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/Environment.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/Environment.cs
@@ -1,0 +1,14 @@
+namespace Eryph.Modules.ComputeApi.Model.V1;
+
+/// <summary>
+/// An environment of the deployment together with the site which realizes it. Provided as an option
+/// list so clients can offer the available environments when authoring configuration.
+/// </summary>
+public class Environment
+{
+    /// <summary>The environment name.</summary>
+    public required string Name { get; set; }
+
+    /// <summary>The name of the site which realizes this environment.</summary>
+    public required string Site { get; set; }
+}

--- a/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/Site.cs
+++ b/src/modules/src/Eryph.Modules.ComputeApi/Model/V1/Site.cs
@@ -1,0 +1,11 @@
+namespace Eryph.Modules.ComputeApi.Model.V1;
+
+/// <summary>
+/// A site of the deployment. Provided as an option list so clients can offer the available sites when
+/// authoring configuration (e.g. which site realizes an environment).
+/// </summary>
+public class Site
+{
+    /// <summary>The site name.</summary>
+    public required string Name { get; set; }
+}

--- a/src/modules/test/Eryph.ModuleCore.Tests/Authorization/ScopeHierarchyTests.cs
+++ b/src/modules/test/Eryph.ModuleCore.Tests/Authorization/ScopeHierarchyTests.cs
@@ -27,13 +27,25 @@ public class ScopeHierarchyTests
     }
 
     [Fact]
-    public void GetImpliedScopes_WithBasicScope_ReturnsOnlyItself()
+    public void GetImpliedScopes_WithReadLeafScope_ReturnsItselfAndComputeBasic()
     {
         // Act
         var result = ScopeHierarchy.GetImpliedScopes(EryphConstants.Authorization.Scopes.CatletsRead);
 
-        // Assert
-        result.Should().BeEquivalentTo(EryphConstants.Authorization.Scopes.CatletsRead);
+        // Assert — every compute scope grants the universal-minimum compute:basic.
+        result.Should().BeEquivalentTo(
+            EryphConstants.Authorization.Scopes.CatletsRead,
+            EryphConstants.Authorization.Scopes.ComputeBasic);
+    }
+
+    [Fact]
+    public void GetImpliedScopes_WithComputeBasic_ReturnsOnlyItself()
+    {
+        // Act
+        var result = ScopeHierarchy.GetImpliedScopes(EryphConstants.Authorization.Scopes.ComputeBasic);
+
+        // Assert — compute:basic is the minimum; it implies nothing further.
+        result.Should().BeEquivalentTo(EryphConstants.Authorization.Scopes.ComputeBasic);
     }
 
     [Fact]
@@ -47,7 +59,8 @@ public class ScopeHierarchyTests
             EryphConstants.Authorization.Scopes.CatletsWrite,
             EryphConstants.Authorization.Scopes.CatletsRead,
             EryphConstants.Authorization.Scopes.CatletsControl,
-            EryphConstants.Authorization.Scopes.CatletsRemoteAccess);
+            EryphConstants.Authorization.Scopes.CatletsRemoteAccess,
+            EryphConstants.Authorization.Scopes.ComputeBasic);
     }
 
     [Fact]
@@ -60,7 +73,8 @@ public class ScopeHierarchyTests
         result.Should().BeEquivalentTo(
             EryphConstants.Authorization.Scopes.CatletsControl,
             EryphConstants.Authorization.Scopes.CatletsRead,
-            EryphConstants.Authorization.Scopes.CatletsRemoteAccess);
+            EryphConstants.Authorization.Scopes.CatletsRemoteAccess,
+            EryphConstants.Authorization.Scopes.ComputeBasic);
     }
 
     [Fact]
@@ -73,6 +87,7 @@ public class ScopeHierarchyTests
         result.Should().BeEquivalentTo(
             EryphConstants.Authorization.Scopes.ComputeWrite,
             EryphConstants.Authorization.Scopes.ComputeRead,
+            EryphConstants.Authorization.Scopes.ComputeBasic,
             EryphConstants.Authorization.Scopes.CatletsWrite,
             EryphConstants.Authorization.Scopes.CatletsRead,
             EryphConstants.Authorization.Scopes.CatletsControl,
@@ -131,7 +146,8 @@ public class ScopeHierarchyTests
             EryphConstants.Authorization.Scopes.CatletsRead,
             EryphConstants.Authorization.Scopes.CatletsControl,
             EryphConstants.Authorization.Scopes.CatletsRemoteAccess,
-            EryphConstants.Authorization.Scopes.GenesRead
+            EryphConstants.Authorization.Scopes.GenesRead,
+            EryphConstants.Authorization.Scopes.ComputeBasic
         );
     }
 
@@ -207,5 +223,26 @@ public class ScopeHierarchyTests
             EryphConstants.Authorization.Scopes.CatletsWrite,
             EryphConstants.Authorization.Scopes.CatletsControl,
             EryphConstants.Authorization.Scopes.ComputeWrite);
+    }
+
+    [Fact]
+    public void GetGrantingScopes_WithComputeBasic_ReturnsEveryComputeScope()
+    {
+        // Act
+        var result = ScopeHierarchy.GetGrantingScopes(EryphConstants.Authorization.Scopes.ComputeBasic);
+
+        // Assert — compute:basic is the universal minimum, so every compute scope grants it.
+        result.Should().BeEquivalentTo(
+            EryphConstants.Authorization.Scopes.ComputeBasic,
+            EryphConstants.Authorization.Scopes.ComputeRead,
+            EryphConstants.Authorization.Scopes.ComputeWrite,
+            EryphConstants.Authorization.Scopes.CatletsRead,
+            EryphConstants.Authorization.Scopes.CatletsWrite,
+            EryphConstants.Authorization.Scopes.CatletsControl,
+            EryphConstants.Authorization.Scopes.CatletsRemoteAccess,
+            EryphConstants.Authorization.Scopes.GenesRead,
+            EryphConstants.Authorization.Scopes.GenesWrite,
+            EryphConstants.Authorization.Scopes.ProjectsRead,
+            EryphConstants.Authorization.Scopes.ProjectsWrite);
     }
 }

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/ConfigurationEndpointsTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/ConfigurationEndpointsTests.cs
@@ -1,0 +1,135 @@
+using System.Threading.Tasks;
+using Eryph.Core;
+using Eryph.Modules.ComputeApi.Configuration;
+using Eryph.Modules.ComputeApi.Endpoints.V1.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Eryph.Modules.ComputeApi.Tests;
+
+public class ConfigurationEndpointsTests
+{
+    private sealed class FakeEnvironmentsConfigProvider(EnvironmentsConfig current) : IEnvironmentsConfigProvider
+    {
+        public EnvironmentsConfig Current { get; } = current;
+        public void Update(EnvironmentsConfig config) { }
+    }
+
+    private sealed class FakeStorageConfigProvider(StorageConfig current) : IStorageConfigProvider
+    {
+        public StorageConfig Current { get; } = current;
+        public void Update(StorageConfig config) { }
+    }
+
+    [Fact]
+    public async Task ListSites_EmptyCatalog_ReturnsOnlyDefaultSite()
+    {
+        var endpoint = new ListSites(new FakeEnvironmentsConfigProvider(new EnvironmentsConfig()));
+
+        var result = await endpoint.HandleAsync();
+
+        result.Value!.Value.Should().ContainSingle()
+            .Which.Name.Should().Be(EryphConstants.DefaultSiteName);
+    }
+
+    [Fact]
+    public async Task ListSites_IncludesDistributedSites_AndDeduplicatesDefault()
+    {
+        var config = new EnvironmentsConfig
+        {
+            // An authored payload never re-declares the reserved default, but a stray duplicate must
+            // still collapse to a single entry.
+            Sites = [new SiteConfig { Name = "berlin" }, new SiteConfig { Name = EryphConstants.DefaultSiteName }],
+        };
+        var endpoint = new ListSites(new FakeEnvironmentsConfigProvider(config));
+
+        var result = await endpoint.HandleAsync();
+
+        result.Value!.Value.Should().SatisfyRespectively(
+            site => site.Name.Should().Be(EryphConstants.DefaultSiteName),
+            site => site.Name.Should().Be("berlin"));
+    }
+
+    [Fact]
+    public async Task ListEnvironments_EmptyCatalog_ReturnsDefaultEnvironmentOnDefaultSite()
+    {
+        var endpoint = new ListEnvironments(new FakeEnvironmentsConfigProvider(new EnvironmentsConfig()));
+
+        var result = await endpoint.HandleAsync();
+
+        var environment = result.Value!.Value.Should().ContainSingle().Which;
+        environment.Name.Should().Be(EryphConstants.DefaultEnvironmentName);
+        environment.Site.Should().Be(EryphConstants.DefaultSiteName);
+    }
+
+    [Fact]
+    public async Task ListEnvironments_MapsSite_AndFallsBackToDefaultSiteWhenMissing()
+    {
+        var config = new EnvironmentsConfig
+        {
+            Environments =
+            [
+                new EnvironmentConfig { Name = "prod", Site = "berlin" },
+                new EnvironmentConfig { Name = "test", Site = "" },
+            ],
+        };
+        var endpoint = new ListEnvironments(new FakeEnvironmentsConfigProvider(config));
+
+        var result = await endpoint.HandleAsync();
+
+        result.Value!.Value.Should().SatisfyRespectively(
+            env =>
+            {
+                env.Name.Should().Be(EryphConstants.DefaultEnvironmentName);
+                env.Site.Should().Be(EryphConstants.DefaultSiteName);
+            },
+            env =>
+            {
+                env.Name.Should().Be("prod");
+                env.Site.Should().Be("berlin");
+            },
+            env =>
+            {
+                env.Name.Should().Be("test");
+                env.Site.Should().Be(EryphConstants.DefaultSiteName);
+            });
+    }
+
+    [Fact]
+    public async Task ListDatastores_EmptyCatalog_ReturnsOnlyDefaultDatastore()
+    {
+        var endpoint = new ListDatastores(new FakeStorageConfigProvider(new StorageConfig()));
+
+        var result = await endpoint.HandleAsync();
+
+        result.Value!.Value.Should().ContainSingle()
+            .Which.Name.Should().Be(EryphConstants.DefaultDataStoreName);
+    }
+
+    [Fact]
+    public async Task ListDatastores_UnionsGlobalAndEnvironmentScoped_AndDeduplicates()
+    {
+        var config = new StorageConfig
+        {
+            Datastores = [new StorageDatastoreConfig { Name = "fast" }],
+            Environments =
+            [
+                new StorageEnvironmentConfig
+                {
+                    Name = "prod",
+                    // 'fast' repeats the global entry (must dedup); 'archive' is env-only (must appear).
+                    Datastores =
+                        [new StorageDatastoreConfig { Name = "fast" }, new StorageDatastoreConfig { Name = "archive" }],
+                },
+            ],
+        };
+        var endpoint = new ListDatastores(new FakeStorageConfigProvider(config));
+
+        var result = await endpoint.HandleAsync();
+
+        result.Value!.Value.Should().SatisfyRespectively(
+            ds => ds.Name.Should().Be(EryphConstants.DefaultDataStoreName),
+            ds => ds.Name.Should().Be("fast"),
+            ds => ds.Name.Should().Be("archive"));
+    }
+}

--- a/src/modules/test/Eryph.Modules.ComputeApi.Tests/ConfigurationEndpointsTests.cs
+++ b/src/modules/test/Eryph.Modules.ComputeApi.Tests/ConfigurationEndpointsTests.cs
@@ -132,4 +132,66 @@ public class ConfigurationEndpointsTests
             ds => ds.Name.Should().Be("fast"),
             ds => ds.Name.Should().Be("archive"));
     }
+
+    // A YAML payload with an omitted or explicit-null section (e.g. `sites: ~`) deserializes the array
+    // to null, which the model comments call out. These tests set the arrays to null explicitly so the
+    // `?? []` guards in the endpoints are actually exercised (new EnvironmentsConfig()/StorageConfig()
+    // default them to empty, not null, so the other tests do not cover this path).
+
+    [Fact]
+    public async Task ListSites_NullSitesArray_ReturnsOnlyDefault()
+    {
+        var endpoint = new ListSites(new FakeEnvironmentsConfigProvider(new EnvironmentsConfig { Sites = null }));
+
+        var result = await endpoint.HandleAsync();
+
+        result.Value!.Value.Should().ContainSingle()
+            .Which.Name.Should().Be(EryphConstants.DefaultSiteName);
+    }
+
+    [Fact]
+    public async Task ListEnvironments_NullEnvironmentsArray_ReturnsOnlyDefault()
+    {
+        var endpoint = new ListEnvironments(
+            new FakeEnvironmentsConfigProvider(new EnvironmentsConfig { Environments = null }));
+
+        var result = await endpoint.HandleAsync();
+
+        result.Value!.Value.Should().ContainSingle()
+            .Which.Name.Should().Be(EryphConstants.DefaultEnvironmentName);
+    }
+
+    [Fact]
+    public async Task ListDatastores_NullArrays_ReturnsOnlyDefault()
+    {
+        var endpoint = new ListDatastores(
+            new FakeStorageConfigProvider(new StorageConfig { Datastores = null, Environments = null }));
+
+        var result = await endpoint.HandleAsync();
+
+        result.Value!.Value.Should().ContainSingle()
+            .Which.Name.Should().Be(EryphConstants.DefaultDataStoreName);
+    }
+
+    [Fact]
+    public async Task ListSites_SkipsWhitespaceNames_AndDeduplicatesCaseInsensitively()
+    {
+        var config = new EnvironmentsConfig
+        {
+            // '   ' must be skipped; 'Berlin' then 'berlin' must collapse to the first-seen 'Berlin'.
+            Sites =
+            [
+                new SiteConfig { Name = "   " },
+                new SiteConfig { Name = "Berlin" },
+                new SiteConfig { Name = "berlin" },
+            ],
+        };
+        var endpoint = new ListSites(new FakeEnvironmentsConfigProvider(config));
+
+        var result = await endpoint.HandleAsync();
+
+        result.Value!.Value.Should().SatisfyRespectively(
+            site => site.Name.Should().Be(EryphConstants.DefaultSiteName),
+            site => site.Name.Should().Be("Berlin"));
+    }
 }

--- a/src/modules/test/Eryph.Modules.Controller.Tests/Components/ConfigDistributionServiceTests.cs
+++ b/src/modules/test/Eryph.Modules.Controller.Tests/Components/ConfigDistributionServiceTests.cs
@@ -150,8 +150,10 @@ public class ConfigDistributionServiceTests
         var records = new Mock<IStateStoreRepository<ConfigRecord>>();
         var service = CreateService(new ControllerSettings(), records);
 
+        // Management is the component type without any config entitlements — it authors
+        // configuration rather than receiving it.
         var bundles = await service.BuildSnapshotAsync(
-            Reg(ComponentType.ComputeApi), new List<AppliedConfigVersion>(), CancellationToken.None);
+            Reg(ComponentType.Management), new List<AppliedConfigVersion>(), CancellationToken.None);
 
         bundles.Should().BeEmpty();
     }
@@ -516,7 +518,7 @@ public class ConfigDistributionServiceTests
         var service = CreateService(records);
 
         var bundles = await service.GetOutdatedBundlesAsync(
-            Reg(ComponentType.ComputeApi), CancellationToken.None);
+            Reg(ComponentType.Management), CancellationToken.None);
 
         bundles.Should().BeEmpty();
         records.Verify(r => r.GetBySpecAsync(It.IsAny<ConfigRecordSpecs.GetByDomainAndScope>(), It.IsAny<CancellationToken>()),


### PR DESCRIPTION
Adds read-only endpoints to the compute API that expose the deployment's configuration vocabulary as option lists for client input, grouped under a shared `/v1/config` path and a single `Config` operation group:

- `GET /v1/config/environments` — environments with the site that realizes each
- `GET /v1/config/sites` — sites
- `GET /v1/config/datastores` — datastore names

The compute API consumes the `StorageConfig` and `Environments` config domains through the existing component config-distribution channel: two `IConfigRealizer`s cache the distributed values in memory, and the endpoints serve them merged with the reserved defaults (deduplicated). Datastore paths are not exposed — those are agent-local.

The endpoints use a neutral authenticated-only policy (`compute:basic`, no scope requirement), since the lists are reference data any authenticated compute client may read.

Verified end-to-end against a running eryph-zero: the controller distributes both domains to the ComputeApi component, the realizers apply them, and the endpoints return the expected values (anonymous/invalid tokens are rejected 401).
